### PR TITLE
docs: update architecture for LLM gateway, phasing, and inference model

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,15 +10,16 @@
 - **Runtime**: Node.js with TypeScript
 - **Protocol**: Model Context Protocol via `@modelcontextprotocol/sdk`
 - **Build**: `tsc` to `dist/`, ES Modules (`"type": "module"`)
-- **Tools**: Each tool in `src/tools/` exports a registration function. Tools are stateless request handlers.
+- **Tools**: Each tool in `src/tools/` exports a registration function. Tools are stateless data request handlers.
 - **Resources**: `src/resources/` for MCP resource providers
 - **Prompts**: `src/prompts/` for MCP prompt templates
 - **Tests**: Vitest in `tests/`
 
 ### Agents (`agents/`) — Python
 - **Framework**: Custom agent base classes in `src/core/`
-- **LLM Abstraction**: Supports Claude (Anthropic) and OpenAI APIs, configurable per agent
+- **LLM Gateway**: Pluggable inference client in the application layer — supports OpenAI, Anthropic, ollama, or skip when host LLM reasons (MCP path)
 - **Domain Agents**: `src/agents/` — filing analyst, earnings interpreter, macro regime, quant signal, thesis guardian, risk, adversarial
+- **Application Layer**: `src/application/` — shared contracts (Pydantic), LLM gateway, services. CLI, MCP server, and future web API are thin wrappers over this.
 - **Quant Tools**: `src/tools/` — regression, factor analysis, Monte Carlo, Bayesian updates
 - **Data Pipelines**: `src/pipelines/` — EDGAR, FRED, market data, research digest
 - **Tests**: pytest in `tests/`
@@ -29,6 +30,16 @@
 - `adversarial/` — thesis-challenging prompts
 - `synthesis/` — multi-document synthesis
 
+## LLM Inference Model
+
+Agents perform deterministic data processing and construct prompts but **do not call LLMs directly**. The LLM gateway in the application layer provides inference when needed:
+
+| Path | LLM reasoning | Gateway |
+|---|---|---|
+| MCP (Copilot, Claude Desktop) | Host LLM reasons | Skipped |
+| CLI | LLM gateway calls provider | Used |
+| Web API (future) | LLM gateway calls provider | Used |
+
 ## Data Flow
 
 ```
@@ -37,6 +48,8 @@ External APIs (EDGAR, FRED, Yahoo Finance)
 Data Pipelines (Python) → Local Data Store
         ↓
 MCP Tools (TypeScript) ← LLM requests via MCP protocol
+        ↓
+Application Layer (contracts + LLM gateway)
         ↓
 Agents (Python) — orchestrated multi-agent reasoning
         ↓
@@ -47,11 +60,15 @@ Research Output (memos, alerts, signals)
 
 | Layer | Technology |
 |---|---|
-| MCP Server | TypeScript, Node.js, `@modelcontextprotocol/sdk` |
-| Agents | Python 3.11+, NumPy, pandas, scipy |
-| Vector DB | ChromaDB (local, v0) |
-| LLM Backend | Claude / GPT-4 / open models (configurable) |
+| MCP Server (data tools) | TypeScript, Node.js, `@modelcontextprotocol/sdk` |
+| MCP Server (agents) | Python, `mcp` SDK |
+| Application Layer | Python, Pydantic, litellm |
+| Agents | Python 3.12+, NumPy, pandas, scipy |
+| Vector DB | ChromaDB (local) |
+| LLM Gateway | Pluggable — OpenAI, Anthropic, ollama, or host LLM via MCP |
 | Data Sources | SEC EDGAR (free), FRED (free), Yahoo Finance (yfinance), QIF files |
+| CLI | Python (`python -m agents.cli`) |
+| Copilot Skills | Markdown workflow definitions (`.github/skills/`) |
 | Testing | Vitest (TS), pytest (Python) |
 | CI/CD | GitHub Actions |
 
@@ -235,6 +252,7 @@ finance-os/
 │   ├── src/
 │   │   ├── core/                   # Agent base, orchestrator, memory
 │   │   ├── agents/                 # Domain-specific agents
+│   │   ├── application/            # Shared contracts, LLM gateway, services
 │   │   ├── tools/                  # Quant tools
 │   │   └── pipelines/             # Data ingestion pipelines
 │   └── tests/

--- a/README.md
+++ b/README.md
@@ -12,19 +12,25 @@ Not a chatbot. A **system**. The personal Bloomberg terminal + quant lab + resea
 - **Adversarial challenge**: Every thesis gets systematically attacked before capital is deployed
 - **Quantitative signals**: Transform unstructured text into structured, timestamped, confidence-weighted quant features
 - **Multi-agent orchestration**: Agents collaborate and debate to produce consolidated research memos
+- **LLM-native**: Pluggable LLM gateway for direct inference (CLI, future web) or delegate to host LLM (Copilot, Claude Desktop via MCP)
 
 ## Project Structure
 
 ```
 finance-os/
