### PR TITLE
feat: application layer — contracts, LLM gateway, services

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,7 +62,7 @@ Research Output (memos, alerts, signals)
 |---|---|
 | MCP Server (data tools) | TypeScript, Node.js, `@modelcontextprotocol/sdk` |
 | MCP Server (agents) | Python, `mcp` SDK |
-| Application Layer | Python, Pydantic, litellm |
+| Application Layer | Python, Pydantic 2.11+, pydantic-settings, litellm |
 | Agents | Python 3.12+, NumPy, pandas, scipy |
 | Vector DB | ChromaDB (local) |
 | LLM Gateway | Pluggable — OpenAI, Anthropic, ollama, or host LLM via MCP |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -111,17 +111,36 @@ These rules exist because this is financial software. Violations produce incorre
 
 ### Running Tests
 
-- **MCP Server**: `cd mcp-server && npm test`
-- **Agents**: `cd agents && source .venv/bin/activate && pytest`
-- **Full suite**: `npm test` (from root, runs workspace tests)
+- **MCP Server (unit)**: `cd mcp-server && npm test`
+- **MCP Server (integration)**: `cd mcp-server && npm run test:integration`
+- **Agents (unit)**: `cd agents && source .venv/bin/activate && pytest -m "not integration"`
+- **Agents (integration)**: `cd agents && source .venv/bin/activate && pytest -m integration`
+- **Full suite (unit)**: `npm test` (from root, runs workspace tests)
 - **Python type checking**: `cd agents && source .venv/bin/activate && mypy src/`
 - **Linting**: `npm run lint` (root), `cd agents && source .venv/bin/activate && ruff check src/ tests/`
 
 > **Note**: Python requires a virtual environment. Set up once: `cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"`
 
+### Unit vs Integration Tests
+
+Tests are split into **unit** (fast, no external deps) and **integration** (calls external APIs):
+
+| | Python | TypeScript |
+|---|---|---|
+| Unit files | `tests/*.py` | `tests/*.test.ts` |
+| Integration files | `tests/*.py` with `@pytest.mark.integration` | `tests/*.integration.test.ts` |
+| Run unit | `pytest -m "not integration"` | `npm test` |
+| Run integration | `pytest -m integration` | `npm run test:integration` |
+
+**Rules:**
+- Mark any test that calls an external service (FRED, EDGAR, etc.) with `@pytest.mark.integration` (Python) or place it in a `*.integration.test.ts` file (TypeScript).
+- Integration tests must **skip gracefully** when credentials are missing (use the `fred_api_key` fixture or similar).
+- CI runs unit tests on every PR. Integration tests run only on pushes to `main`.
+- `npm run preflight` runs unit tests only.
+
 ### Pre-Push Preflight
 
-**Always run `npm run preflight` from the repo root before pushing.** This mirrors CI exactly: build → test → lint (TypeScript), then ruff → pytest (Python). A push that fails CI is a wasted round-trip. Fix locally first.
+**Always run `npm run preflight` from the repo root before pushing.** This mirrors CI: build → unit test → lint (TypeScript), then ruff → unit pytest (Python). A push that fails CI is a wasted round-trip. Fix locally first.
 
 ```bash
 npm run preflight   # must pass before every push

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -197,8 +197,11 @@ Examples: `tolginator/AddEdgarPipeline`, `copilot/RefactorAgentFramework`
 0. **Never commit to main.** Main is only for PRs and production builds.
 1. `git worktree add <path> -b <username>/<task> origin/main`
 2. Work exclusively in the worktree.
-3. Run `npm run preflight` — fix any failures before pushing.
-4. Commit, push, create PR targeting `main`.
+3. Make **separate, descriptive commits** for each logical change within a PR.
+4. Do **not** amend or force-push — keep the commit history intact for review.
+5. Run `npm run preflight` — fix any failures before pushing.
+6. Commit, push, create PR targeting `main`.
+7. **Squash merge** when merging PRs into main (`gh pr merge --squash`).
 
 ### After PR Merge
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   mcp-server:
-    name: MCP Server (TypeScript)
+    name: MCP Server – Unit (TypeScript)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -26,8 +26,25 @@ jobs:
       - run: npm test
       - run: npm run lint
 
+  mcp-server-integration:
+    name: MCP Server – Integration (TypeScript)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    defaults:
+      run:
+        working-directory: mcp-server
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:integration
+
   agents:
-    name: Agents (Python)
+    name: Agents – Unit (Python)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -39,4 +56,19 @@ jobs:
           python-version: '3.12'
       - run: pip install -e ".[dev]"
       - run: ruff check src/ tests/
-      - run: pytest
+      - run: pytest -m "not integration"
+
+  agents-integration:
+    name: Agents – Integration (Python)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    defaults:
+      run:
+        working-directory: agents
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: pip install -e ".[dev]"
+      - run: pytest -m integration

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ Thumbs.db
 .env.local
 .env.*.local
 
+# Config files with secrets (config lives at ~/.config/finance-os/)
+config.json
+*.secret
+*.key
+
 # Test coverage
 coverage/
 htmlcov/

--- a/README.md
+++ b/README.md
@@ -61,13 +61,6 @@ pytest -m "not integration"    # unit tests only
 pytest -m integration          # integration tests (requires API keys)
 ```
 
-Optional dependencies for quant and RAG features:
-
-```bash
-pip install -e ".[quant]"    # numpy, pandas, scipy
-pip install -e ".[rag]"      # chromadb
-```
-
 ### Configuration
 
 Create `~/.config/finance-os/config.json`:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ finance-os/
 │   └── src/
 │       ├── agents/      # Domain agents (filing, earnings, macro, risk, etc.)
 │       ├── core/        # BaseAgent, orchestrator, vector memory
-│       ├── application/ # Shared contracts, LLM gateway, services (planned)
+│       ├── application/ # Contracts, LLM gateway, services, config
 │       └── pipelines/   # Research digest pipeline
 ├── prompts/             # Shared prompt library
 ├── docs/                # Architecture, agent, and tool documentation
@@ -57,7 +57,8 @@ cd agents
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -e ".[dev]"
-pytest
+pytest -m "not integration"    # unit tests only
+pytest -m integration          # integration tests (requires API keys)
 ```
 
 Optional dependencies for quant and RAG features:
@@ -67,6 +68,20 @@ pip install -e ".[quant]"    # numpy, pandas, scipy
 pip install -e ".[rag]"      # chromadb
 ```
 
+### Configuration
+
+Create `~/.config/finance-os/config.json`:
+
+```json
+{
+  "fred_api_key": "your-fred-api-key",
+  "llm_provider": "skip",
+  "llm_default_model": "gpt-4o"
+}
+```
+
+Environment variables (`FINANCE_OS_*`) override config file values. See [docs/architecture.md](docs/architecture.md) for details.
+
 ### Preflight (run before every push)
 
 From the repo root:
