### PR TITLE
feat: switch default model to gpt-4.1-mini with configurable SKU

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,7 +62,7 @@ Research Output (memos, alerts, signals)
 |---|---|
 | MCP Server (data tools) | TypeScript, Node.js, `@modelcontextprotocol/sdk` |
 | MCP Server (agents) | Python, `mcp` SDK |
-| Application Layer | Python, Pydantic 2.11+, pydantic-settings, litellm |
+| Application Layer | Python, Pydantic 2.11+, pydantic-settings, azure-identity |
 | Agents | Python 3.12+, NumPy, pandas, scipy |
 | Vector DB | ChromaDB (local) |
 | LLM Gateway | Pluggable — OpenAI, Anthropic, ollama, or host LLM via MCP |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Environment variables (`FINANCE_OS_*`) override config file values — use doubl
 |-------|--------|-------------|
 | `llm_provider` | `"skip"` (default), `"azure_openai"` | `skip` returns raw agent data without LLM synthesis — ideal for the MCP path where Copilot/Claude reasons over the output. `azure_openai` enables LLM synthesis via Azure OpenAI with Entra ID (OAuth2/OIDC) authentication — no API keys required. |
 | `azure.endpoint` | URL string | Azure OpenAI resource endpoint (e.g. `https://my-instance.openai.azure.com`). Required when provider is `"azure_openai"`. |
-| `azure.deployment` | Deployment name | Azure OpenAI model deployment name (e.g. `gpt-4o-mini`). This is the deployment you created in Azure AI Studio. Required when provider is `"azure_openai"`. |
+| `azure.deployment` | Deployment name | Azure OpenAI model deployment name (e.g. `gpt-4.1-mini`). This is the deployment you created in Azure AI Studio. Required when provider is `"azure_openai"`. |
 | `azure.api_version` | API version string | Azure OpenAI API version. Default `"2024-10-21"`. |
 | `llm_temperature` | `0.0`–`2.0` | Sampling temperature for LLM calls. Default `0.0` (deterministic). |
 | `fred_api_key` | API key string | [FRED API](https://fred.stlouisfed.org/docs/api/api_key.html) key for the macro-regime agent. Free to obtain. |

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -64,9 +64,9 @@ The defaults work for everything else, but you can customize:
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `openAiAccountName` | *(required)* | Globally unique name for the Azure OpenAI resource |
-| `modelName` | `gpt-4o-mini` | OpenAI model to deploy |
+| `modelName` | `gpt-4.1-mini` | OpenAI model to deploy |
 | `modelVersion` | `2024-11-20` | Model version |
-| `deploymentName` | `gpt-4o-mini` | Deployment name (becomes `azure.deployment` in config) |
+| `deploymentName` | `gpt-4.1-mini` | Deployment name (becomes `azure.deployment` in config) |
 | `deploymentCapacity` | `10` | Capacity in thousands of tokens per minute |
 | `principalId` | *(required)* | Your Entra object ID |
 | `principalType` | `User` | `User`, `ServicePrincipal`, or `Group` |
@@ -86,7 +86,7 @@ Expected output:
 
 ```json
 {
-  "deploymentName": { "value": "gpt-4o-mini" },
+  "deploymentName": { "value": "gpt-4.1-mini" },
   "endpoint": { "value": "https://finance-os-openai.openai.azure.com/" }
 }
 ```
@@ -102,7 +102,7 @@ Update `~/.config/finance-os/config.json`:
   "llm_provider": "azure_openai",
   "azure": {
     "endpoint": "https://finance-os-openai.openai.azure.com/",
-    "deployment": "gpt-4o-mini",
+    "deployment": "gpt-4.1-mini",
     "api_version": "2024-10-21"
   }
 }
@@ -113,7 +113,7 @@ Or use environment variables:
 ```bash
 export FINANCE_OS_LLM_PROVIDER=azure_openai
 export FINANCE_OS_AZURE__ENDPOINT=https://finance-os-openai.openai.azure.com/
-export FINANCE_OS_AZURE__DEPLOYMENT=gpt-4o
+export FINANCE_OS_AZURE__DEPLOYMENT=gpt-4.1-mini
 ```
 
 ## Step 7 — Verify it works

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -7,7 +7,7 @@ Bicep templates for provisioning Azure resources used by finance-os.
 | Resource | Purpose |
 |----------|---------|
 | Azure OpenAI (Cognitive Services) | LLM inference with Entra-only auth (API keys disabled) |