-├── mcp-server/          # TypeScript MCP server (tools for LLMs)
-├── agents/              # Python agent framework (domain agents, orchestrator)
+├── mcp-server/          # TypeScript MCP server (data tools for LLMs)
+├── agents/              # Python agent framework + application layer
+│   └── src/
+│       ├── agents/      # Domain agents (filing, earnings, macro, risk, etc.)
+│       ├── core/        # BaseAgent, orchestrator, vector memory
+│       ├── application/ # Shared contracts, LLM gateway, services (planned)
+│       └── pipelines/   # Research digest pipeline
 ├── prompts/             # Shared prompt library
 ├── docs/                # Architecture, agent, and tool documentation
-└── .github/             # CI, copilot instructions, templates
+└── .github/             # CI, copilot instructions, skills, templates
 ```
 
-See [docs/architecture.md](docs/architecture.md) for the full system architecture, data flow, and tech stack.
+See [docs/architecture.md](docs/architecture.md) for the full system architecture, LLM gateway design, and data flow.
 See [docs/agents.md](docs/agents.md) for agent descriptions and the orchestration model.
 See [docs/tools.md](docs/tools.md) for MCP tool reference and how to add new tools.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -7,6 +7,10 @@ All agents extend `BaseAgent` in `agents/src/core/agent.py`, which defines:
 - `system_prompt` — the agent's persona and capabilities
 - Conversation history management
 
+### Current state: no LLM calls
+
+Agents currently perform deterministic data processing (regex, heuristics, statistics) and construct prompts, but **do not call an LLM directly**. This is by design for the MCP path, where the host LLM (Copilot, Claude Desktop) does the reasoning. For the CLI and future web paths, the **LLM gateway** in the application layer will handle inference — see [architecture.md](architecture.md#llm-gateway).
+
 ## Agent Catalog
 
 | Agent | Module | Purpose |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,60 +3,125 @@
 ## System Overview
 
 ```
