### PR TITLE
feat: Agent CLI — terminal entry points

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -275,6 +275,7 @@ finance-os/
 │   │   ├── core/                   # Agent base, orchestrator, memory
 │   │   ├── agents/                 # Domain-specific agents
 │   │   ├── application/            # Shared contracts, LLM gateway, services
+│   │   ├── cli/                    # CLI entry points (finance-os command)
 │   │   ├── tools/                  # Quant tools
 │   │   └── pipelines/             # Data ingestion pipelines
 │   └── tests/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ finance-os/
 │       ├── agents/      # Domain agents (filing, earnings, macro, risk, etc.)
 │       ├── core/        # BaseAgent, orchestrator, vector memory
 │       ├── application/ # Contracts, LLM gateway, services, config
+│       ├── cli/         # CLI entry points (finance-os command)
 │       └── pipelines/   # Research digest pipeline
 ├── prompts/             # Shared prompt library
 ├── docs/                # Architecture, agent, and tool documentation
@@ -74,6 +75,23 @@ Create `~/.config/finance-os/config.json`:
 ```
 
 Environment variables (`FINANCE_OS_*`) override config file values. See [docs/architecture.md](docs/architecture.md) for details.
+
+### Agent CLI
+
+After installing the agents package (`pip install -e ".[dev]"`), the `finance-os` command is available:
+
+```bash
+finance-os list                                      # List available agents
+finance-os config                                    # Show current config
+finance-os run macro-regime                          # Run a single agent
+finance-os run filing-analyst --ticker AAPL           # With options
+finance-os pipeline --ticker AAPL                     # Multi-agent research pipeline
+finance-os digest --tickers AAPL,MSFT,GOOG            # Research digest
+finance-os --output json run macro-regime             # JSON output
+finance-os run adversarial --prompt "Bull case" --synthesize  # LLM synthesis
+```
+
+Use `--synthesize` to pass agent output through the LLM gateway (requires `llm_provider: "litellm"` in config). Use `--output json` for structured output.
 
 ### Preflight (run before every push)
 

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -24,6 +24,9 @@ dev = [
     "chromadb>=1.0.0",
 ]
 
+[project.scripts]
+finance-os = "src.cli.main:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/agents/src/cli/__main__.py
+++ b/agents/src/cli/__main__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Entry point for `python -m src.cli` or `finance-os` console script."""
+
+from src.cli.main import main
+
+if __name__ == "__main__":
+    main()

--- a/agents/src/cli/commands.py
+++ b/agents/src/cli/commands.py
@@ -1,0 +1,285 @@
+"""CLI command implementations."""
+
+import argparse
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from src.application.config import AppConfig
+from src.application.contracts.agents import (
+    AnalyzeEarningsRequest,
+    AssessRiskRequest,
+    ChallengeThesisRequest,
+    ClassifyMacroRequest,
+    EvaluateThesisRequest,
+    GenerateSignalsRequest,
+    RunDigestRequest,
+    RunPipelineRequest,
+    SearchFilingsRequest,
+    TaskDefinition,
+)
+from src.application.llm.gateway import LLMGateway, create_gateway
+from src.application.services.agent_service import AgentService
+from src.application.services.digest_service import DigestService
+from src.application.services.pipeline_service import PipelineService
+from src.core.agent import BaseAgent
+
+# Agent name aliases: accept hyphens or underscores
+AGENT_ALIASES: dict[str, str] = {
+    "macro-regime": "macro_regime",
+    "filing-analyst": "filing_analyst",
+    "earnings-interpreter": "earnings_interpreter",
+    "quant-signal": "quant_signal",
+    "thesis-guardian": "thesis_guardian",
+    "risk-analyst": "risk_analyst",
+}
+
+AGENT_INFO: list[dict[str, str]] = [
+    {"name": "macro_regime", "description": "Classifies macro regime from FRED indicators"},
+    {"name": "filing_analyst", "description": "Searches and analyzes SEC filings (10-K/10-Q)"},
+    {"name": "earnings_interpreter", "description": "Analyzes earnings call transcripts"},
+    {"name": "quant_signal", "description": "Generates composite quantitative signals"},
+    {"name": "thesis_guardian", "description": "Monitors investment theses against data"},
+    {"name": "risk_analyst", "description": "Portfolio risk analysis (VaR, stress tests)"},
+    {"name": "adversarial", "description": "Challenges investment theses adversarially"},
+]
+
+
+def _normalize_agent_name(name: str) -> str:
+    """Normalize agent name: accept hyphens or underscores."""
+    return AGENT_ALIASES.get(name, name.replace("-", "_"))
+
+
+def _load_config() -> AppConfig:
+    """Load application config."""
+    return AppConfig()
+
+
+def _create_gateway(config: AppConfig, model_override: str = "") -> LLMGateway:
+    """Create LLM gateway from config with optional model override."""
+    model = model_override or config.llm_default_model
+    return create_gateway(
+        provider_type=config.llm_provider,
+        default_model=model,
+    )
+
+
+def _json_serial(obj: object) -> Any:
+    """JSON serializer for objects not serializable by default."""
+    if isinstance(obj, Decimal):
+        return str(obj)
+    msg = f"Type {type(obj)} not serializable"
+    raise TypeError(msg)
+
+
+def _output(data: dict[str, Any], args: argparse.Namespace) -> None:
+    """Print output in the requested format."""
+    if args.output == "json":
+        print(json.dumps(data, default=_json_serial, indent=2))
+    else:
+        content = data.get("content", "")
+        if content:
+            print(content)
+        # Print key metadata fields
+        for key, value in data.items():
+            if key == "content":
+                continue
+            if value and value != 0:
+                print(f"  {key}: {value}")
+
+
+async def run_agent(args: argparse.Namespace) -> None:
+    """Run a single agent."""
+    agent_name = _normalize_agent_name(args.agent)
+    config = _load_config()
+    service = AgentService()
+
+    result: dict[str, Any]
+    match agent_name:
+        case "macro_regime":
+            api_key = args.api_key or config.fred_api_key
+            request = ClassifyMacroRequest(api_key=api_key)
+            response = await service.classify_macro(request)
+            result = response.model_dump(mode="json")
+
+        case "filing_analyst":
+            request = SearchFilingsRequest(ticker=args.ticker)
+            response = await service.search_filings(request)
+            result = response.model_dump(mode="json")
+
+        case "earnings_interpreter":
+            transcript = args.prompt or "No transcript provided"
+            request = AnalyzeEarningsRequest(
+                transcript=transcript, ticker=args.ticker
+            )
+            response = await service.analyze_earnings(request)
+            result = response.model_dump(mode="json")
+
+        case "quant_signal":
+            request = GenerateSignalsRequest()
+            response = await service.generate_signals(request)
+            result = response.model_dump(mode="json")
+
+        case "thesis_guardian":
+            request = EvaluateThesisRequest(theses=[])
+            response = await service.evaluate_thesis(request)
+            result = response.model_dump(mode="json")
+
+        case "risk_analyst":
+            request = AssessRiskRequest()
+            response = await service.assess_risk(request)
+            result = response.model_dump(mode="json")
+
+        case "adversarial":
+            prompt = args.prompt or "Challenge these claims"
+            request = ChallengeThesisRequest(prompt=prompt)
+            response = await service.challenge_thesis(request)
+            result = response.model_dump(mode="json")
+
+        case _:
+            known = ", ".join(info["name"] for info in AGENT_INFO)
+            msg = f"Unknown agent: {args.agent}. Available: {known}"
+            raise ValueError(msg)
+
+    if args.synthesize and config.llm_provider != "skip":
+        gateway = _create_gateway(config, args.model)
+        synthesis = await gateway.synthesize(
+            system_prompt="You are a financial analyst assistant.",
+            agent_output=result.get("content", ""),
+        )
+        result["synthesis"] = synthesis.content
+
+    _output(result, args)
+
+
+def _get_all_agents() -> list[BaseAgent]:
+    """Instantiate all available agents."""
+    from src.agents.adversarial import AdversarialAgent
+    from src.agents.earnings_interpreter import EarningsInterpreterAgent
+    from src.agents.filing_analyst import FilingAnalystAgent
+    from src.agents.macro_regime import MacroRegimeAgent
+    from src.agents.quant_signal import QuantSignalAgent
+    from src.agents.risk_agent import RiskAgent
+    from src.agents.thesis_guardian import ThesisGuardianAgent
+
+    return [
+        MacroRegimeAgent(),
+        FilingAnalystAgent(),
+        EarningsInterpreterAgent(),
+        QuantSignalAgent(),
+        ThesisGuardianAgent(),
+        RiskAgent(),
+        AdversarialAgent(),
+    ]
+
+
+# Default research pipeline: agents and their prompts for a given ticker
+DEFAULT_PIPELINE_AGENTS = [
+    ("macro_regime", "Classify current macro regime"),
+    ("filing_analyst", "Search recent filings for {ticker}"),
+    ("quant_signal", "Generate signals"),
+    ("thesis_guardian", "Evaluate theses"),
+    ("risk_analyst", "Assess portfolio risk"),
+    ("adversarial", "Challenge the investment thesis for {ticker}"),
+]
+
+
+async def run_pipeline(args: argparse.Namespace) -> None:
+    """Run multi-agent research pipeline."""
+    config = _load_config()
+    service = PipelineService()
+
+    for agent in _get_all_agents():
+        service.register_agent(agent)
+
+    # Build task list
+    if args.agents:
+        selected = [_normalize_agent_name(a.strip()) for a in args.agents.split(",")]
+        pipeline_agents = [
+            (name, prompt) for name, prompt in DEFAULT_PIPELINE_AGENTS
+            if name in selected
+        ]
+    else:
+        pipeline_agents = DEFAULT_PIPELINE_AGENTS
+
+    tasks = [
+        TaskDefinition(
+            agent_name=name,
+            prompt=prompt.format(ticker=args.ticker),
+            task_id=f"{name}-{args.ticker}",
+        )
+        for name, prompt in pipeline_agents
+    ]
+
+    request = RunPipelineRequest(tasks=tasks)
+    date = args.date or datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    response = await service.run_pipeline(request, ticker=args.ticker, date=date)
+
+    result = response.model_dump(mode="json")
+
+    if args.synthesize and config.llm_provider != "skip":
+        gateway = _create_gateway(config, args.model)
+        memo_content = ""
+        if response.memo:
+            memo_content = json.dumps(response.memo, default=_json_serial)
+        synthesis = await gateway.synthesize(
+            system_prompt="You are a financial analyst. Synthesize this research memo.",
+            agent_output=memo_content,
+        )
+        result["synthesis"] = synthesis.content
+
+    _output(result, args)
+
+
+async def run_digest(args: argparse.Namespace) -> None:
+    """Run research digest."""
+    tickers = [t.strip().upper() for t in args.tickers.split(",")]
+
+    request = RunDigestRequest(
+        tickers=tickers,
+        lookback_days=args.lookback_days,
+        alert_threshold=Decimal(str(args.alert_threshold)),
+    )
+    service = DigestService()
+    response = await service.run_digest(request)
+
+    result = response.model_dump(mode="json")
+    _output(result, args)
+
+
+def list_agents(args: argparse.Namespace) -> None:
+    """List available agents."""
+    if args.output == "json":
+        print(json.dumps(AGENT_INFO, indent=2))
+    else:
+        print("Available agents:\n")
+        for info in AGENT_INFO:
+            aliases = [k for k, v in AGENT_ALIASES.items() if v == info["name"]]
+            alias_str = f" (alias: {aliases[0]})" if aliases else ""
+            print(f"  {info['name']}{alias_str}")
+            print(f"    {info['description']}\n")
+
+
+def show_config(args: argparse.Namespace) -> None:
+    """Show current configuration (masks sensitive values)."""
+    config = _load_config()
+    data = {
+        "llm_provider": config.llm_provider,
+        "llm_default_model": config.llm_default_model,
+        "llm_temperature": config.llm_temperature,
+        "fred_api_key": _mask(config.fred_api_key),
+    }
+    if args.output == "json":
+        print(json.dumps(data, indent=2))
+    else:
+        print("Finance OS Configuration:\n")
+        for key, value in data.items():
+            print(f"  {key}: {value}")
+
+
+def _mask(value: str) -> str:
+    """Mask a sensitive value, showing only last 4 chars."""
+    if len(value) <= 4:
+        return "****" if value else "(not set)"
+    return "****" + value[-4:]

--- a/agents/src/cli/main.py
+++ b/agents/src/cli/main.py
@@ -1,0 +1,100 @@
+"""CLI argument parsing and dispatch."""
+
+import argparse
+import asyncio
+import sys
+
+from src.cli.commands import list_agents, run_agent, run_digest, run_pipeline, show_config
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="finance-os",
+        description="Finance OS — personal investment intelligence CLI",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # --- run <agent> ---
+    run_parser = subparsers.add_parser("run", help="Run a single agent")
+    run_parser.add_argument("agent", help="Agent name (e.g. macro-regime, filing-analyst)")
+    run_parser.add_argument("--ticker", default="", help="Stock ticker symbol")
+    run_parser.add_argument("--prompt", default="", help="Free-form prompt text")
+    run_parser.add_argument("--api-key", default="", help="Override FRED API key")
+    run_parser.add_argument("--model", default="", help="Override LLM model")
+    run_parser.add_argument(
+        "--synthesize",
+        action="store_true",
+        help="Synthesize agent output via LLM gateway",
+    )
+
+    # --- pipeline ---
+    pipeline_parser = subparsers.add_parser(
+        "pipeline", help="Run multi-agent research pipeline"
+    )
+    pipeline_parser.add_argument("--ticker", required=True, help="Stock ticker symbol")
+    pipeline_parser.add_argument("--date", default="", help="Analysis date (YYYY-MM-DD)")
+    pipeline_parser.add_argument(
+        "--agents", default="", help="Comma-separated agent names (default: all)"
+    )
+    pipeline_parser.add_argument("--model", default="", help="Override LLM model")
+    pipeline_parser.add_argument(
+        "--synthesize",
+        action="store_true",
+        help="Synthesize memo via LLM gateway",
+    )
+
+    # --- digest ---
+    digest_parser = subparsers.add_parser("digest", help="Run research digest")
+    digest_parser.add_argument(
+        "--tickers", required=True, help="Comma-separated ticker list"
+    )
+    digest_parser.add_argument(
+        "--lookback-days", type=int, default=7, help="Lookback period in days"
+    )
+    digest_parser.add_argument(
+        "--alert-threshold", type=float, default=0.5, help="Materiality threshold"
+    )
+    digest_parser.add_argument("--model", default="", help="Override LLM model")
+
+    # --- list ---
+    subparsers.add_parser("list", help="List available agents")
+
+    # --- config ---
+    subparsers.add_parser("config", help="Show current configuration")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        match args.command:
+            case "run":
+                asyncio.run(run_agent(args))
+            case "pipeline":
+                asyncio.run(run_pipeline(args))
+            case "digest":
+                asyncio.run(run_digest(args))
+            case "list":
+                list_agents(args)
+            case "config":
+                show_config(args)
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except Exception as e:  # noqa: BLE001
+        if args.output == "json":
+            import json
+            print(json.dumps({"error": str(e)}))
+        else:
+            print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/agents/tests/test_cli.py
+++ b/agents/tests/test_cli.py
@@ -1,0 +1,331 @@
+"""Tests for CLI argument parsing and command dispatch."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.cli.commands import (
+    AGENT_INFO,
+    _mask,
+    _normalize_agent_name,
+)
+from src.cli.main import build_parser, main
+
+
+class TestArgParsing:
+    """Verify argument parsing for all subcommands."""
+
+    def test_run_basic(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "macro-regime"])
+        assert args.command == "run"
+        assert args.agent == "macro-regime"
+        assert args.ticker == ""
+        assert args.synthesize is False
+
+    def test_run_with_options(self):
+        parser = build_parser()
+        args = parser.parse_args([
+            "run", "filing-analyst",
+            "--ticker", "AAPL",
+            "--model", "gpt-4o",
+            "--synthesize",
+        ])
+        assert args.agent == "filing-analyst"
+        assert args.ticker == "AAPL"
+        assert args.model == "gpt-4o"
+        assert args.synthesize is True
+
+    def test_pipeline_requires_ticker(self):
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["pipeline"])
+
+    def test_pipeline_with_options(self):
+        parser = build_parser()
+        args = parser.parse_args([
+            "pipeline", "--ticker", "MSFT",
+            "--date", "2026-01-15",
+            "--agents", "macro-regime,risk-analyst",
+        ])
+        assert args.ticker == "MSFT"
+        assert args.date == "2026-01-15"
+        assert args.agents == "macro-regime,risk-analyst"
+
+    def test_digest_requires_tickers(self):
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["digest"])
+
+    def test_digest_with_options(self):
+        parser = build_parser()
+        args = parser.parse_args([
+            "digest", "--tickers", "AAPL,GOOG",
+            "--lookback-days", "14",
+            "--alert-threshold", "0.7",
+        ])
+        assert args.tickers == "AAPL,GOOG"
+        assert args.lookback_days == 14
+        assert args.alert_threshold == 0.7
+
+    def test_list_command(self):
+        parser = build_parser()
+        args = parser.parse_args(["list"])
+        assert args.command == "list"
+
+    def test_config_command(self):
+        parser = build_parser()
+        args = parser.parse_args(["config"])
+        assert args.command == "config"
+
+    def test_output_json(self):
+        parser = build_parser()
+        args = parser.parse_args(["--output", "json", "list"])
+        assert args.output == "json"
+
+    def test_no_command_fails(self):
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args([])
+
+
+class TestAgentNameNormalization:
+    """Agent names accept hyphens or underscores."""
+
+    def test_hyphen_to_underscore(self):
+        assert _normalize_agent_name("macro-regime") == "macro_regime"
+        assert _normalize_agent_name("filing-analyst") == "filing_analyst"
+
+    def test_underscore_passthrough(self):
+        assert _normalize_agent_name("macro_regime") == "macro_regime"
+        assert _normalize_agent_name("adversarial") == "adversarial"
+
+    def test_unknown_name_normalizes(self):
+        assert _normalize_agent_name("custom-agent") == "custom_agent"
+
+
+class TestMasking:
+    """Sensitive values are masked in config output."""
+
+    def test_masks_long_value(self):
+        assert _mask("abcdefgh1234") == "****1234"
+
+    def test_masks_short_value(self):
+        assert _mask("ab") == "****"
+
+    def test_empty_value(self):
+        assert _mask("") == "(not set)"
+
+
+class TestListCommand:
+    """List command outputs agent info."""
+
+    def test_list_text(self, capsys):
+        parser = build_parser()
+        args = parser.parse_args(["list"])
+        from src.cli.commands import list_agents
+        list_agents(args)
+        captured = capsys.readouterr()
+        for info in AGENT_INFO:
+            assert info["name"] in captured.out
+
+    def test_list_json(self, capsys):
+        parser = build_parser()
+        args = parser.parse_args(["--output", "json", "list"])
+        from src.cli.commands import list_agents
+        list_agents(args)
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data) == len(AGENT_INFO)
+        assert all("name" in entry for entry in data)
+
+
+class TestConfigCommand:
+    """Config command outputs masked configuration."""
+
+    def test_config_masks_api_key(self, capsys, monkeypatch):
+        from pathlib import Path
+
+        monkeypatch.setenv("FINANCE_OS_FRED_API_KEY", "supersecretkey123")
+        monkeypatch.setattr("src.application.config.CONFIG_FILE", Path("/nonexistent"))
+
+        parser = build_parser()
+        args = parser.parse_args(["config"])
+        from src.cli.commands import show_config
+        show_config(args)
+        captured = capsys.readouterr()
+        assert "supersecretkey123" not in captured.out
+        assert "****" in captured.out
+
+    def test_config_json(self, capsys, monkeypatch):
+        monkeypatch.setenv("FINANCE_OS_FRED_API_KEY", "mykey12345")
+        from pathlib import Path
+        monkeypatch.setattr("src.application.config.CONFIG_FILE", Path("/nonexistent"))
+
+        parser = build_parser()
+        args = parser.parse_args(["--output", "json", "config"])
+        from src.cli.commands import show_config
+        show_config(args)
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["fred_api_key"] == "****2345"
+        assert "mykey12345" not in json.dumps(data)
+
+
+class TestRunAgent:
+    """Run command dispatches to correct agent."""
+
+    @pytest.mark.asyncio
+    async def test_run_unknown_agent(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "nonexistent"])
+        from src.cli.commands import run_agent
+        with pytest.raises(ValueError, match="Unknown agent"):
+            await run_agent(args)
+
+    @pytest.mark.asyncio
+    async def test_run_macro_regime(self, capsys, monkeypatch):
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("src.application.config.CONFIG_FILE", Path("/nonexistent"))
+
+        parser = build_parser()
+        args = parser.parse_args(["--output", "json", "run", "macro-regime"])
+
+        mock_result = MagicMock()
+        mock_result.model_dump.return_value = {
+            "content": "Macro regime: expansion",
+            "regime": "expansion",
+            "indicators_fetched": 3,
+            "indicators_with_data": 3,
+        }
+        mock_method = AsyncMock(return_value=mock_result)
+        with patch(
+            "src.cli.commands.AgentService.classify_macro", mock_method
+        ):
+            from src.cli.commands import run_agent
+            await run_agent(args)
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["regime"] == "expansion"
+
+    @pytest.mark.asyncio
+    async def test_run_adversarial_with_prompt(self, capsys, monkeypatch):
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("src.application.config.CONFIG_FILE", Path("/nonexistent"))
+
+        parser = build_parser()
+        args = parser.parse_args([
+            "--output", "json",
+            "run", "adversarial",
+            "--prompt", "AAPL will beat earnings",
+        ])
+
+        mock_result = MagicMock()
+        mock_result.model_dump.return_value = {
+            "content": "Counter: supply chain risks",
+            "conviction_score": "MODERATE",
+            "counter_count": 2,
+            "blind_spot_count": 1,
+        }
+        mock_method = AsyncMock(return_value=mock_result)
+        with patch(
+            "src.cli.commands.AgentService.challenge_thesis", mock_method
+        ):
+            from src.cli.commands import run_agent
+            await run_agent(args)
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["conviction_score"] == "MODERATE"
+
+
+class TestPipeline:
+    """Pipeline command runs multi-agent orchestration."""
+
+    @pytest.mark.asyncio
+    async def test_pipeline_dispatches(self, capsys, monkeypatch):
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("src.application.config.CONFIG_FILE", Path("/nonexistent"))
+
+        parser = build_parser()
+        args = parser.parse_args([
+            "--output", "json",
+            "pipeline", "--ticker", "AAPL",
+        ])
+
+        mock_result = MagicMock()
+        mock_result.model_dump.return_value = {
+            "results": [],
+            "total_duration_ms": 100,
+            "successful": 0,
+            "failed": 0,
+            "memo": None,
+        }
+        mock_result.memo = None
+        mock_method = AsyncMock(return_value=mock_result)
+        with patch(
+            "src.cli.commands.PipelineService.run_pipeline", mock_method
+        ):
+            from src.cli.commands import run_pipeline
+            await run_pipeline(args)
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "total_duration_ms" in data
+
+
+class TestDigest:
+    """Digest command runs research digest."""
+
+    @pytest.mark.asyncio
+    async def test_digest_dispatches(self, capsys, monkeypatch):
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("src.application.config.CONFIG_FILE", Path("/nonexistent"))
+
+        parser = build_parser()
+        args = parser.parse_args([
+            "--output", "json",
+            "digest", "--tickers", "AAPL,GOOG",
+        ])
+
+        mock_result = MagicMock()
+        mock_result.model_dump.return_value = {
+            "ticker_count": 2,
+            "entry_count": 0,
+            "alert_count": 0,
+            "material_count": 0,
+            "content": "Digest for AAPL, GOOG",
+        }
+        mock_method = AsyncMock(return_value=mock_result)
+        with patch(
+            "src.cli.commands.DigestService.run_digest", mock_method
+        ):
+            from src.cli.commands import run_digest
+            await run_digest(args)
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["ticker_count"] == 2
+
+
+class TestMainEntryPoint:
+    """Main function dispatches correctly."""
+
+    def test_main_list(self, capsys):
+        main(["list"])
+        captured = capsys.readouterr()
+        assert "macro_regime" in captured.out
+
+    def test_main_error_text(self, capsys):
+        with pytest.raises(SystemExit):
+            main(["run", "nonexistent-xyz"])
+
+    def test_main_error_json(self, capsys):
+        with pytest.raises(SystemExit):
+            main(["--output", "json", "run", "nonexistent-xyz"])

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@
 | Vector DB | ChromaDB (local) |
 | LLM Gateway | Pluggable — OpenAI, Anthropic, ollama, or host LLM via MCP |
 | Data Sources | SEC EDGAR (free), FRED (free API key), Yahoo Finance, QIF |
-| CLI | Python (`python -m agents.cli`, planned) |
+| CLI | Python (`finance-os` console script) |
 | Copilot Skills | Markdown workflow definitions (`.github/skills/`, planned) |
 | Testing | Vitest (TypeScript), pytest with markers (Python) — unit and integration separated |
 | Linting | ESLint (TypeScript), ruff (Python) |
@@ -67,21 +67,62 @@ The LLM gateway is a first-class component in the application layer. It resolves
 
 ### Two inference paths
 
-| Path | How LLM reasoning works |
-|---|---|
-| **MCP path** (Copilot, Claude Desktop) | Host LLM calls MCP tools → agents return structured data + prompts → host LLM synthesizes. Gateway is **skipped**. |
-| **Direct path** (CLI, future Web API) | User invokes agent → application layer calls LLM gateway → agents return data → gateway calls LLM for synthesis. |
+```
+                         ┌─────────────────────────────────────────────┐
+                         │           MCP Path (Copilot / Claude)       │
+                         │                                             │
+  User ──→ Copilot ──→ Host LLM ──→ MCP Server ──→ Agent Service     │
+                 ↑         │              ↑              │             │
+                 │         │              │              ↓             │
+                 │         │         SkipProvider    Agents run()      │
+                 │         │         (no LLM call)   (data + prompts)  │
+                 │         │                             │             │
+                 │         ←── synthesizes from ─────────┘             │
+                 │              agent output                           │
+                 └─────────── returns to user                         │
+                         └─────────────────────────────────────────────┘
 