-| Model deployment (e.g. gpt-4o-mini) | The deployment your config points to |
+| Model deployment (e.g. gpt-4.1-mini) | The deployment your config points to |
 | RBAC role assignment | `Cognitive Services OpenAI User` for your principal |
 
 ## Prerequisites

--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -2,7 +2,7 @@
 //
 // Deploys:
 //   1. Azure OpenAI (Cognitive Services) with Entra-only auth (API keys disabled)
-//   2. Model deployment (e.g. gpt-4o-mini)
+//   2. Model deployment (e.g. gpt-4.1-mini)
 //   3. RBAC role assignment for the specified principal
 //
 // Usage:
@@ -25,17 +25,20 @@ param openAiAccountName string
 @allowed(['S0'])
 param openAiSku string = 'S0'
 
-@description('Model to deploy (e.g. gpt-4o, gpt-4o-mini).')
-param modelName string = 'gpt-4o-mini'
+@description('Model to deploy (e.g. gpt-4.1-mini, gpt-4.1-mini).')
+param modelName string = 'gpt-4.1-mini'
 
 @description('Model version to deploy.')
-param modelVersion string = '2024-07-18'
+param modelVersion string = '2025-04-14'
 
 @description('Deployment name — this is the value for azure.deployment in config.json.')
-param deploymentName string = 'gpt-4o-mini'
+param deploymentName string = 'gpt-4.1-mini'
 
 @description('Deployment capacity in thousands of tokens per minute.')
 param deploymentCapacity int = 10
+
+@description('Deployment SKU name (e.g. Standard, GlobalStandard). Newer models require GlobalStandard.')
+param deploymentSkuName string = 'Standard'
 
 @description('Object ID of the Entra principal (user or service principal) to grant access.')
 param principalId string
@@ -56,6 +59,7 @@ module openAi 'modules/cognitive-services.bicep' = {
     modelVersion: modelVersion
     deploymentName: deploymentName
     deploymentCapacity: deploymentCapacity
+    deploymentSkuName: deploymentSkuName
   }
 }
 

--- a/infrastructure/modules/cognitive-services.bicep
+++ b/infrastructure/modules/cognitive-services.bicep
@@ -24,6 +24,9 @@ param deploymentName string
 @description('Capacity in thousands of tokens per minute.')
 param deploymentCapacity int
 
+@description('Deployment SKU name.')
+param deploymentSkuName string = 'GlobalStandard'
+
 resource account 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
   name: accountName
   location: location
@@ -49,7 +52,7 @@ resource deployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01
   parent: account
   name: deploymentName
   sku: {
-    name: 'Standard'
+    name: deploymentSkuName
     capacity: deploymentCapacity
   }
   properties: {

--- a/infrastructure/parameters.sample.bicepparam
+++ b/infrastructure/parameters.sample.bicepparam
@@ -13,14 +13,17 @@ using 'main.bicep'
 param openAiAccountName = ''
 
 // Model to deploy and its version.
-param modelName = 'gpt-4o-mini'
-param modelVersion = '2024-07-18'
+param modelName = 'gpt-4.1-mini'
+param modelVersion = '2025-04-14'
 
 // Deployment name — this becomes the azure.deployment value in config.json.
-param deploymentName = 'gpt-4o-mini'
+param deploymentName = 'gpt-4.1-mini'
 
 // Capacity in thousands of tokens per minute.
 param deploymentCapacity = 10
+
+// Deployment SKU — newer models (gpt-4.1+) require 'Standard'.
+param deploymentSkuName = 'Standard'
 
 // Your Entra user/principal object ID.
 // Find it with: az ad signed-in-user show --query id -o tsv


### PR DESCRIPTION
## Summary
Switches the default Azure OpenAI model from gpt-4o-mini to **gpt-4.1-mini** ($0.40/$1.60 per 1M tokens) and adds a configurable deployment SKU parameter to the Bicep templates.

## Changes
- Replace gpt-4o-mini with gpt-4.1-mini across all Bicep templates, parameters, and docs
- Add `deploymentSkuName` parameter to Bicep (default: `Standard`)
- Update `.github/copilot-instructions.md`: `litellm` → `azure-identity` in tech stack
- Update deployment guide and README with new model references

## Testing
- All 318 unit tests pass
- All 6 Azure OpenAI integration tests pass against live gpt-4.1-mini deployment
- Full Bicep deployment verified (resource + model + RBAC)

Closes #67