-┌─────────────────────────────────────────────────────┐
-│                   Orchestration Layer                │
-│         Agent Framework (multi-agent collab)         │
-├──────────┬──────────┬──────────┬──────────┬─────────┤
-│  Filing  │ Earnings │  Macro   │  Thesis  │  Risk   │
-│  Analyst │  Call    │  Regime  │ Guardian │  Agent  │
-│  Agent   │ Interp.  │  Agent   │          │         │
-├──────────┴──────────┴──────────┴──────────┴─────────┤
-│                    MCP Tool Layer                    │
-│  Financial │ SEC     │ Quant   │ Portfolio│ Alt     │
-│  Data Tool │ Filings │ Model   │ Diag.   │ Data    │
-├─────────────────────────────────────────────────────┤
-│                   Data Pipeline                     │
-│  EDGAR │ FRED │ Yahoo Finance │ QIF │ Vector DB    │
-├─────────────────────────────────────────────────────┤
-│               RAG + Knowledge Layer                 │
-│  Vector Store │ Knowledge Graph │ Thesis DB         │
-└─────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│                        UX Layer                              │
+│  Copilot CLI │ Agent CLI │ Copilot Skills │ Web UI (future)  │
+├──────────────────────────────────────────────────────────────┤
+│                    Interface Layer                            │
+│  TS MCP Server (data tools) │ Python MCP Server (agents)     │
+│                             │ Web API / FastAPI (future)      │
+├──────────────────────────────────────────────────────────────┤
+│                  Application Layer                            │
+│  Pydantic Contracts │ LLM Gateway │ Agent Services            │
+├──────────────────────────────────────────────────────────────┤
+│                   Orchestration Layer                         │
+│         Agent Framework (multi-agent collaboration)           │
+├──────────┬──────────┬──────────┬──────────┬─────────┬────────┤
+│  Filing  │ Earnings │  Macro   │  Thesis  │  Risk   │ Adver- │
+│  Analyst │  Call    │  Regime  │ Guardian │  Agent  │ sarial │
+│  Agent   │ Interp.  │  Agent   │          │         │        │
+├──────────┴──────────┴──────────┴──────────┴─────────┴────────┤
+│                    MCP Tool Layer                             │
+│  Financial │ SEC     │ Quant   │ Portfolio│ Alt             │
+│  Data Tool │ Filings │ Model   │ Diag.   │ Data            │
+├──────────────────────────────────────────────────────────────┤
+│                   Data Pipeline                               │
+│  EDGAR │ FRED │ Yahoo Finance │ QIF │ Vector DB              │
+├──────────────────────────────────────────────────────────────┤
+│               RAG + Knowledge Layer                           │
+│  Vector Store │ Knowledge Graph │ Thesis DB                   │
+└──────────────────────────────────────────────────────────────┘
 ```
 
 ## Tech Stack
 
 | Layer | Technology |
 |---|---|
-| MCP Server | TypeScript, Node.js, `@modelcontextprotocol/sdk` |
+| MCP Server (data tools) | TypeScript, Node.js, `@modelcontextprotocol/sdk` |
+| MCP Server (agents) | Python, `mcp` SDK (planned) |
+| Application Layer | Python, Pydantic, litellm (planned) |
 | Agents | Python 3.12+, NumPy, pandas, scipy |
 | Vector DB | ChromaDB (local) |
-| LLM Backend | Claude / GPT-4 / open models (configurable) |
+| LLM Gateway | Pluggable — OpenAI, Anthropic, ollama, or host LLM via MCP |
 | Data Sources | SEC EDGAR (free), FRED (free API key), Yahoo Finance, QIF |
+| CLI | Python (`python -m agents.cli`, planned) |
+| Copilot Skills | Markdown workflow definitions (`.github/skills/`, planned) |
 | Testing | Vitest (TypeScript), pytest (Python) |
 | Linting | ESLint (TypeScript), ruff (Python) |
 | CI/CD | GitHub Actions |
 
-## Data Flow
+## LLM Gateway
+
+The LLM gateway is a first-class component in the application layer, not a bolt-on. It resolves the fundamental question: *who does the LLM reasoning?*
 
 ```
-External APIs (EDGAR, FRED, Yahoo Finance)
-        ↓
-Data Pipelines (Python) → Local Data Store
-        ↓
-MCP Tools (TypeScript) ← LLM requests via MCP protocol
-        ↓
-Agents (Python) — orchestrated multi-agent reasoning
-        ↓
-Research Output (memos, alerts, signals)
+┌─────────────────────────────────────────────────────────┐
+│                   Application Layer                      │
+│                                                          │
+│  contracts/     Pydantic request/response models         │
+│  llm/           Pluggable inference client               │
+│  services/      Agent invocation, orchestration           │
+│  config/        Provider selection, model routing          │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Two inference paths
+
+| Path | How LLM reasoning works |
+|---|---|
+| **MCP path** (Copilot, Claude Desktop) | Host LLM calls MCP tools → agents return structured data + prompts → host LLM synthesizes. Gateway is **skipped**. |
+| **Direct path** (CLI, future Web API) | User invokes agent → application layer calls LLM gateway → agents return data → gateway calls LLM for synthesis. |
+
+### Why this matters
+
+The agents currently build prompts and structure data but **never call an LLM**. This is correct for the MCP path where the host LLM reasons. But the CLI and web paths need their own LLM inference — the gateway provides it without duplicating agent logic.
+
+### Provider flexibility
+
+The gateway is pluggable:
+- **Cloud**: OpenAI, Anthropic, Google (via litellm or native SDKs)
+- **Local**: ollama, llama.cpp
+- **Skip**: MCP consumers can bypass the gateway entirely
+
+## Data Flow
+
+### MCP Path (Copilot / Claude Desktop)
+```
+Host LLM ──→ MCP Protocol ──→ TS MCP Server ──→ Data Tools (Yahoo, EDGAR, etc.)
+         └─→ MCP Protocol ──→ Py MCP Server ──→ Application Layer ──→ Agents
+                                                  (gateway skipped)
+```
+
+### Direct Path (CLI / future Web)
+```
+User ──→ CLI / Web API ──→ Application Layer ──→ Agents ──→ structured data
+                                │                              │
+                                └── LLM Gateway ←──────────────┘
+                                        │
+                                        ↓
+                                  LLM inference
+                                        │
+                                        ↓
+                                 synthesized output
 ```
 
 ## Component Details
 
 ### MCP Server (`mcp-server/`)
 