-### Why this matters
+                         ┌─────────────────────────────────────────────┐
+                         │           CLI Path (Direct)                 │
+                         │                                             │
+  User ──→ finance-os ──→ AppConfig ──→ Agent Service                 │
+              CLI              │              │                        │
+               │               │              ↓                        │
+               │               │         Agents run()                  │
+               │               │         (data + prompts)              │
+               │               │              │                        │
+               │               │              ↓                        │
+               │      --synthesize?     structured output              │
+               │           │                  │                        │
+               │      ┌────┴────┐             │                        │
+               │      │   YES   │       ┌─────┴─────┐                 │
+               │      ↓         │       │    NO     │                  │
+               │  LLM Gateway   │       ↓           │                 │
+               │      │         │  print as-is      │                 │
+               │      ↓         │  (text / json)    │                 │
+               │  LiteLLMProvider       │           │                  │
+               │      │         │       │           │                  │
+               │      ↓         │       │           │                  │
+               │  OpenAI /      │       │           │                  │
+               │  Anthropic /   │       │           │                  │
+               │  Ollama        │       │           │                  │
+               │      │         │       │           │                  │
+               │      ↓         │       │           │                  │
+               │  synthesized   │       │           │                  │
+               │  narrative     │       │           │                  │
+               │      └─────────┴───────┴───→ User  │                 │
+               │                                                       │
+               └───────────────────────────────────────────────────────┘
+```
 
-The agents currently build prompts and structure data but **never call an LLM**. This is correct for the MCP path where the host LLM reasons. But the CLI and web paths need their own LLM inference — the gateway provides it without duplicating agent logic.
+**Key difference**: In the MCP path, the host LLM (Copilot/Claude) does all reasoning — agents just return data. In the CLI path, agents return data by default; the LLM gateway is only invoked when `--synthesize` is explicitly requested.
 
-### Provider flexibility
-
-The gateway is pluggable:
-- **Cloud**: OpenAI, Anthropic, Google (via litellm or native SDKs)
-- **Local**: ollama, llama.cpp
-- **Skip**: MCP consumers can bypass the gateway entirely
+| Path | Who reasons? | Gateway | LLM cost |
+|---|---|---|---|
+| **MCP** (Copilot, Claude Desktop) | Host LLM | `SkipProvider` (no-op) | Included in host |
+| **CLI** (no `--synthesize`) | Nobody — raw output | Not called | Zero |
+| **CLI** (`--synthesize`) | LLM via gateway | `LiteLLMProvider` | Pay-per-call |
+| **Web API** (future) | LLM via gateway | `LiteLLMProvider` | Pay-per-call |
 
 ## Data Flow
 
@@ -170,6 +211,6 @@ Shared prompt templates organized by strategy:
 | Component | Issue | Status |
 |---|---|---|
 | Application layer (contracts, LLM gateway, services, config) | #49 | ✅ Complete |
-| Agent CLI | #50 | Next |
+| Agent CLI | #50 | ✅ Complete |
 | Python MCP server | #51 | Next |
 | Copilot Skills | #53 | Blocked on #50, #51 |


### PR DESCRIPTION
## Summary

Adds the `finance-os` console script with 5 subcommands for running agents, pipelines, and digests from the terminal. First user-facing UX.

### Commands

| Command | Description |
|---|---|
| `finance-os run <agent>` | Run a single agent |
| `finance-os pipeline --ticker <T>` | Multi-agent research pipeline |
| `finance-os digest --tickers <LIST>` | Research digest |
| `finance-os list` | List available agents |
| `finance-os config` | Show current configuration |

### Features
- Agent name aliases (hyphens and underscores both accepted)
- `--output json` for structured output
- `--synthesize` for optional LLM synthesis (provider-aware, off by default)
- Config-driven: honors AppConfig defaults, supports CLI overrides
- 28 new unit tests

### Files
- `agents/src/cli/` — CLI package (main, commands)
- `agents/tests/test_cli.py` — 28 tests
- `agents/pyproject.toml` — console script entry point
- `README.md` — CLI usage section
- `.github/copilot-instructions.md` — repo structure updated

Closes #50