@@ -75,13 +90,14 @@ From the repo root:
 npm run preflight
 ```
 
-This mirrors CI exactly: build → test → lint (TypeScript), then ruff → pytest (Python). A push that fails CI is a wasted round-trip.
+This mirrors CI: build → unit test → lint (TypeScript), then ruff → unit pytest (Python). Integration tests run in CI only on pushes to `main`.
 
 ## Development
 
 ### Git Workflow
 
 - Never commit to `main` — use worktrees and feature branches
+- Make separate, descriptive commits per logical change; squash merge PRs
 - Branch naming: `<username>/<MeaningfulDescription>`
 - Every PR must have a corresponding issue created first
 - Run `npm run preflight` before pushing

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -7,6 +7,9 @@ license = {text = "MIT"}
 dependencies = [
     "anthropic>=0.94.0",
     "openai>=2.31.0",
+    "pydantic>=2.11",
+    "pydantic-settings>=2.9",
+    "litellm>=1.72",
 ]
 
 [project.optional-dependencies]

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -51,3 +51,6 @@ warn_unused_configs = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "integration: tests that call external services (FRED, EDGAR, etc.)",
+]

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -18,13 +18,9 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "ruff>=0.15.10",
     "mypy>=1.20.0",
-]
-quant = [
     "numpy>=2.4.4",
     "pandas>=3.0.2",
     "scipy>=1.17.1",
-]
-rag = [
     "chromadb>=1.0.0",
 ]
 

--- a/agents/src/application/__init__.py
+++ b/agents/src/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application layer — shared contracts, LLM gateway, and services."""

--- a/agents/src/application/config.py
+++ b/agents/src/application/config.py
@@ -1,0 +1,68 @@
+"""Application configuration — env vars + optional JSON config file.
+
+Priority (highest wins): env vars > config file > defaults.
+Config file location: ~/.config/finance-os/config.json
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+
+CONFIG_DIR = Path.home() / ".config" / "finance-os"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
+
+def _load_config_file() -> dict[str, Any]:
+    """Load config from ~/.config/finance-os/config.json if it exists."""
+    if CONFIG_FILE.is_file():
+        return json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+    return {}
+
+
+class JsonFileSource(PydanticBaseSettingsSource):
+    """Settings source that reads from the JSON config file."""
+
+    def get_field_value(
+        self, field: Any, field_name: str
+    ) -> tuple[Any, str, bool]:
+        data = _load_config_file()
+        val = data.get(field_name)
+        return val, field_name, val is not None
+
+    def __call__(self) -> dict[str, Any]:
+        return _load_config_file()
+
+
+class AppConfig(BaseSettings):
+    """Configuration for the finance-os application layer.
+
+    Values can be set via:
+    1. Environment variables with FINANCE_OS_ prefix (highest priority)
+    2. ~/.config/finance-os/config.json
+    3. Built-in defaults
+    """
+
+    model_config = {"env_prefix": "FINANCE_OS_"}
+
+    llm_provider: str = "skip"
+    llm_default_model: str = "gpt-4o"
+    llm_temperature: float = 0.0
+    fred_api_key: str = ""
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            env_settings,
+            JsonFileSource(settings_cls),
+            file_secret_settings,
+        )

--- a/agents/src/application/contracts/__init__.py
+++ b/agents/src/application/contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Agent operation contracts — Pydantic request/response models."""

--- a/agents/src/application/contracts/agents.py
+++ b/agents/src/application/contracts/agents.py
@@ -1,0 +1,216 @@
+"""Pydantic request/response contracts for agent operations.
+
+Contracts model what agents actually do, not aspirational capabilities.
+Each pair maps directly to an agent's run() kwargs and metadata output.
+"""
+
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+# --- Earnings Interpreter ---
+
+
+class AnalyzeEarningsRequest(BaseModel):
+    """Request to analyze an earnings transcript."""
+
+    transcript: str = Field(min_length=1, description="Earnings call transcript text")
+    ticker: str = Field(default="", description="Company ticker for context")
+
+
+class AnalyzeEarningsResponse(BaseModel):
+    """Structured earnings analysis results."""
+
+    content: str = Field(description="Human-readable analysis report")
+    tone: str = Field(description="Overall tone classification")
+    net_sentiment: float = Field(description="Net sentiment score")
+    confidence: str = Field(description="Confidence level in the assessment")
+    guidance_direction: str = Field(description="Forward guidance direction")
+    guidance_count: int = Field(description="Number of guidance items extracted")
+    key_phrase_count: int = Field(description="Number of key phrases identified")
+
+
+# --- Macro Regime ---
+
+
+class ClassifyMacroRequest(BaseModel):
+    """Request to classify the current macro regime."""
+
+    api_key: str = Field(default="", description="FRED API key")
+    indicators: list[str] = Field(
+        default_factory=list,
+        description="FRED series IDs to fetch. Empty uses defaults.",
+    )
+
+
+class ClassifyMacroResponse(BaseModel):
+    """Macro regime classification results."""
+
+    content: str = Field(description="Human-readable macro dashboard")
+    regime: str = Field(description="Classified regime (expansion/contraction/transition)")
+    indicators_fetched: int = Field(description="Number of indicators requested")
+    indicators_with_data: int = Field(description="Number that returned data")
+
+
+# --- Filing Analyst ---
+
+
+class SearchFilingsRequest(BaseModel):
+    """Request to search/list SEC filings for a company."""
+
+    ticker: str = Field(default="", description="Company ticker symbol")
+    cik: str = Field(default="", description="SEC CIK number")
+    form_type: str = Field(default="10-K", description="Filing form type filter")
+
+
+class SearchFilingsResponse(BaseModel):
+    """Filing search results."""
+
+    content: str = Field(description="Formatted filing list or search results")
+    cik: str = Field(default="", description="Resolved CIK")
+    form_type: str = Field(default="", description="Form type searched")
+    filing_count: int = Field(default=0, description="Number of filings found")
+
+
+# --- Quant Signal ---
+
+
+class GenerateSignalsRequest(BaseModel):
+    """Request to generate composite quant signals."""
+
+    signals: list[dict] = Field(
+        default_factory=list,
+        description="Pre-computed signal dicts with name/value/weight/direction",
+    )
+    sentiment: Decimal | None = Field(default=None, description="Sentiment input")
+    regime: str = Field(default="", description="Current macro regime")
+    direction: str = Field(default="", description="Signal direction context")
+    source: str = Field(default="", description="Signal source attribution")
+    method: str = Field(default="equal_weight", description="Scoring method")
+
+
+class GenerateSignalsResponse(BaseModel):
+    """Composite signal results."""
+
+    content: str = Field(description="Human-readable signal report")
+    agent: str = Field(default="quant-signal", description="Agent that produced signals")
+    composite: dict = Field(default_factory=dict, description="Composite score details")
+    signals: list[dict] = Field(default_factory=list, description="Individual signal details")
+
+
+# --- Thesis Guardian ---
+
+
+class EvaluateThesisRequest(BaseModel):
+    """Request to evaluate investment theses against observed data."""
+
+    theses: list[dict] = Field(
+        description="Thesis dicts with ticker, hypothesis, assumptions, status",
+    )
+    data: dict[str, Decimal] = Field(
+        default_factory=dict,
+        description="Observed metric values to evaluate assumptions against",
+    )
+
+
+class EvaluateThesisResponse(BaseModel):
+    """Thesis evaluation results."""
+
+    content: str = Field(description="Human-readable thesis report")
+    theses_checked: int = Field(description="Number of theses evaluated")
+    alerts_generated: int = Field(description="Total alerts raised")
+    critical_alerts: int = Field(description="Number of critical alerts")
+
+
+# --- Risk Agent ---
+
+
+class AssessRiskRequest(BaseModel):
+    """Request to run risk analysis on a portfolio."""
+
+    positions: list[dict] = Field(
+        default_factory=list,
+        description="Position dicts with ticker, weight, returns",
+    )
+    scenarios: list[dict] = Field(
+        default_factory=list,
+        description="Scenario dicts with name, shocks",
+    )
+    returns: list[Decimal] = Field(
+        default_factory=list,
+        description="Historical return series for VaR/CVaR",
+    )
+
+
+class AssessRiskResponse(BaseModel):
+    """Risk analysis results."""
+
+    content: str = Field(description="Human-readable risk report")
+
+
+# --- Adversarial ---
+
+
+class ChallengeThesisRequest(BaseModel):
+    """Request to adversarially challenge claims or a thesis."""
+
+    claims: list[str] = Field(
+        default_factory=list,
+        description="Claims to challenge. If empty, uses prompt text.",
+    )
+    prompt: str = Field(default="", description="Free-text thesis to challenge")
+
+
+class ChallengeThesisResponse(BaseModel):
+    """Adversarial challenge results."""
+
+    content: str = Field(description="Human-readable challenge report")
+    conviction_score: str = Field(description="Final conviction score")
+    counter_count: int = Field(description="Number of counter-arguments generated")
+    blind_spot_count: int = Field(description="Number of blind spots identified")
+
+
+# --- Pipeline ---
+
+
+class RunPipelineRequest(BaseModel):
+    """Request to run a multi-agent orchestrated pipeline."""
+
+    tasks: list[dict] = Field(
+        description="Task dicts with agent_name, prompt, kwargs, priority, depends_on, task_id",
+    )
+
+
+class RunPipelineResponse(BaseModel):
+    """Pipeline execution results."""
+
+    results: list[dict] = Field(description="Per-task results")
+    total_duration_ms: int = Field(description="Total pipeline duration")
+    successful: int = Field(description="Number of successful tasks")
+    failed: int = Field(description="Number of failed tasks")
+    memo: dict | None = Field(default=None, description="Generated research memo if requested")
+
+
+# --- Research Digest ---
+
+
+class RunDigestRequest(BaseModel):
+    """Request to run the research digest pipeline."""
+
+    tickers: list[str] = Field(description="Watchlist tickers")
+    lookback_days: int = Field(default=7, description="Days of data to consider")
+    alert_threshold: float = Field(default=0.5, description="Materiality threshold")
+    sources: list[dict] = Field(
+        default_factory=list,
+        description="Pre-loaded DataSource dicts. If empty, pipeline runs with no sources.",
+    )
+
+
+class RunDigestResponse(BaseModel):
+    """Research digest results."""
+
+    ticker_count: int = Field(description="Number of tickers processed")
+    entry_count: int = Field(description="Number of digest entries")
+    alert_count: int = Field(description="Number of alerts generated")
+    material_count: int = Field(description="Number of material entries")
+    content: str = Field(description="Human-readable digest summary")

--- a/agents/src/application/contracts/agents.py
+++ b/agents/src/application/contracts/agents.py
@@ -93,7 +93,7 @@ class GenerateSignalsResponse(BaseModel):
     """Composite signal results."""
 
     content: str = Field(description="Human-readable signal report")
-    agent: str = Field(default="quant-signal", description="Agent that produced signals")
+    agent: str = Field(default="quant_signal", description="Agent that produced signals")
     composite: dict = Field(default_factory=dict, description="Composite score details")
     signals: list[dict] = Field(default_factory=list, description="Individual signal details")
 
@@ -173,11 +173,28 @@ class ChallengeThesisResponse(BaseModel):
 # --- Pipeline ---
 
 
+class TaskDefinition(BaseModel):
+    """Definition for a single pipeline task."""
+
+    agent_name: str = Field(min_length=1, description="Agent name to execute")
+    prompt: str = Field(default="", description="Prompt text passed to the agent")
+    kwargs: dict[str, object] = Field(
+        default_factory=dict,
+        description="Additional keyword arguments passed to the agent",
+    )
+    priority: int = Field(default=0, description="Scheduling priority for the task")
+    depends_on: list[str] = Field(
+        default_factory=list,
+        description="Task IDs that must complete before this task runs",
+    )
+    task_id: str = Field(default="", description="Unique task identifier")
+
+
 class RunPipelineRequest(BaseModel):
     """Request to run a multi-agent orchestrated pipeline."""
 
-    tasks: list[dict] = Field(
-        description="Task dicts with agent_name, prompt, kwargs, priority, depends_on, task_id",
+    tasks: list[TaskDefinition] = Field(
+        description="Task definitions for the pipeline",
     )
 
 
@@ -199,7 +216,7 @@ class RunDigestRequest(BaseModel):
 
     tickers: list[str] = Field(description="Watchlist tickers")
     lookback_days: int = Field(default=7, description="Days of data to consider")
-    alert_threshold: float = Field(default=0.5, description="Materiality threshold")
+    alert_threshold: Decimal = Field(default=Decimal("0.5"), description="Materiality threshold")
     sources: list[dict] = Field(
         default_factory=list,
         description="Pre-loaded DataSource dicts. If empty, pipeline runs with no sources.",

--- a/agents/src/application/llm/__init__.py
+++ b/agents/src/application/llm/__init__.py
@@ -1,0 +1,6 @@
+"""LLM gateway — pluggable inference for direct-path usage."""
+
+from src.application.llm.gateway import LLMGateway, create_gateway
+from src.application.llm.types import LLMMessage, LLMProvider, LLMResponse
+
+__all__ = ["LLMGateway", "LLMMessage", "LLMProvider", "LLMResponse", "create_gateway"]

--- a/agents/src/application/llm/gateway.py
+++ b/agents/src/application/llm/gateway.py
@@ -1,0 +1,104 @@
+"""LLM gateway — routes inference requests to the configured provider."""
+
+from typing import Any
+
+from src.application.llm.providers import SkipProvider
+from src.application.llm.types import LLMMessage, LLMProvider, LLMResponse
+
+
+class LLMGateway:
+    """Routes LLM requests to a configured provider.
+
+    The gateway is the single entry point for all LLM inference in the
+    application layer. CLI and web paths use it; MCP path can skip it.
+
+    Supports per-operation model overrides and synthesis templates.
+    """
+
+    def __init__(self, provider: LLMProvider | None = None) -> None:
+        self._provider = provider or SkipProvider()
+
+    @property
+    def provider(self) -> LLMProvider:
+        """The current LLM provider."""
+        return self._provider
+
+    async def complete(
+        self,
+        messages: list[LLMMessage],
+        *,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Route a completion request to the provider.
+
+        Args:
+            messages: Conversation messages.
+            model: Model override for this request.
+            temperature: Sampling temperature.
+            max_tokens: Max tokens in response.
+            **kwargs: Provider-specific options.
+
+        Returns:
+            LLMResponse from the provider.
+        """
+        return await self._provider.complete(
+            messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+
+    async def synthesize(
+        self,
+        system_prompt: str,
+        agent_output: str,
+        *,
+        model: str | None = None,
+        instruction: str = (
+            "Synthesize the following agent output into a clear, actionable summary."
+        ),
+    ) -> LLMResponse:
+        """Synthesize agent output into a narrative using LLM reasoning.
+
+        This is the primary integration point for the direct path (CLI/web).
+        Agents produce structured data; the gateway synthesizes it.
+
+        Args:
+            system_prompt: The agent's system prompt for context.
+            agent_output: The structured output from the agent.
+            model: Model override.
+            instruction: Synthesis instruction.
+
+        Returns:
+            LLMResponse with synthesized narrative.
+        """
+        messages = [
+            LLMMessage(role="system", content=system_prompt),
+            LLMMessage(role="user", content=f"{instruction}\n\n{agent_output}"),
+        ]
+        return await self.complete(messages, model=model)
+
+
+def create_gateway(provider_type: str = "skip", **kwargs: Any) -> LLMGateway:
+    """Factory for creating configured gateways.
+
+    Args:
+        provider_type: One of "skip", "litellm".
+        **kwargs: Provider-specific configuration.
+
+    Returns:
+        Configured LLMGateway.
+    """
+    if provider_type == "skip":
+        return LLMGateway(SkipProvider())
+    elif provider_type == "litellm":
+        from src.application.llm.litellm_provider import LiteLLMProvider
+
+        return LLMGateway(LiteLLMProvider(**kwargs))
+    else:
+        msg = f"Unknown provider type: {provider_type}"
+        raise ValueError(msg)

--- a/agents/src/application/llm/litellm_provider.py
+++ b/agents/src/application/llm/litellm_provider.py
@@ -1,0 +1,62 @@
+"""LiteLLM-based LLM provider implementation.
+
+Wraps litellm.acompletion for multi-provider support (OpenAI, Anthropic, ollama, etc.).
+LiteLLM types do not leak outside this module.
+"""
+
+from typing import Any
+
+import litellm
+
+from src.application.llm.types import LLMMessage, LLMProvider, LLMResponse
+
+
+class LiteLLMProvider:
+    """LLM provider using litellm for multi-provider routing."""
+
+    def __init__(self, default_model: str = "gpt-4o") -> None:
+        self._default_model = default_model
+
+    async def complete(
+        self,
+        messages: list[LLMMessage],
+        *,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Complete via litellm."""
+        resolved_model = model or self._default_model
+        litellm_messages = [{"role": m.role, "content": m.content} for m in messages]
+
+        litellm_kwargs: dict[str, Any] = {
+            "model": resolved_model,
+            "messages": litellm_messages,
+            "temperature": temperature,
+        }
+        if max_tokens is not None:
+            litellm_kwargs["max_tokens"] = max_tokens
+        litellm_kwargs.update(kwargs)
+
+        response = await litellm.acompletion(**litellm_kwargs)
+
+        content = response.choices[0].message.content or ""
+        usage = {}
+        if response.usage:
+            usage = {
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            }
+
+        return LLMResponse(
+            content=content,
+            model=resolved_model,
+            usage=usage,
+        )
+
+
+# Verify protocol conformance
+assert isinstance(LiteLLMProvider, type)
+_: type[LLMProvider] = LiteLLMProvider  # type: ignore[assignment]

--- a/agents/src/application/llm/providers.py
+++ b/agents/src/application/llm/providers.py
@@ -1,0 +1,37 @@
+"""SkipProvider — pass-through LLM provider for the MCP path."""
+
+from typing import Any
+
+from src.application.llm.types import LLMMessage, LLMProvider, LLMResponse
+
+
+class SkipProvider:
+    """LLM provider that returns agent output unchanged.
+
+    Used in MCP path where the host LLM does reasoning.
+    """
+
+    async def complete(
+        self,
+        messages: list[LLMMessage],
+        *,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Return the last user message content as-is."""
+        user_content = ""
+        for msg in reversed(messages):
+            if msg.role == "user":
+                user_content = msg.content
+                break
+        return LLMResponse(
+            content=user_content,
+            model="skip",
+            usage={"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        )
+
+
+# Verify protocol conformance
+_skip_check: type[LLMProvider] = SkipProvider  # type: ignore[assignment]

--- a/agents/src/application/llm/types.py
+++ b/agents/src/application/llm/types.py
@@ -1,0 +1,54 @@
+"""LLM gateway — pluggable inference for direct-path (CLI/web) usage.
+
+MCP path: host LLM reasons, gateway is skipped.
+Direct path: gateway calls a provider for synthesis/reasoning.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass
+class LLMMessage:
+    """A message in an LLM conversation."""
+
+    role: str  # "system", "user", "assistant"
+    content: str
+
+
+@dataclass
+class LLMResponse:
+    """Response from an LLM provider."""
+
+    content: str
+    model: str
+    usage: dict[str, int] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class LLMProvider(Protocol):
+    """Protocol for LLM inference providers."""
+
+    async def complete(
+        self,
+        messages: list[LLMMessage],
+        *,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Send messages to an LLM and get a completion.
+
+        Args:
+            messages: Conversation messages.
+            model: Model override (uses provider default if None).
+            temperature: Sampling temperature.
+            max_tokens: Max tokens in response.
+            **kwargs: Provider-specific options.
+
+        Returns:
+            LLMResponse with the completion.
+        """
+        ...

--- a/agents/src/application/services/__init__.py
+++ b/agents/src/application/services/__init__.py
@@ -1,0 +1,7 @@
+"""Application services — agent, pipeline, and digest invocation."""
+
+from src.application.services.agent_service import AgentService
+from src.application.services.digest_service import DigestService
+from src.application.services.pipeline_service import PipelineService
+
+__all__ = ["AgentService", "DigestService", "PipelineService"]

--- a/agents/src/application/services/agent_service.py
+++ b/agents/src/application/services/agent_service.py
@@ -1,0 +1,205 @@
+"""Agent invocation service — maps typed contracts to agent run() calls.
+
+Handles contract validation, kwargs mapping, and response normalization.
+"""
+
+from typing import Any
+
+from src.agents.adversarial import AdversarialAgent
+from src.agents.earnings_interpreter import EarningsInterpreterAgent
+from src.agents.filing_analyst import FilingAnalystAgent
+from src.agents.macro_regime import MacroRegimeAgent
+from src.agents.quant_signal import QuantSignalAgent
+from src.agents.risk_agent import RiskAgent
+from src.agents.thesis_guardian import ThesisGuardianAgent
+from src.application.contracts.agents import (
+    AnalyzeEarningsRequest,
+    AnalyzeEarningsResponse,
+    AssessRiskRequest,
+    AssessRiskResponse,
+    ChallengeThesisRequest,
+    ChallengeThesisResponse,
+    ClassifyMacroRequest,
+    ClassifyMacroResponse,
+    EvaluateThesisRequest,
+    EvaluateThesisResponse,
+    GenerateSignalsRequest,
+    GenerateSignalsResponse,
+    SearchFilingsRequest,
+    SearchFilingsResponse,
+)
+from src.application.llm.gateway import LLMGateway
+from src.core.agent import AgentResponse, BaseAgent
+
+
+def _metadata_get(metadata: dict[str, Any], key: str, default: Any = "") -> Any:
+    """Safely get a metadata value with a default."""
+    return metadata.get(key, default)
+
+
+class AgentService:
+    """Invokes agents with validated contracts and optional LLM synthesis.
+
+    Each method:
+    1. Validates the Pydantic request
+    2. Maps fields to agent kwargs
+    3. Runs the agent
+    4. Normalizes the response into a typed contract
+    5. Optionally synthesizes via LLM gateway
+    """
+
+    def __init__(self, gateway: LLMGateway | None = None) -> None:
+        self._gateway = gateway
+        self._agents: dict[str, BaseAgent] = {}
+
+    def _get_or_create(self, agent_cls: type[BaseAgent], *args: Any) -> BaseAgent:
+        """Cache agent instances by class name."""
+        key = agent_cls.__name__
+        if key not in self._agents:
+            self._agents[key] = agent_cls(*args)
+        return self._agents[key]
+
+    async def analyze_earnings(
+        self, request: AnalyzeEarningsRequest
+    ) -> AnalyzeEarningsResponse:
+        """Analyze an earnings transcript."""
+        agent = self._get_or_create(EarningsInterpreterAgent)
+        prompt = request.ticker or "Analyze this transcript"
+        response: AgentResponse = await agent.run(
+            prompt, transcript=request.transcript
+        )
+        return AnalyzeEarningsResponse(
+            content=response.content,
+            tone=_metadata_get(response.metadata, "tone"),
+            net_sentiment=float(_metadata_get(response.metadata, "net_sentiment", 0)),
+            confidence=str(_metadata_get(response.metadata, "confidence", "")),
+            guidance_direction=_metadata_get(response.metadata, "guidance_direction"),
+            guidance_count=int(_metadata_get(response.metadata, "guidance_count", 0)),
+            key_phrase_count=int(_metadata_get(response.metadata, "key_phrase_count", 0)),
+        )
+
+    async def classify_macro(
+        self, request: ClassifyMacroRequest
+    ) -> ClassifyMacroResponse:
+        """Classify the macro regime."""
+        agent = self._get_or_create(MacroRegimeAgent)
+        kwargs: dict[str, Any] = {}
+        if request.api_key:
+            kwargs["api_key"] = request.api_key
+        if request.indicators:
+            kwargs["indicators"] = request.indicators
+        response = await agent.run("Classify current macro regime", **kwargs)
+        return ClassifyMacroResponse(
+            content=response.content,
+            regime=_metadata_get(response.metadata, "regime"),
+            indicators_fetched=int(
+                _metadata_get(response.metadata, "indicators_fetched", 0)
+            ),
+            indicators_with_data=int(
+                _metadata_get(response.metadata, "indicators_with_data", 0)
+            ),
+        )
+
+    async def search_filings(
+        self, request: SearchFilingsRequest
+    ) -> SearchFilingsResponse:
+        """Search SEC filings for a company."""
+        agent = self._get_or_create(FilingAnalystAgent)
+        kwargs: dict[str, Any] = {"form_type": request.form_type}
+        if request.ticker:
+            kwargs["ticker"] = request.ticker
+        if request.cik:
+            kwargs["cik"] = request.cik
+        prompt = f"Search filings for {request.ticker or request.cik}"
+        response = await agent.run(prompt, **kwargs)
+        return SearchFilingsResponse(
+            content=response.content,
+            cik=str(_metadata_get(response.metadata, "cik", "")),
+            form_type=str(_metadata_get(response.metadata, "form_type", "")),
+            filing_count=int(_metadata_get(response.metadata, "filing_count", 0)),
+        )
+
+    async def generate_signals(
+        self, request: GenerateSignalsRequest
+    ) -> GenerateSignalsResponse:
+        """Generate composite quant signals."""
+        agent = self._get_or_create(QuantSignalAgent)
+        kwargs: dict[str, Any] = {
+            "method": request.method,
+        }
+        if request.signals:
+            kwargs["signals"] = request.signals
+        if request.sentiment is not None:
+            kwargs["sentiment"] = request.sentiment
+        if request.regime:
+            kwargs["regime"] = request.regime
+        if request.direction:
+            kwargs["direction"] = request.direction
+        if request.source:
+            kwargs["source"] = request.source
+        response = await agent.run("Generate composite signals", **kwargs)
+        return GenerateSignalsResponse(
+            content=response.content,
+            agent=_metadata_get(response.metadata, "agent", "quant-signal"),
+            composite=_metadata_get(response.metadata, "composite", {}),
+            signals=_metadata_get(response.metadata, "signals", []),
+        )
+
+    async def evaluate_thesis(
+        self, request: EvaluateThesisRequest
+    ) -> EvaluateThesisResponse:
+        """Evaluate investment theses against observed data."""
+        agent = self._get_or_create(ThesisGuardianAgent)
+        response = await agent.run(
+            "Evaluate theses",
+            theses=request.theses,
+            data=request.data,
+        )
+        return EvaluateThesisResponse(
+            content=response.content,
+            theses_checked=int(
+                _metadata_get(response.metadata, "theses_checked", 0)
+            ),
+            alerts_generated=int(
+                _metadata_get(response.metadata, "alerts_generated", 0)
+            ),
+            critical_alerts=int(
+                _metadata_get(response.metadata, "critical_alerts", 0)
+            ),
+        )
+
+    async def assess_risk(self, request: AssessRiskRequest) -> AssessRiskResponse:
+        """Run risk analysis."""
+        agent = self._get_or_create(RiskAgent)
+        kwargs: dict[str, Any] = {}
+        if request.positions:
+            kwargs["positions"] = request.positions
+        if request.scenarios:
+            kwargs["scenarios"] = request.scenarios
+        if request.returns:
+            kwargs["returns"] = request.returns
+        response = await agent.run("Assess portfolio risk", **kwargs)
+        return AssessRiskResponse(content=response.content)
+
+    async def challenge_thesis(
+        self, request: ChallengeThesisRequest
+    ) -> ChallengeThesisResponse:
+        """Adversarially challenge a thesis."""
+        agent = self._get_or_create(AdversarialAgent)
+        kwargs: dict[str, Any] = {}
+        if request.claims:
+            kwargs["claims"] = request.claims
+        prompt = request.prompt or "Challenge these claims"
+        response = await agent.run(prompt, **kwargs)
+        return ChallengeThesisResponse(
+            content=response.content,
+            conviction_score=str(
+                _metadata_get(response.metadata, "conviction_score", "")
+            ),
+            counter_count=int(
+                _metadata_get(response.metadata, "counter_count", 0)
+            ),
+            blind_spot_count=int(
+                _metadata_get(response.metadata, "blind_spot_count", 0)
+            ),
+        )

--- a/agents/src/application/services/agent_service.py
+++ b/agents/src/application/services/agent_service.py
@@ -28,7 +28,6 @@ from src.application.contracts.agents import (
     SearchFilingsRequest,
     SearchFilingsResponse,
 )
-from src.application.llm.gateway import LLMGateway
 from src.core.agent import AgentResponse, BaseAgent
 
 
@@ -38,18 +37,16 @@ def _metadata_get(metadata: dict[str, Any], key: str, default: Any = "") -> Any:
 
 
 class AgentService:
-    """Invokes agents with validated contracts and optional LLM synthesis.
+    """Invokes agents with validated contracts.
 
     Each method:
     1. Validates the Pydantic request
     2. Maps fields to agent kwargs
     3. Runs the agent
     4. Normalizes the response into a typed contract
-    5. Optionally synthesizes via LLM gateway
     """
 
-    def __init__(self, gateway: LLMGateway | None = None) -> None:
-        self._gateway = gateway
+    def __init__(self) -> None:
         self._agents: dict[str, BaseAgent] = {}
 
     def _get_or_create(self, agent_cls: type[BaseAgent], *args: Any) -> BaseAgent:
@@ -110,7 +107,8 @@ class AgentService:
             kwargs["ticker"] = request.ticker
         if request.cik:
             kwargs["cik"] = request.cik
-        prompt = f"Search filings for {request.ticker or request.cik}"
+        query_target = request.ticker or request.cik
+        prompt = f"Search filings for {query_target}" if query_target else ""
         response = await agent.run(prompt, **kwargs)
         return SearchFilingsResponse(
             content=response.content,
@@ -140,7 +138,7 @@ class AgentService:
         response = await agent.run("Generate composite signals", **kwargs)
         return GenerateSignalsResponse(
             content=response.content,
-            agent=_metadata_get(response.metadata, "agent", "quant-signal"),
+            agent=_metadata_get(response.metadata, "agent", "quant_signal"),
             composite=_metadata_get(response.metadata, "composite", {}),
             signals=_metadata_get(response.metadata, "signals", []),
         )

--- a/agents/src/application/services/digest_service.py
+++ b/agents/src/application/services/digest_service.py
@@ -1,0 +1,65 @@
+"""Digest service — wraps research pipeline for typed digest execution."""
+
+from src.application.contracts.agents import RunDigestRequest, RunDigestResponse
+from src.pipelines.research_digest import (
+    DataSource,
+    PipelineConfig,
+    ResearchPipeline,
+)
+
+
+class DigestService:
+    """Runs the research digest pipeline with typed contracts."""
+
+    async def run_digest(self, request: RunDigestRequest) -> RunDigestResponse:
+        """Execute the research digest pipeline.
+
+        Args:
+            request: Digest request with tickers, sources, and config.
+
+        Returns:
+            RunDigestResponse with digest summary and metrics.
+        """
+        config = PipelineConfig(
+            tickers=request.tickers,
+            lookback_days=request.lookback_days,
+            alert_threshold=request.alert_threshold,
+        )
+        pipeline = ResearchPipeline(config)
+
+        for source_dict in request.sources:
+            source = DataSource(
+                source_type=source_dict.get("source_type", ""),
+                ticker=source_dict.get("ticker", ""),
+                date=source_dict.get("date", ""),
+                content=source_dict.get("content", ""),
+                metadata=source_dict.get("metadata", {}),
+            )
+            pipeline.add_source(source)
+
+        digest = pipeline.run()
+
+        entry_lines = []
+        for entry in digest.entries:
+            material_tag = " [MATERIAL]" if entry.material else ""
+            entry_lines.append(
+                f"- {entry.ticker}: {entry.source}{material_tag} "
+                f"(sentiment={entry.sentiment:.2f})"
+            )
+
+        alert_lines = [f"- [{a.severity}] {a.ticker}: {a.message}" for a in digest.alerts]
+
+        content_parts = [f"Research Digest — {len(digest.entries)} entries"]
+        if entry_lines:
+            content_parts.append("\n".join(entry_lines))
+        if alert_lines:
+            content_parts.append(f"\nAlerts ({len(alert_lines)}):")
+            content_parts.append("\n".join(alert_lines))
+
+        return RunDigestResponse(
+            ticker_count=len(request.tickers),
+            entry_count=len(digest.entries),
+            alert_count=len(digest.alerts),
+            material_count=sum(1 for e in digest.entries if e.material),
+            content="\n".join(content_parts),
+        )

--- a/agents/src/application/services/pipeline_service.py
+++ b/agents/src/application/services/pipeline_service.py
@@ -1,0 +1,96 @@
+"""Pipeline service — wraps orchestrator for typed pipeline execution."""
+
+from typing import Any
+
+from src.application.contracts.agents import RunPipelineRequest, RunPipelineResponse
+from src.core.agent import BaseAgent
+from src.core.orchestrator import AgentTask, Orchestrator
+
+
+class PipelineService:
+    """Runs multi-agent pipelines via the orchestrator.
+
+    Maps typed pipeline requests to AgentTask lists,
+    executes via Orchestrator, and returns typed responses.
+    """
+
+    def __init__(self, orchestrator: Orchestrator | None = None) -> None:
+        self._orchestrator = orchestrator or Orchestrator()
+
+    @property
+    def orchestrator(self) -> Orchestrator:
+        """The underlying orchestrator."""
+        return self._orchestrator
+
+    def register_agent(self, agent: BaseAgent) -> None:
+        """Register an agent with the orchestrator."""
+        self._orchestrator.register(agent)
+
+    async def run_pipeline(
+        self,
+        request: RunPipelineRequest,
+        *,
+        ticker: str = "",
+        date: str = "",
+    ) -> RunPipelineResponse:
+        """Execute a multi-agent pipeline.
+
+        Args:
+            request: Pipeline request with task definitions.
+            ticker: Optional ticker for memo generation.
+            date: Optional date for memo generation.
+
+        Returns:
+            RunPipelineResponse with results and optional memo.
+        """
+        tasks: list[AgentTask] = []
+        for task_def in request.tasks:
+            agent_name = task_def.get("agent_name", "")
+            agent = self._orchestrator.get_agent(agent_name)
+            if agent is None:
+                continue
+
+            task = AgentTask(
+                agent=agent,
+                prompt=task_def.get("prompt", ""),
+                kwargs=task_def.get("kwargs", {}),
+                priority=task_def.get("priority", 0),
+                depends_on=task_def.get("depends_on", []),
+                task_id=task_def.get("task_id"),
+            )
+            tasks.append(task)
+
+        pipeline_result = await self._orchestrator.run_pipeline(tasks)
+
+        result_dicts: list[dict[str, Any]] = []
+        for r in pipeline_result.results:
+            result_dicts.append({
+                "task_id": r.task_id or r.agent_name,
+                "agent_name": r.agent_name,
+                "success": r.success,
+                "duration_ms": r.duration_ms,
+                "content": r.response.content,
+                "metadata": r.response.metadata,
+                "error": r.error,
+            })
+
+        memo = None
+        if ticker and date:
+            research_memo = self._orchestrator.generate_memo(
+                ticker, date, pipeline_result.results
+            )
+            memo = {
+                "ticker": research_memo.ticker,
+                "date": research_memo.date,
+                "sections": research_memo.sections,
+                "sources": research_memo.sources,
+                "summary": research_memo.summary,
+            }
+
+        return RunPipelineResponse(
+            results=result_dicts,
+            total_duration_ms=pipeline_result.total_duration_ms,
+            successful=pipeline_result.successful,
+            failed=pipeline_result.failed,
+            memo=memo,
+        )

--- a/agents/src/application/services/pipeline_service.py
+++ b/agents/src/application/services/pipeline_service.py
@@ -45,18 +45,17 @@ class PipelineService:
         """
         tasks: list[AgentTask] = []
         for task_def in request.tasks:
-            agent_name = task_def.get("agent_name", "")
-            agent = self._orchestrator.get_agent(agent_name)
+            agent = self._orchestrator.get_agent(task_def.agent_name)
             if agent is None:
                 continue
 
             task = AgentTask(
                 agent=agent,
-                prompt=task_def.get("prompt", ""),
-                kwargs=task_def.get("kwargs", {}),
-                priority=task_def.get("priority", 0),
-                depends_on=task_def.get("depends_on", []),
-                task_id=task_def.get("task_id"),
+                prompt=task_def.prompt,
+                kwargs=task_def.kwargs,
+                priority=task_def.priority,
+                depends_on=task_def.depends_on,
+                task_id=task_def.task_id or None,
             )
             tasks.append(task)
 
@@ -76,15 +75,23 @@ class PipelineService:
 
         memo = None
         if ticker and date:
-            research_memo = self._orchestrator.generate_memo(
-                ticker, date, pipeline_result.results
-            )
+            memo_sections: dict[str, str] = {}
+            for r in pipeline_result.results:
+                if not r.success:
+                    continue
+                section_key = r.task_id or r.agent_name
+                if section_key in memo_sections:
+                    section_key = f"{section_key} ({r.agent_name})"
+                memo_sections[section_key] = r.response.content
+
+            sources = [r.agent_name for r in pipeline_result.results if r.success]
+            analyzed = ", ".join(sources) if sources else "none"
             memo = {
-                "ticker": research_memo.ticker,
-                "date": research_memo.date,
-                "sections": research_memo.sections,
-                "sources": research_memo.sources,
-                "summary": research_memo.summary,
+                "ticker": ticker,
+                "date": date,
+                "sections": memo_sections,
+                "sources": sources,
+                "summary": f"Research memo for {ticker} on {date}. Analyzed by: {analyzed}.",
             }
 
         return RunPipelineResponse(

--- a/agents/src/core/orchestrator.py
+++ b/agents/src/core/orchestrator.py
@@ -18,6 +18,12 @@ class AgentTask:
     kwargs: dict[str, Any] = field(default_factory=dict)
     priority: int = 0
     depends_on: list[str] = field(default_factory=list)
+    task_id: str | None = None
+
+    @property
+    def id(self) -> str:
+        """Unique task identifier. Falls back to agent name for backwards compat."""
+        return self.task_id if self.task_id is not None else self.agent.name
 
 
 @dataclass
@@ -29,6 +35,7 @@ class AgentResult:
     duration_ms: int
     success: bool
     error: str | None = None
+    task_id: str | None = None
 
 
 @dataclass
@@ -107,6 +114,7 @@ class Orchestrator:
                 response=response,
                 duration_ms=elapsed,
                 success=True,
+                task_id=task.id,
             )
         except Exception as exc:  # noqa: BLE001
             elapsed = int((time.monotonic() - start) * 1000)
@@ -116,6 +124,7 @@ class Orchestrator:
                 duration_ms=elapsed,
                 success=False,
                 error=str(exc),
+                task_id=task.id,
             )
 
     async def run_pipeline(self, tasks: list[AgentTask]) -> PipelineResult:
@@ -124,6 +133,7 @@ class Orchestrator:
         Tasks with no dependencies run first (ordered by priority desc).
         Tasks with dependencies wait for their dependencies to complete.
         Failed dependencies cause dependent tasks to fail with an error message.
+        Dependencies reference task IDs (or agent names for backwards compat).
 
         Args:
             tasks: List of agent tasks to execute.
@@ -157,8 +167,9 @@ class Orchestrator:
                             error=(
                                 f"Dependency failed: {', '.join(failed_deps)}"
                             ),
+                            task_id=task.id,
                         )
-                        completed[task.agent.name] = result
+                        completed[task.id] = result
                         all_results.append(result)
                         continue
                     ready.append(task)
@@ -174,8 +185,9 @@ class Orchestrator:
                         duration_ms=0,
                         success=False,
                         error="Unresolvable dependency",
+                        task_id=task.id,
                     )
-                    completed[task.agent.name] = result
+                    completed[task.id] = result
                     all_results.append(result)
                 break
 
@@ -186,8 +198,9 @@ class Orchestrator:
             batch_results = await asyncio.gather(
                 *(self.run_task(t) for t in ready)
             )
-            for result in batch_results:
-                completed[result.agent_name] = result
+            for idx, result in enumerate(batch_results):
+                task_id = ready[idx].id
+                completed[task_id] = result
                 all_results.append(result)
 
             remaining = blocked

--- a/agents/tests/conftest.py
+++ b/agents/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Shared test fixtures."""
+
+import pytest
+
+from src.application.config import AppConfig
+
+
+@pytest.fixture()
+def fred_api_key() -> str:
+    """Return the FRED API key from config, or skip if not set."""
+    config = AppConfig()
+    if not config.fred_api_key:
+        pytest.skip("FRED API key not configured")
+    return config.fred_api_key

--- a/agents/tests/support/mock_provider.py
+++ b/agents/tests/support/mock_provider.py
@@ -1,0 +1,40 @@
+"""MockProvider — canned LLM responses for testing."""
+
+from typing import Any
+
+from src.application.llm.types import LLMMessage, LLMProvider, LLMResponse
+
+
+class MockProvider:
+    """LLM provider that returns canned responses for testing."""
+
+    def __init__(self, response: str = "Mock LLM response") -> None:
+        self._response = response
+        self.calls: list[dict[str, Any]] = []
+
+    async def complete(
+        self,
+        messages: list[LLMMessage],
+        *,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Return a canned response and record the call."""
+        self.calls.append({
+            "messages": messages,
+            "model": model,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            **kwargs,
+        })
+        return LLMResponse(
+            content=self._response,
+            model=model or "mock",
+            usage={"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        )
+
+
+# Verify protocol conformance
+_mock_check: type[LLMProvider] = MockProvider  # type: ignore[assignment]

--- a/agents/tests/test_adversarial.py
+++ b/agents/tests/test_adversarial.py
@@ -137,40 +137,44 @@ class TestComputeConviction:
     def test_no_issues_full_conviction(self) -> None:
         assert compute_conviction([], []) == Decimal("1.0")
 
-    def test_strong_counter_penalty(self) -> None:
-        counters = [
-            CounterArgument("c", "x", "historical", "STRONG"),
-        ]
-        assert compute_conviction(counters, []) == Decimal("0.85")
+    def test_strong_counter_reduces_more_than_moderate(self) -> None:
+        strong = compute_conviction(
+            [CounterArgument("c", "x", "historical", "STRONG")], []
+        )
+        moderate = compute_conviction(
+            [CounterArgument("c", "x", "historical", "MODERATE")], []
+        )
+        weak = compute_conviction(
+            [CounterArgument("c", "x", "historical", "WEAK")], []
+        )
+        assert strong < moderate < weak < Decimal("1.0")
 
-    def test_moderate_counter_penalty(self) -> None:
-        counters = [
-            CounterArgument("c", "x", "historical", "MODERATE"),
-        ]
-        assert compute_conviction(counters, []) == Decimal("0.90")
+    def test_more_issues_lower_conviction(self) -> None:
+        one = compute_conviction(
+            [CounterArgument("c", "x", "historical", "STRONG")], []
+        )
+        two = compute_conviction(
+            [CounterArgument("c", "x", "historical", "STRONG")] * 2, []
+        )
+        assert two < one
 
-    def test_weak_counter_penalty(self) -> None:
-        counters = [
-            CounterArgument("c", "x", "historical", "WEAK"),
-        ]
-        assert compute_conviction(counters, []) == Decimal("0.95")
+    def test_blind_spots_reduce_conviction(self) -> None:
+        high = compute_conviction(
+            [], [BlindSpot("regulatory", "desc", "HIGH")]
+        )
+        low = compute_conviction(
+            [], [BlindSpot("macro", "desc", "LOW")]
+        )
+        assert high < low < Decimal("1.0")
 
-    def test_blind_spot_penalties(self) -> None:
-        spots = [
-            BlindSpot("regulatory", "desc", "HIGH"),
-            BlindSpot("macro", "desc", "LOW"),
-        ]
-        # 1.0 - 0.10 - 0.02 = 0.88
-        assert compute_conviction([], spots) == Decimal("0.88")
-
-    def test_combined_penalties(self) -> None:
-        counters = [
-            CounterArgument("c", "x", "historical", "STRONG"),
-            CounterArgument("c", "x", "structural", "MODERATE"),
-        ]
+    def test_combined_issues_reduce_more_than_either_alone(self) -> None:
+        counters = [CounterArgument("c", "x", "historical", "STRONG")]
         spots = [BlindSpot("exec", "desc", "MEDIUM")]
-        # 1.0 - 0.15 - 0.10 - 0.05 = 0.70
-        assert compute_conviction(counters, spots) == Decimal("0.70")
+        combined = compute_conviction(counters, spots)
+        counters_only = compute_conviction(counters, [])
+        spots_only = compute_conviction([], spots)
+        assert combined < counters_only
+        assert combined < spots_only
 
     def test_clamps_to_zero(self) -> None:
         counters = [

--- a/agents/tests/test_config.py
+++ b/agents/tests/test_config.py
@@ -2,7 +2,7 @@
 
 import json
 
-from src.application.config import CONFIG_DIR, CONFIG_FILE, AppConfig
+from src.application.config import AppConfig
 
 
 class TestAppConfig:
@@ -54,8 +54,3 @@ class TestAppConfig:
         config = AppConfig()
         assert config.fred_api_key == ""
         assert config.llm_provider == "skip"
-
-    def test_config_dir_location(self):
-        assert CONFIG_DIR.name == "finance-os"
-        assert CONFIG_DIR.parent.name == ".config"
-        assert CONFIG_FILE.name == "config.json"

--- a/agents/tests/test_config.py
+++ b/agents/tests/test_config.py
@@ -1,0 +1,61 @@
+"""Tests for application config."""
+
+import json
+
+from src.application.config import CONFIG_DIR, CONFIG_FILE, AppConfig
+
+
+class TestAppConfig:
+    def test_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "src.application.config.CONFIG_FILE", tmp_path / "nonexistent.json"
+        )
+        config = AppConfig()
+        assert config.llm_provider == "skip"
+        assert config.llm_default_model == "gpt-4o"
+        assert config.llm_temperature == 0.0
+        assert config.fred_api_key == ""
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("FINANCE_OS_LLM_PROVIDER", "litellm")
+        monkeypatch.setenv("FINANCE_OS_LLM_DEFAULT_MODEL", "claude-sonnet-4")
+        config = AppConfig()
+        assert config.llm_provider == "litellm"
+        assert config.llm_default_model == "claude-sonnet-4"
+
+    def test_fred_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("FINANCE_OS_FRED_API_KEY", "test-key-123")
+        config = AppConfig()
+        assert config.fred_api_key == "test-key-123"
+
+    def test_config_file_loads(self, tmp_path, monkeypatch):
+        cfg = {"fred_api_key": "file-key-456", "llm_provider": "litellm"}
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps(cfg))
+        monkeypatch.setattr("src.application.config.CONFIG_FILE", cfg_file)
+        config = AppConfig()
+        assert config.fred_api_key == "file-key-456"
+        assert config.llm_provider == "litellm"
+
+    def test_env_overrides_config_file(self, tmp_path, monkeypatch):
+        cfg = {"fred_api_key": "file-key", "llm_provider": "litellm"}
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps(cfg))
+        monkeypatch.setattr("src.application.config.CONFIG_FILE", cfg_file)
+        monkeypatch.setenv("FINANCE_OS_FRED_API_KEY", "env-key")
+        config = AppConfig()
+        assert config.fred_api_key == "env-key"
+        assert config.llm_provider == "litellm"
+
+    def test_missing_config_file_uses_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "src.application.config.CONFIG_FILE", tmp_path / "nonexistent.json"
+        )
+        config = AppConfig()
+        assert config.fred_api_key == ""
+        assert config.llm_provider == "skip"
+
+    def test_config_dir_location(self):
+        assert CONFIG_DIR.name == "finance-os"
+        assert CONFIG_DIR.parent.name == ".config"
+        assert CONFIG_FILE.name == "config.json"

--- a/agents/tests/test_contracts.py
+++ b/agents/tests/test_contracts.py
@@ -7,7 +7,6 @@ from pydantic import ValidationError
 
 from src.application.contracts.agents import (
     AnalyzeEarningsRequest,
-    AnalyzeEarningsResponse,
     AssessRiskRequest,
     ChallengeThesisRequest,
     ClassifyMacroRequest,
@@ -20,27 +19,9 @@ from src.application.contracts.agents import (
 
 
 class TestAnalyzeEarningsContract:
-    def test_valid_request(self):
-        req = AnalyzeEarningsRequest(transcript="Q3 earnings call transcript...")
-        assert req.transcript == "Q3 earnings call transcript..."
-        assert req.ticker == ""
-
     def test_empty_transcript_rejected(self):
         with pytest.raises(ValidationError):
             AnalyzeEarningsRequest(transcript="")
-
-    def test_response_from_metadata(self):
-        resp = AnalyzeEarningsResponse(
-            content="Report",
-            tone="bullish",
-            net_sentiment=0.75,
-            confidence="HIGH",
-            guidance_direction="up",
-            guidance_count=3,
-            key_phrase_count=12,
-        )
-        assert resp.tone == "bullish"
-        assert resp.net_sentiment == 0.75
 
 
 class TestClassifyMacroContract:

--- a/agents/tests/test_contracts.py
+++ b/agents/tests/test_contracts.py
@@ -1,0 +1,124 @@
+"""Tests for application layer contracts."""
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from src.application.contracts.agents import (
+    AnalyzeEarningsRequest,
+    AnalyzeEarningsResponse,
+    AssessRiskRequest,
+    ChallengeThesisRequest,
+    ClassifyMacroRequest,
+    EvaluateThesisRequest,
+    GenerateSignalsRequest,
+    RunDigestRequest,
+    RunPipelineRequest,
+    SearchFilingsRequest,
+)
+
+
+class TestAnalyzeEarningsContract:
+    def test_valid_request(self):
+        req = AnalyzeEarningsRequest(transcript="Q3 earnings call transcript...")
+        assert req.transcript == "Q3 earnings call transcript..."
+        assert req.ticker == ""
+
+    def test_empty_transcript_rejected(self):
+        with pytest.raises(ValidationError):
+            AnalyzeEarningsRequest(transcript="")
+
+    def test_response_from_metadata(self):
+        resp = AnalyzeEarningsResponse(
+            content="Report",
+            tone="bullish",
+            net_sentiment=0.75,
+            confidence="HIGH",
+            guidance_direction="up",
+            guidance_count=3,
+            key_phrase_count=12,
+        )
+        assert resp.tone == "bullish"
+        assert resp.net_sentiment == 0.75
+
+
+class TestClassifyMacroContract:
+    def test_defaults(self):
+        req = ClassifyMacroRequest()
+        assert req.api_key == ""
+        assert req.indicators == []
+
+    def test_with_indicators(self):
+        req = ClassifyMacroRequest(api_key="test", indicators=["GDP", "UNRATE"])
+        assert len(req.indicators) == 2
+
+
+class TestSearchFilingsContract:
+    def test_defaults(self):
+        req = SearchFilingsRequest()
+        assert req.form_type == "10-K"
+
+    def test_with_ticker(self):
+        req = SearchFilingsRequest(ticker="AAPL")
+        assert req.ticker == "AAPL"
+
+
+class TestGenerateSignalsContract:
+    def test_with_decimal_sentiment(self):
+        req = GenerateSignalsRequest(sentiment=Decimal("0.85"))
+        assert req.sentiment == Decimal("0.85")
+
+    def test_defaults(self):
+        req = GenerateSignalsRequest()
+        assert req.method == "equal_weight"
+        assert req.signals == []
+
+
+class TestEvaluateThesisContract:
+    def test_with_data(self):
+        thesis = {
+            "ticker": "AAPL", "hypothesis": "Growth",
+            "assumptions": [], "status": "active",
+        }
+        req = EvaluateThesisRequest(
+            theses=[thesis],
+            data={"revenue_growth": Decimal("0.15")},
+        )
+        assert len(req.theses) == 1
+        assert req.data["revenue_growth"] == Decimal("0.15")
+
+
+class TestAssessRiskContract:
+    def test_defaults(self):
+        req = AssessRiskRequest()
+        assert req.positions == []
+        assert req.scenarios == []
+        assert req.returns == []
+
+
+class TestChallengeThesisContract:
+    def test_with_claims(self):
+        req = ChallengeThesisRequest(claims=["Revenue will grow 20%"])
+        assert len(req.claims) == 1
+
+    def test_with_prompt_only(self):
+        req = ChallengeThesisRequest(prompt="AAPL will outperform")
+        assert req.claims == []
+
+
+class TestRunPipelineContract:
+    def test_valid_tasks(self):
+        req = RunPipelineRequest(tasks=[
+            {"agent_name": "macro-regime", "prompt": "Classify"},
+            {"agent_name": "risk", "prompt": "Assess risk", "depends_on": ["macro-regime"]},
+        ])
+        assert len(req.tasks) == 2
+
+
+class TestRunDigestContract:
+    def test_defaults(self):
+        req = RunDigestRequest(tickers=["AAPL", "MSFT"])
+        assert req.lookback_days == 7
+        assert req.alert_threshold == 0.5
+        assert req.sources == []

--- a/agents/tests/test_llm_gateway.py
+++ b/agents/tests/test_llm_gateway.py
@@ -1,0 +1,140 @@
+"""Tests for the LLM gateway and providers."""
+
+import pytest
+
+from src.application.llm.gateway import LLMGateway, create_gateway
+from src.application.llm.providers import SkipProvider
+from src.application.llm.types import LLMMessage, LLMProvider
+from tests.support.mock_provider import MockProvider
+
+
+class TestMockProvider:
+    @pytest.mark.asyncio
+    async def test_returns_canned_response(self):
+        provider = MockProvider(response="Test output")
+        messages = [LLMMessage(role="user", content="Hello")]
+        result = await provider.complete(messages)
+        assert result.content == "Test output"
+        assert result.model == "mock"
+
+    @pytest.mark.asyncio
+    async def test_records_calls(self):
+        provider = MockProvider()
+        messages = [LLMMessage(role="user", content="Query")]
+        await provider.complete(messages, model="gpt-4o")
+        assert len(provider.calls) == 1
+        assert provider.calls[0]["model"] == "gpt-4o"
+
+    @pytest.mark.asyncio
+    async def test_multiple_calls_recorded(self):
+        provider = MockProvider()
+        msg = [LLMMessage(role="user", content="A")]
+        await provider.complete(msg)
+        await provider.complete(msg)
+        assert len(provider.calls) == 2
+
+    def test_conforms_to_protocol(self):
+        assert isinstance(MockProvider(), LLMProvider)
+
+
+class TestSkipProvider:
+    @pytest.mark.asyncio
+    async def test_returns_last_user_message(self):
+        provider = SkipProvider()
+        messages = [
+            LLMMessage(role="system", content="You are helpful"),
+            LLMMessage(role="user", content="Agent output data"),
+        ]
+        result = await provider.complete(messages)
+        assert result.content == "Agent output data"
+        assert result.model == "skip"
+
+    @pytest.mark.asyncio
+    async def test_empty_messages_returns_empty(self):
+        provider = SkipProvider()
+        result = await provider.complete([])
+        assert result.content == ""
+
+    @pytest.mark.asyncio
+    async def test_no_user_messages_returns_empty(self):
+        provider = SkipProvider()
+        messages = [LLMMessage(role="system", content="sys")]
+        result = await provider.complete(messages)
+        assert result.content == ""
+
+    def test_conforms_to_protocol(self):
+        assert isinstance(SkipProvider(), LLMProvider)
+
+
+class TestLLMGateway:
+    @pytest.mark.asyncio
+    async def test_default_uses_skip_provider(self):
+        gateway = LLMGateway()
+        messages = [LLMMessage(role="user", content="Pass through")]
+        result = await gateway.complete(messages)
+        assert result.content == "Pass through"
+
+    @pytest.mark.asyncio
+    async def test_with_mock_provider(self):
+        provider = MockProvider(response="Mocked")
+        gateway = LLMGateway(provider)
+        messages = [LLMMessage(role="user", content="Q")]
+        result = await gateway.complete(messages)
+        assert result.content == "Mocked"
+
+    @pytest.mark.asyncio
+    async def test_synthesize_sends_system_and_user(self):
+        provider = MockProvider(response="Synthesized summary")
+        gateway = LLMGateway(provider)
+        result = await gateway.synthesize(
+            system_prompt="You are a financial analyst",
+            agent_output="Revenue up 15%, margins stable",
+        )
+        assert result.content == "Synthesized summary"
+        assert len(provider.calls) == 1
+        messages = provider.calls[0]["messages"]
+        assert messages[0].role == "system"
+        assert messages[1].role == "user"
+        assert "Revenue up 15%" in messages[1].content
+
+    @pytest.mark.asyncio
+    async def test_synthesize_custom_instruction(self):
+        provider = MockProvider(response="Custom")
+        gateway = LLMGateway(provider)
+        result = await gateway.synthesize(
+            system_prompt="Analyst",
+            agent_output="Data",
+            instruction="Summarize in one sentence",
+        )
+        assert result.content == "Custom"
+        messages = provider.calls[0]["messages"]
+        assert "Summarize in one sentence" in messages[1].content
+
+    @pytest.mark.asyncio
+    async def test_model_override_forwarded(self):
+        provider = MockProvider()
+        gateway = LLMGateway(provider)
+        messages = [LLMMessage(role="user", content="Q")]
+        await gateway.complete(messages, model="claude-sonnet-4")
+        assert provider.calls[0]["model"] == "claude-sonnet-4"
+
+
+class TestCreateGateway:
+    def test_skip_provider(self):
+        gateway = create_gateway("skip")
+        assert isinstance(gateway.provider, SkipProvider)
+
+    def test_mock_provider_via_constructor(self):
+        provider = MockProvider(response="Hello")
+        gateway = LLMGateway(provider)
+        assert isinstance(gateway.provider, MockProvider)
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="Unknown provider"):
+            create_gateway("nonexistent")
+
+    def test_litellm_provider(self):
+        gateway = create_gateway("litellm", default_model="gpt-4o-mini")
+        from src.application.llm.litellm_provider import LiteLLMProvider
+
+        assert isinstance(gateway.provider, LiteLLMProvider)

--- a/agents/tests/test_macro_regime.py
+++ b/agents/tests/test_macro_regime.py
@@ -142,3 +142,21 @@ class TestMacroRegimeAgent:
         agent = MacroRegimeAgent()
         response = await agent.run("analyze")
         assert "API key" in response.content
+
+
+class TestLiveFRED:
+    """Live FRED API tests — skipped when API key is not configured."""
+
+    async def test_fetch_single_series(self, fred_api_key: str) -> None:
+        from src.agents.macro_regime import fetch_fred_series
+
+        observations = fetch_fred_series("UNRATE", fred_api_key, limit=3)
+        assert len(observations) > 0
+        assert "date" in observations[0]
+        assert "value" in observations[0]
+
+    async def test_agent_run_produces_regime(self, fred_api_key: str) -> None:
+        agent = MacroRegimeAgent(fred_api_key=fred_api_key)
+        response = await agent.run("classify current macro regime", indicators=["UNRATE"])
+        assert response.metadata["regime"] in ("EXPANSION", "CONTRACTION", "TRANSITION")
+        assert "nemployment rate" in response.content

--- a/agents/tests/test_macro_regime.py
+++ b/agents/tests/test_macro_regime.py
@@ -2,6 +2,8 @@
 
 from decimal import Decimal
 
+import pytest
+
 from src.agents.macro_regime import (
     IndicatorReading,
     MacroRegimeAgent,
@@ -144,6 +146,7 @@ class TestMacroRegimeAgent:
         assert "API key" in response.content
 
 
+@pytest.mark.integration
 class TestLiveFRED:
     """Live FRED API tests — skipped when API key is not configured."""
 

--- a/agents/tests/test_orchestrator.py
+++ b/agents/tests/test_orchestrator.py
@@ -225,3 +225,62 @@ async def test_pipeline_empty_task_list(orchestrator: Orchestrator) -> None:
     assert result.successful == 0
     assert result.failed == 0
     assert result.results == []
+
+
+# ---------------------------------------------------------------------------
+# task_id tests
+# ---------------------------------------------------------------------------
+
+
+def test_task_id_defaults_to_agent_name() -> None:
+    agent = MockAgent("analyst")
+    task = AgentTask(agent=agent, prompt="go")
+    assert task.id == "analyst"
+
+
+def test_task_id_explicit() -> None:
+    agent = MockAgent("analyst")
+    task = AgentTask(agent=agent, prompt="go", task_id="task-1")
+    assert task.id == "task-1"
+
+
+async def test_run_task_includes_task_id(orchestrator: Orchestrator) -> None:
+    agent = MockAgent("analyst")
+    task = AgentTask(agent=agent, prompt="go", task_id="custom-id")
+    result = await orchestrator.run_task(task)
+    assert result.task_id == "custom-id"
+
+
+async def test_run_task_default_task_id(orchestrator: Orchestrator) -> None:
+    agent = MockAgent("analyst")
+    task = AgentTask(agent=agent, prompt="go")
+    result = await orchestrator.run_task(task)
+    assert result.task_id == "analyst"
+
+
+async def test_pipeline_same_agent_different_task_ids(
+    orchestrator: Orchestrator,
+) -> None:
+    """The same agent can run multiple times with different task IDs."""
+    agent = MockAgent("shared-agent", "output")
+    tasks = [
+        AgentTask(agent=agent, prompt="task 1", task_id="t1"),
+        AgentTask(agent=agent, prompt="task 2", task_id="t2"),
+    ]
+    result = await orchestrator.run_pipeline(tasks)
+    assert result.successful == 2
+    task_ids = {r.task_id for r in result.results}
+    assert task_ids == {"t1", "t2"}
+
+
+async def test_pipeline_task_id_dependencies(orchestrator: Orchestrator) -> None:
+    """Dependencies can reference task IDs instead of agent names."""
+    agent = MockAgent("worker", "done")
+    tasks = [
+        AgentTask(agent=agent, prompt="first", task_id="step-1"),
+        AgentTask(agent=agent, prompt="second", task_id="step-2", depends_on=["step-1"]),
+    ]
+    result = await orchestrator.run_pipeline(tasks)
+    assert result.successful == 2
+    ids = [r.task_id for r in result.results]
+    assert ids.index("step-1") < ids.index("step-2")

--- a/agents/tests/test_services.py
+++ b/agents/tests/test_services.py
@@ -1,0 +1,203 @@
+"""Tests for application services — agent, pipeline, and digest."""
+
+from decimal import Decimal
+
+import pytest
+
+from src.application.contracts.agents import (
+    AnalyzeEarningsRequest,
+    AssessRiskRequest,
+    ChallengeThesisRequest,
+    GenerateSignalsRequest,
+    RunDigestRequest,
+    RunPipelineRequest,
+)
+from src.application.services.agent_service import AgentService
+from src.application.services.digest_service import DigestService
+from src.application.services.pipeline_service import PipelineService
+from src.core.agent import AgentResponse, BaseAgent
+
+# --- Test helpers ---
+
+
+class StubAgent(BaseAgent):
+    """Agent that returns a fixed response for testing services."""
+
+    def __init__(self, name: str = "stub", response_content: str = "stub output",
+                 metadata: dict | None = None):
+        super().__init__(name=name, description="Stub agent")
+        self._response_content = response_content
+        self._metadata = metadata or {}
+
+    @property
+    def system_prompt(self) -> str:
+        return "Stub"
+
+    async def run(self, prompt: str, **kwargs) -> AgentResponse:
+        return AgentResponse(
+            content=self._response_content,
+            metadata=self._metadata,
+        )
+
+
+# --- AgentService tests ---
+
+
+class TestAgentServiceEarnings:
+    @pytest.mark.asyncio
+    async def test_analyze_earnings_maps_response(self):
+        service = AgentService()
+        request = AnalyzeEarningsRequest(
+            transcript="Revenue increased 15% year over year. We expect continued growth."
+        )
+        result = await service.analyze_earnings(request)
+        assert result.content  # agent produces a report
+        assert result.tone  # tone is classified
+        assert isinstance(result.net_sentiment, float)
+        assert isinstance(result.confidence, str)
+        assert isinstance(result.guidance_count, int)
+
+
+class TestAgentServiceSignals:
+    @pytest.mark.asyncio
+    async def test_generate_signals_with_sentiment(self):
+        service = AgentService()
+        request = GenerateSignalsRequest(sentiment=Decimal("0.75"))
+        result = await service.generate_signals(request)
+        assert result.content
+        assert result.agent == "quant_signal"
+
+
+class TestAgentServiceChallenge:
+    @pytest.mark.asyncio
+    async def test_challenge_with_claims(self):
+        service = AgentService()
+        request = ChallengeThesisRequest(
+            claims=["Revenue will grow 20% annually for 5 years"]
+        )
+        result = await service.challenge_thesis(request)
+        assert result.content
+        assert isinstance(result.counter_count, int)
+        assert isinstance(result.blind_spot_count, int)
+
+
+class TestAgentServiceRisk:
+    @pytest.mark.asyncio
+    async def test_assess_risk_with_returns(self):
+        service = AgentService()
+        returns = [Decimal(str(x)) for x in [0.02, -0.01, 0.03, -0.02, 0.01,
+                                               0.015, -0.005, 0.02, -0.01, 0.01]]
+        request = AssessRiskRequest(returns=returns)
+        result = await service.assess_risk(request)
+        assert result.content
+
+
+# --- PipelineService tests ---
+
+
+class TestPipelineService:
+    @pytest.mark.asyncio
+    async def test_run_pipeline_with_registered_agents(self):
+        stub = StubAgent(
+            name="test-agent",
+            response_content="Result",
+            metadata={"key": "value"},
+        )
+        service = PipelineService()
+        service.register_agent(stub)
+
+        request = RunPipelineRequest(tasks=[
+            {"agent_name": "test-agent", "prompt": "Do work"},
+        ])
+        result = await service.run_pipeline(request)
+        assert result.successful == 1
+        assert result.failed == 0
+        assert len(result.results) == 1
+        assert result.results[0]["content"] == "Result"
+
+    @pytest.mark.asyncio
+    async def test_pipeline_skips_unregistered_agents(self):
+        service = PipelineService()
+        request = RunPipelineRequest(tasks=[
+            {"agent_name": "nonexistent", "prompt": "Do work"},
+        ])
+        result = await service.run_pipeline(request)
+        assert result.successful == 0
+        assert result.failed == 0
+        assert len(result.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_pipeline_with_task_ids(self):
+        stub = StubAgent(name="agent-a", response_content="A output")
+        service = PipelineService()
+        service.register_agent(stub)
+
+        request = RunPipelineRequest(tasks=[
+            {"agent_name": "agent-a", "prompt": "Task 1", "task_id": "task-1"},
+            {"agent_name": "agent-a", "prompt": "Task 2", "task_id": "task-2"},
+        ])
+        result = await service.run_pipeline(request)
+        assert result.successful == 2
+        task_ids = [r["task_id"] for r in result.results]
+        assert "task-1" in task_ids
+        assert "task-2" in task_ids
+
+    @pytest.mark.asyncio
+    async def test_pipeline_with_dependencies(self):
+        stub_a = StubAgent(name="first", response_content="First")
+        stub_b = StubAgent(name="second", response_content="Second")
+        service = PipelineService()
+        service.register_agent(stub_a)
+        service.register_agent(stub_b)
+
+        request = RunPipelineRequest(tasks=[
+            {"agent_name": "first", "prompt": "Go"},
+            {"agent_name": "second", "prompt": "After first", "depends_on": ["first"]},
+        ])
+        result = await service.run_pipeline(request)
+        assert result.successful == 2
+
+    @pytest.mark.asyncio
+    async def test_pipeline_with_memo(self):
+        stub = StubAgent(name="analyst", response_content="Analysis done")
+        service = PipelineService()
+        service.register_agent(stub)
+
+        request = RunPipelineRequest(tasks=[
+            {"agent_name": "analyst", "prompt": "Analyze"},
+        ])
+        result = await service.run_pipeline(request, ticker="AAPL", date="2026-04-12")
+        assert result.memo is not None
+        assert result.memo["ticker"] == "AAPL"
+        assert "analyst" in result.memo["sources"]
+
+
+# --- DigestService tests ---
+
+
+class TestDigestService:
+    @pytest.mark.asyncio
+    async def test_empty_digest(self):
+        service = DigestService()
+        request = RunDigestRequest(tickers=["AAPL"])
+        result = await service.run_digest(request)
+        assert result.ticker_count == 1
+        assert result.entry_count == 0
+        assert result.alert_count == 0
+
+    @pytest.mark.asyncio
+    async def test_digest_with_sources(self):
+        service = DigestService()
+        request = RunDigestRequest(
+            tickers=["AAPL"],
+            sources=[{
+                "source_type": "filing",
+                "ticker": "AAPL",
+                "date": "2026-04-01",
+                "content": "Revenue increased significantly",
+                "metadata": {},
+            }],
+        )
+        result = await service.run_digest(request)
+        assert result.entry_count == 1
+        assert "AAPL" in result.content

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -9,7 +9,7 @@ All agents extend `BaseAgent` in `agents/src/core/agent.py`, which defines:
 
 ### Current state: no LLM calls
 
-Agents currently perform deterministic data processing (regex, heuristics, statistics) and construct prompts, but **do not call an LLM directly**. This is by design for the MCP path, where the host LLM (Copilot, Claude Desktop) does the reasoning. For the CLI and future web paths, the **LLM gateway** in the application layer will handle inference — see [architecture.md](architecture.md#llm-gateway).
+Agents currently perform deterministic data processing (regex, heuristics, statistics) and construct prompts, but **do not call an LLM directly**. This is by design for the MCP path, where the host LLM (Copilot, Claude Desktop) does the reasoning. For the CLI and future web paths, the **LLM gateway** in the application layer handles inference — see [architecture.md](architecture.md#llm-gateway).
 
 ## Agent Catalog
 
@@ -28,10 +28,19 @@ Agents currently perform deterministic data processing (regex, heuristics, stati
 The `Orchestrator` (`agents/src/core/orchestrator.py`) coordinates agents:
 
 - **Agent registry** — register and discover agents by name
-- **Dependency-aware pipeline** — tasks declare dependencies; independent tasks run in parallel via `asyncio.gather`
+- **Task identity** — tasks have explicit `task_id` (falls back to agent name), enabling the same agent to run multiple times in a pipeline
+- **Dependency-aware pipeline** — tasks declare dependencies by task ID; independent tasks run in parallel via `asyncio.gather`
 - **Priority ordering** — higher-priority tasks execute first within each dependency level
 - **Graceful failure** — failed tasks don't crash the pipeline; dependent tasks get error messages
 - **Research memos** — aggregate agent outputs into structured memos with sections and source attribution
+
+### Application Services
+
+The application layer (`agents/src/application/services/`) provides typed wrappers:
+
+- **`AgentService`** — maps Pydantic request/response contracts to agent `run()` calls. Validates inputs, normalizes metadata, and caches agent instances.
+- **`PipelineService`** — wraps orchestrator with task definitions from typed contracts, optional memo generation.
+- **`DigestService`** — wraps research pipeline with typed I/O and formatted output.
 
 ## Vector Memory
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@
 |---|---|
 | MCP Server (data tools) | TypeScript, Node.js, `@modelcontextprotocol/sdk` |
 | MCP Server (agents) | Python, `mcp` SDK (planned) |
-| Application Layer | Python, Pydantic, litellm (planned) |
+| Application Layer | Python, Pydantic 2.11+, pydantic-settings 2.9+, litellm 1.72+ |
 | Agents | Python 3.12+, NumPy, pandas, scipy |
 | Vector DB | ChromaDB (local) |
 | LLM Gateway | Pluggable — OpenAI, Anthropic, ollama, or host LLM via MCP |
@@ -52,16 +52,16 @@
 
 ## LLM Gateway
 
-The LLM gateway is a first-class component in the application layer, not a bolt-on. It resolves the fundamental question: *who does the LLM reasoning?*
+The LLM gateway is a first-class component in the application layer. It resolves the fundamental question: *who does the LLM reasoning?*
 
 ```
 ┌─────────────────────────────────────────────────────────┐
 │                   Application Layer                      │
 │                                                          │
 │  contracts/     Pydantic request/response models         │