-The MCP server exposes investment tools to LLMs via the Model Context Protocol. Each tool is a self-contained module in `src/tools/` that exports a `registerXxxTool(server)` function. Tools are stateless request handlers that validate inputs via zod schemas and return structured responses.
+The TypeScript MCP server exposes investment **data tools** to LLMs via the Model Context Protocol. Each tool is a self-contained module in `src/tools/` that exports a `registerXxxTool(server)` function. Tools are stateless request handlers that validate inputs via zod schemas and return structured responses.
 
 Entry point: `src/index.ts` registers all tools and starts the server on stdio transport.
+
+### Application Layer (`agents/src/application/`, planned)
+
+The shared core that all interfaces wrap. Contains:
+- **Contracts** — Pydantic request/response models for every agent operation
+- **LLM gateway** — pluggable inference client with provider routing
+- **Services** — agent invocation, orchestration coordination, pipeline triggers
+- **Config** — provider selection, model routing, API key management
+
+CLI, Python MCP server, and future Web API are thin wrappers over this layer.
 
 ### Agent Framework (`agents/`)
 
@@ -80,3 +145,14 @@ Shared prompt templates organized by strategy:
 - **Analysis** — constraint-driven analytical templates
 - **Adversarial** — thesis-challenging prompts
 - **Synthesis** — multi-document cross-reference prompts
+
+## Phasing
+
+| Phase | Focus | Status |
+|---|---|---|
+| 0 | Repository foundation, MCP server, agent framework | ✅ Complete |
+| 1 | Core tools and agents (SEC, earnings, macro, quant, portfolio) | ✅ Complete |
+| 2 | Intelligence layer (thesis, risk, adversarial, orchestrator, pipeline) | ✅ Complete |
+| 3 | Integration layer (application layer + LLM gateway, CLI, Python MCP, Skills) | 🔜 Next |
+| 4 | Advanced (knowledge graph, alt data, fine-tuning) — Copilot-first | Planned |
+| 5 | Web layer (FastAPI + Web UI) — after Copilot CLI is mostly complete | Planned |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,9 +2,13 @@
 
 ## Overview
 
-The MCP server (`mcp-server/`) exposes tools to LLMs via the Model Context Protocol. Each tool is a self-contained TypeScript module that registers with the server via `server.tool()`.
+finance-os has two MCP servers:
 
-## Tool Catalog
+1. **TypeScript MCP server** (`mcp-server/`) — data tools that fetch, parse, and compute financial data. These are stateless request handlers callable by any LLM via the Model Context Protocol.
+
+2. **Python MCP server** (planned, `agents/src/mcp_server.py`) — agent tools that expose the Python agent framework to LLMs. Wraps the shared application layer. When a host LLM calls these tools, the LLM gateway is skipped (the host LLM does the reasoning).
+
+## TypeScript Tool Catalog
 
 | Tool | Module | Purpose |
 |---|---|---|


### PR DESCRIPTION
## Changes

Update all documentation to reflect the LLM gateway architecture and revised phasing.

### Files changed
- **`.github/copilot-instructions.md`** — updated tech stack, data flow, added LLM inference model section, application layer in repo structure
- **`README.md`** — added LLM-native goal, updated project structure
- **`docs/architecture.md`** — new system diagram (UX/interface/app layers), LLM gateway design, two inference paths, phasing table
- **`docs/agents.md`** — documented no-LLM-calls state with gateway reference
- **`docs/tools.md`** — documented two MCP servers (TS data + planned Python agents)

### Context
- LLM gateway is a first-class component in the application layer, not a bolt-on
- MCP path: host LLM reasons, gateway skipped. CLI/web path: gateway calls provider.
- Phases: 0-2 (done), 3 (integration + gateway), 4 (advanced, Copilot-first), 5 (web, deferred)

Closes #59