-│  llm/           Pluggable inference client               │
-│  services/      Agent invocation, orchestration           │
-│  config/        Provider selection, model routing          │
+│  llm/           LLMProvider protocol + implementations   │
+│  services/      AgentService, PipelineService, Digest    │
+│  config.py      AppConfig (FINANCE_OS_* env vars)        │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -113,13 +113,22 @@ The TypeScript MCP server exposes investment **data tools** to LLMs via the Mode
 
 Entry point: `src/index.ts` registers all tools and starts the server on stdio transport.
 
-### Application Layer (`agents/src/application/`, planned)
+### Application Layer (`agents/src/application/`)
 
-The shared core that all interfaces wrap. Contains:
-- **Contracts** — Pydantic request/response models for every agent operation
-- **LLM gateway** — pluggable inference client with provider routing
-- **Services** — agent invocation, orchestration coordination, pipeline triggers
-- **Config** — provider selection, model routing, API key management
+The shared core that all interfaces wrap. Implemented as:
+
+- **Contracts** (`contracts/agents.py`) — Pydantic request/response models for every agent operation (9 request/response pairs covering all 7 agents, pipeline, and digest). Models match actual agent capabilities.
+- **LLM Gateway** (`llm/`) — pluggable inference via `LLMProvider` protocol:
+  - `LiteLLMProvider` — multi-provider routing (OpenAI, Anthropic, ollama, etc.)
+  - `MockProvider` — deterministic responses for testing
+  - `SkipProvider` — MCP path where host LLM reasons
+  - `LLMGateway` — routes requests, `synthesize()` for agent output → narrative
+  - `create_gateway()` — factory for creating configured gateways
+- **Services** (`services/`) — typed wrappers over agents:
+  - `AgentService` — maps Pydantic contracts to agent `run()` calls with normalization
+  - `PipelineService` — wraps orchestrator with task_id support and memo generation
+  - `DigestService` — wraps research pipeline with typed I/O
+- **Config** (`config.py`) — `AppConfig` via pydantic-settings, environment variables with `FINANCE_OS_` prefix
 
 CLI, Python MCP server, and future Web API are thin wrappers over this layer.
 
@@ -130,7 +139,7 @@ Domain-tuned Python agents built on a shared `BaseAgent` ABC (`src/core/agent.py
 - An async `run()` method for execution
 - Access to conversation history
 
-The orchestrator (`src/core/orchestrator.py`) coordinates agents via dependency-aware pipelines with priority ordering and parallel execution.
+The orchestrator (`src/core/orchestrator.py`) coordinates agents via dependency-aware pipelines with priority ordering and parallel execution. Tasks are identified by `task_id` (or agent name for backwards compatibility), enabling the same agent to run multiple times in a single pipeline.
 
 The vector memory layer (`src/core/memory.py`) provides ChromaDB-backed RAG for document retrieval with metadata filtering.
 
@@ -153,6 +162,15 @@ Shared prompt templates organized by strategy:
 | 0 | Repository foundation, MCP server, agent framework | ✅ Complete |
 | 1 | Core tools and agents (SEC, earnings, macro, quant, portfolio) | ✅ Complete |
 | 2 | Intelligence layer (thesis, risk, adversarial, orchestrator, pipeline) | ✅ Complete |
-| 3 | Integration layer (application layer + LLM gateway, CLI, Python MCP, Skills) | 🔜 Next |
+| 3 | Integration layer (application layer + LLM gateway, CLI, Python MCP, Skills) | 🔧 In Progress |
 | 4 | Advanced (knowledge graph, alt data, fine-tuning) — Copilot-first | Planned |
 | 5 | Web layer (FastAPI + Web UI) — after Copilot CLI is mostly complete | Planned |
+
+### Phase 3 Progress
+
+| Component | Issue | Status |
+|---|---|---|
+| Application layer (contracts, LLM gateway, services, config) | #49 | ✅ Complete |
+| Agent CLI | #50 | Next |
+| Python MCP server | #51 | Next |
+| Copilot Skills | #53 | Blocked on #50, #51 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@
 | Data Sources | SEC EDGAR (free), FRED (free API key), Yahoo Finance, QIF |
 | CLI | Python (`python -m agents.cli`, planned) |
 | Copilot Skills | Markdown workflow definitions (`.github/skills/`, planned) |
-| Testing | Vitest (TypeScript), pytest (Python) |
+| Testing | Vitest (TypeScript), pytest with markers (Python) — unit and integration separated |
 | Linting | ESLint (TypeScript), ruff (Python) |
 | CI/CD | GitHub Actions |
 
@@ -61,7 +61,7 @@ The LLM gateway is a first-class component in the application layer. It resolves
 │  contracts/     Pydantic request/response models         │
 │  llm/           LLMProvider protocol + implementations   │
 │  services/      AgentService, PipelineService, Digest    │
-│  config.py      AppConfig (FINANCE_OS_* env vars)        │
+│  config.py      AppConfig (config file + FINANCE_OS_* env vars)  │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -120,15 +120,14 @@ The shared core that all interfaces wrap. Implemented as:
 - **Contracts** (`contracts/agents.py`) — Pydantic request/response models for every agent operation (9 request/response pairs covering all 7 agents, pipeline, and digest). Models match actual agent capabilities.
 - **LLM Gateway** (`llm/`) — pluggable inference via `LLMProvider` protocol:
   - `LiteLLMProvider` — multi-provider routing (OpenAI, Anthropic, ollama, etc.)
-  - `MockProvider` — deterministic responses for testing
   - `SkipProvider` — MCP path where host LLM reasons
   - `LLMGateway` — routes requests, `synthesize()` for agent output → narrative
-  - `create_gateway()` — factory for creating configured gateways
+  - `create_gateway()` — factory for creating configured gateways ("skip", "litellm")
 - **Services** (`services/`) — typed wrappers over agents:
-  - `AgentService` — maps Pydantic contracts to agent `run()` calls with normalization
+  - `AgentService` — maps Pydantic request/response contracts to agent `run()` calls. Validates inputs, normalizes metadata, and caches agent instances.
   - `PipelineService` — wraps orchestrator with task_id support and memo generation
   - `DigestService` — wraps research pipeline with typed I/O
-- **Config** (`config.py`) — `AppConfig` via pydantic-settings, environment variables with `FINANCE_OS_` prefix
+- **Config** (`config.py`) — `AppConfig` via pydantic-settings. Loads from `~/.config/finance-os/config.json` (user settings) and `FINANCE_OS_*` environment variables (highest priority).
 
 CLI, Python MCP server, and future Web API are thin wrappers over this layer.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -8,17 +8,19 @@ finance-os has two MCP servers:
 
 2. **Python MCP server** (planned, `agents/src/mcp_server.py`) — agent tools that expose the Python agent framework to LLMs. Wraps the shared application layer. When a host LLM calls these tools, the LLM gateway is skipped (the host LLM does the reasoning).
 
+Both servers are configured as separate MCP servers in the client (Copilot, Claude Desktop, etc.).
+
 ## TypeScript Tool Catalog
 
-| Tool | Module | Purpose |
-|---|---|---|
-| `echo` | `echo.ts` | Test/placeholder tool |
-| `financial-data` | `financial-data.ts` | Stock quotes and fundamentals via Yahoo Finance |
-| `sec-filings` | `sec-filings.ts` | SEC EDGAR filing fetch, parse, section extraction |
-| `portfolio` | `portfolio.ts` | Portfolio diagnostics — exposures, drawdowns, HHI concentration |
-| `qif` | `qif.ts` | QIF personal finance data — transactions, accounts, categories |
+| Tool | Module | Purpose | Status |
+|---|---|---|---|
+| `echo` | `echo.ts` | Test/placeholder tool | ✅ |
+| `financial-data` | `financial-data.ts` | Stock quotes and fundamentals via Yahoo Finance | ✅ |
+| `sec-filings` | `sec-filings.ts` | SEC EDGAR filing fetch, parse, section extraction | ✅ |
+| `portfolio` | `portfolio.ts` | Portfolio diagnostics — exposures, drawdowns, HHI concentration | ✅ |
+| `qif` | `qif.ts` | QIF personal finance data — transactions, accounts, categories | ✅ |
 
-## Tool Details
+## TypeScript Tool Details
 
 ### financial-data
 
@@ -50,7 +52,27 @@ Queries personal financial data from Quicken Interchange Format files.
 - **Filters**: date range, account, category, limit
 - **Parser**: handles banking, investment, and split transactions
 
-## Adding a New Tool
+## Python Agent Tool Catalog (planned)
+
+The Python MCP server will expose agents via the application layer's typed contracts. Each tool maps to a Pydantic request/response pair in `agents/src/application/contracts/agents.py`.
+
+| Tool | Contract | Purpose | Status |
+|---|---|---|---|
+| `analyze-earnings` | `AnalyzeEarningsRequest/Response` | Sentiment, tone, guidance extraction from transcripts | Planned |
+| `classify-macro` | `ClassifyMacroRequest/Response` | Macro regime classification from FRED indicators | Planned |
+| `search-filings` | `SearchFilingsRequest/Response` | SEC EDGAR filing search and listing | Planned |
+| `generate-signals` | `GenerateSignalsRequest/Response` | Composite quant signal scoring | Planned |
+| `evaluate-thesis` | `EvaluateThesisRequest/Response` | Thesis assumption evaluation against observed data | Planned |
+| `assess-risk` | `AssessRiskRequest/Response` | VaR/CVaR, scenarios, stress tests | Planned |
+| `challenge-thesis` | `ChallengeThesisRequest/Response` | Adversarial counter-arguments, blind spots, conviction | Planned |
+| `run-pipeline` | `RunPipelineRequest/Response` | Multi-agent orchestrated pipeline with memo generation | Planned |
+| `run-digest` | `RunDigestRequest/Response` | Research digest with alerts and materiality scoring | Planned |
+
+### LLM Gateway behavior in MCP path
+
+When called via MCP, the host LLM does the reasoning — the LLM gateway is **skipped**. Agents return structured data and the host LLM synthesizes the narrative. This means the Python MCP tools are thin wrappers: validate input → invoke agent service → return structured response.
+
+## Adding a New TypeScript Tool
 
 1. Create `mcp-server/src/tools/<name>.ts`
 2. Export a `registerXxxTool(server: McpServer)` function
@@ -59,3 +81,10 @@ Queries personal financial data from Quicken Interchange Format files.
 5. Import and call from `src/index.ts`
 6. Add tests in `mcp-server/tests/<name>.test.ts`
 7. Return `{ content: [{ type: "text", text: result }] }` from the handler
+
+## Adding a New Python Agent Tool
+
+1. If the agent exists, add a contract pair in `agents/src/application/contracts/agents.py`
+2. Add a service method in `agents/src/application/services/agent_service.py`
+3. Register the tool in `agents/src/mcp_server.py` (when Python MCP server exists)
+4. Add tests in `agents/tests/test_services.py` and `agents/tests/test_mcp_server.py`

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts --passWithNoTests",
     "test:watch": "vitest",
     "lint": "eslint src/ tests/"
   },

--- a/mcp-server/vitest.integration.config.ts
+++ b/mcp-server/vitest.integration.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["tests/**/*.test.ts"],
-    exclude: ["tests/**/*.integration.test.ts"],
+    include: ["tests/**/*.integration.test.ts"],
   },
 });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build --workspace=mcp-server",
     "test": "npm run test --workspace=mcp-server",
     "lint": "npm run lint --workspace=mcp-server",
-    "preflight": "npm run build && npm test && npm run lint && (cd agents && ruff check src/ tests/ && python -m pytest || echo '⚠ Python preflight skipped (ruff/pytest not installed). CI will catch Python issues.')"
+    "preflight": "npm run build && npm test && npm run lint && bash -c 'cd agents && source .venv/bin/activate && ruff check src/ tests/ && python3 -m pytest -m \"not integration\"' || echo '⚠ Python preflight skipped (venv not set up). CI will catch Python issues.'"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

Application layer (`agents/src/application/`) — the shared core that CLI, Python MCP server, and future Web API all wrap.

### What is included

**Contracts** (`contracts/agents.py`)
- Pydantic request/response models for all 7 agents, pipeline, and digest
- Modeled around actual agent capabilities (not aspirational)

**LLM Gateway** (`llm/`)
- `LLMProvider` protocol + `LLMMessage`/`LLMResponse` types
- `LiteLLMProvider` — multi-provider routing (OpenAI, Anthropic, ollama)
- `SkipProvider` — MCP path where host LLM reasons (production)
- `LLMGateway` — routes requests, `synthesize()` for agent output to narrative
- `create_gateway()` factory ("skip", "litellm")

**Services** (`services/`)
- `AgentService` — maps typed contracts to agent run() calls with normalization
- `PipelineService` — wraps orchestrator with task_id support and memo generation
- `DigestService` — wraps research pipeline with typed I/O

**Config** (`config.py`)
- `AppConfig` via pydantic-settings — loads from `~/.config/finance-os/config.json` + `FINANCE_OS_*` env vars

### Orchestrator fix
- Added `task_id` to `AgentTask` and `AgentResult`
- Pipeline now keys by `task.id` instead of `agent_name`

### Test infrastructure
- MockProvider moved to `tests/support/` (not production code)
- Registered `integration` pytest marker; live FRED tests marked
- CI split into unit (every PR) and integration (main push only) jobs
- Removed tautology tests, rewrote mirror tests with property-based assertions
- Consolidated quant/rag into dev extras — `pip install -e ".[dev]"` installs everything

### Docs
- Updated README, architecture.md, agents.md, tools.md, copilot-instructions.md
- Enforced separate commits + squash merge workflow

### Tests
281 Python + 45 TypeScript = 326 total, all passing.

Closes #49