### PR TITLE
feat: Copilot Skills — financial analysis workflows

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -256,6 +256,12 @@ finance-os/
 ├── package.json                    # Root workspace config
 ├── .github/
 │   ├── copilot-instructions.md     # This file
+│   ├── skills/                     # Copilot Skills (SKILL.md workflows)
+│   │   ├── earnings-analysis/      # Earnings transcript analysis
+│   │   ├── thesis-evaluation/      # Thesis challenge + conviction scoring
+│   │   ├── research-digest/        # Watchlist digest + pipeline
+│   │   ├── risk-assessment/        # Portfolio risk + stress tests
+│   │   └── macro-overview/         # Macro regime classification
 │   ├── workflows/                  # CI/CD
 │   ├── ISSUE_TEMPLATE/             # Issue templates
 │   ├── acl/                        # CODEOWNERS, access

--- a/.github/skills/earnings-analysis/SKILL.md
+++ b/.github/skills/earnings-analysis/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Analyze earnings call transcripts for sentiment, guidance, and key themes.
   Use when asked to analyze earnings, interpret an earnings call, or assess
   management tone and forward guidance.
+model: claude-sonnet-4
 tools:
   - shell
 ---

--- a/.github/skills/earnings-analysis/SKILL.md
+++ b/.github/skills/earnings-analysis/SKILL.md
@@ -9,6 +9,20 @@ tools:
   - shell
 ---
 
+## Environment Setup
+
+Before running any `finance-os` CLI commands, activate the Python environment:
+
+```bash
+cd agents && source .venv/bin/activate
+```
+
+If the venv doesn't exist, create it first:
+
+```bash
+cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+```
+
 ## Procedure
 
 1. **Obtain the transcript.** If the user provides a transcript directly, use it.

--- a/.github/skills/earnings-analysis/SKILL.md
+++ b/.github/skills/earnings-analysis/SKILL.md
@@ -11,16 +11,8 @@ tools:
 
 ## Environment Setup
 
-Before running any `finance-os` CLI commands, activate the Python environment:
-
 ```bash
-cd agents && source .venv/bin/activate
-```
-
-If the venv doesn't exist, create it first:
-
-```bash
-cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+source agents/scripts/ensure-env.sh
 ```
 
 ## Procedure

--- a/.github/skills/earnings-analysis/SKILL.md
+++ b/.github/skills/earnings-analysis/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: earnings-analysis
+description: >-
+  Analyze earnings call transcripts for sentiment, guidance, and key themes.
+  Use when asked to analyze earnings, interpret an earnings call, or assess
+  management tone and forward guidance.
+tools:
+  - shell
+---
+
+## Procedure
+
+1. **Obtain the transcript.** If the user provides a transcript directly, use it.
+   If they provide a ticker, fetch the latest earnings transcript from public sources.
+
+2. **Run the earnings interpreter agent.**
+
+   ```bash
+   finance-os run earnings-interpreter --ticker <TICKER> --prompt "<transcript_text>"
+   ```
+
+   Or via MCP tool `analyze_earnings`:
+   - `transcript`: The full or partial earnings call text.
+   - `ticker`: The company ticker symbol (optional but recommended).
+
+3. **Review the output.** The agent returns:
+   - `net_sentiment`: Score from -1.0 (bearish) to 1.0 (bullish).
+   - `tone`: Overall tone classification.
+   - `guidance_direction`: Whether guidance was raised, maintained, or lowered.
+   - `guidance_count`: Number of forward-looking statements detected.
+   - `key_phrase_count`: Notable phrases extracted.
+   - `content`: Human-readable summary.
+
+4. **Contextualize.** Compare sentiment against:
+   - Prior quarter results (is tone improving or deteriorating?).
+   - Consensus expectations (did guidance surprise?).
+   - Sector peers (is this company-specific or industry-wide?).
+
+5. **Synthesize findings.** Present a concise summary covering:
+   - Management tone and confidence level.
+   - Key guidance changes and their implications.
+   - Notable phrases or hedging language.
+   - Whether the earnings support or challenge the investment thesis.

--- a/.github/skills/macro-overview/SKILL.md
+++ b/.github/skills/macro-overview/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Classify the current macroeconomic regime using FRED economic indicators.
   Use when asked about macro conditions, economic outlook, interest rate
   environment, recession risk, or economic regime classification.
+model: gpt-4.1
 tools:
   - shell
 ---

--- a/.github/skills/macro-overview/SKILL.md
+++ b/.github/skills/macro-overview/SKILL.md
@@ -9,6 +9,20 @@ tools:
   - shell
 ---
 
+## Environment Setup
+
+Before running any `finance-os` CLI commands, activate the Python environment:
+
+```bash
+cd agents && source .venv/bin/activate
+```
+
+If the venv doesn't exist, create it first:
+
+```bash
+cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+```
+
 ## Procedure
 
 1. **Run the macro regime classifier.**

--- a/.github/skills/macro-overview/SKILL.md
+++ b/.github/skills/macro-overview/SKILL.md
@@ -11,16 +11,8 @@ tools:
 
 ## Environment Setup
 
-Before running any `finance-os` CLI commands, activate the Python environment:
-
 ```bash
-cd agents && source .venv/bin/activate
-```
-
-If the venv doesn't exist, create it first:
-
-```bash
-cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+source agents/scripts/ensure-env.sh
 ```
 
 ## Procedure

--- a/.github/skills/macro-overview/SKILL.md
+++ b/.github/skills/macro-overview/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: macro-overview
+description: >-
+  Classify the current macroeconomic regime using FRED economic indicators.
+  Use when asked about macro conditions, economic outlook, interest rate
+  environment, recession risk, or economic regime classification.
+tools:
+  - shell
+---
+
+## Procedure
+
+1. **Run the macro regime classifier.**
+
+   ```bash
+   finance-os run macro-regime
+   ```
+
+   Or via MCP tool `classify_macro`:
+   - `indicators`: Optional list of specific FRED series IDs to analyze.
+     Defaults to standard indicators (unemployment, GDP growth, yield curve,
+     inflation, ISM manufacturing).
+
+2. **Review regime output.** The agent returns:
+   - `regime`: One of EXPANSION, CONTRACTION, or TRANSITION.
+   - `indicators_fetched`: Number of FRED series retrieved.
+   - `indicators_with_data`: Number with valid recent readings.
+   - `content`: Human-readable regime analysis with indicator details.
+
+3. **Interpret the regime.** Explain what the classification means:
+   - **EXPANSION**: Growth accelerating, favorable for risk assets. Equities
+     and credit tend to outperform. Consider cyclical tilts.
+   - **CONTRACTION**: Growth decelerating or negative. Defensive positioning
+     warranted. Favor quality, low-beta, and duration.
+   - **TRANSITION**: Mixed signals, regime change likely. Heightened
+     uncertainty. Reduce leverage, increase cash buffers.
+
+4. **Connect to portfolio implications.** Based on the regime:
+   - Which sectors historically outperform in this regime?
+   - How should position sizing and risk tolerances adjust?
+   - What leading indicators to watch for regime change signals?
+
+5. **Identify key indicators to monitor.** Highlight:
+   - Indicators closest to inflection points.
+   - Divergences between indicators (e.g., strong employment but inverted curve).
+   - Data releases coming in the next 1–2 weeks that could shift the regime.

--- a/.github/skills/research-digest/SKILL.md
+++ b/.github/skills/research-digest/SKILL.md
@@ -12,16 +12,8 @@ tools:
 
 ## Environment Setup
 
-Before running any `finance-os` CLI commands, activate the Python environment:
-
 ```bash
-cd agents && source .venv/bin/activate
-```
-
-If the venv doesn't exist, create it first:
-
-```bash
-cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+source agents/scripts/ensure-env.sh
 ```
 
 ## Procedure

--- a/.github/skills/research-digest/SKILL.md
+++ b/.github/skills/research-digest/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: research-digest
+description: >-
+  Run a full research pipeline for a watchlist of tickers. Fetches SEC filings,
+  classifies macro regime, scores materiality, and generates alerts. Use when
+  asked for a research digest, daily briefing, watchlist update, or market
+  overview for specific tickers.
+tools:
+  - shell
+---
+
+## Procedure
+
+1. **Identify the ticker watchlist.** Ask the user for tickers if not provided.
+   Accept comma-separated symbols (e.g., MSFT,AAPL,GOOG).
+
+2. **Run the research digest.**
+
+   ```bash
+   finance-os digest --tickers <TICKER1>,<TICKER2>,<TICKER3>
+   ```
+
+   Or via MCP tool `research_digest`:
+   - `tickers`: List of ticker symbols.
+   - `lookback_days`: Number of days to consider (default: 7).
+   - `alert_threshold`: Materiality threshold 0.0–1.0 (default: 0.5).
+
+3. **Review digest output.** The digest returns:
+   - `entry_count`: Total data entries processed.
+   - `alert_count`: Material changes detected.
+   - `material_count`: Entries exceeding the materiality threshold.
+   - `content`: Human-readable digest with per-entry sentiment scores.
+
+4. **For deeper analysis on flagged tickers**, run the full pipeline.
+
+   ```bash
+   finance-os pipeline --ticker <TICKER>
+   ```
+
+   Or via MCP tool `orchestrate` with the default pipeline tasks.
+   The pipeline runs: macro regime → filing analyst → earnings interpreter →
+   quant signals (depends on macro + earnings) → adversarial (depends on
+   filings + earnings). Returns a structured research memo.
+
+5. **Present findings.** Organize by priority:
+   - **Material alerts** first — what changed and why it matters.
+   - **Sentiment shifts** — which tickers are trending positive or negative.
+   - **Action items** — tickers that warrant deeper analysis or thesis review.
+   - **Macro context** — current regime and its implications for the watchlist.

--- a/.github/skills/research-digest/SKILL.md
+++ b/.github/skills/research-digest/SKILL.md
@@ -44,10 +44,23 @@ source agents/scripts/ensure-env.sh
    finance-os pipeline --ticker <TICKER>
    ```
 
-   Or via MCP tool `orchestrate` with the default pipeline tasks.
-   The pipeline runs: macro regime → filing analyst → earnings interpreter →
-   quant signals (depends on macro + earnings) → adversarial (depends on
-   filings + earnings). Returns a structured research memo.
+   This runs the default pipeline: macro regime → filing analyst → earnings
+   interpreter → quant signals → adversarial, with dependency ordering.
+
+   Via MCP tool `orchestrate`, provide the full task list explicitly:
+
+   ```json
+   {
+     "ticker": "<TICKER>",
+     "tasks": [
+       {"agent_name": "macro_regime", "prompt": "Classify regime", "task_id": "macro"},
+       {"agent_name": "filing_analyst", "prompt": "Search filings", "task_id": "filings"},
+       {"agent_name": "earnings_interpreter", "prompt": "Analyze earnings", "task_id": "earnings"},
+       {"agent_name": "quant_signal", "prompt": "Generate signals", "task_id": "signals", "depends_on": ["macro", "earnings"]},
+       {"agent_name": "adversarial", "prompt": "Challenge thesis", "task_id": "adversarial", "depends_on": ["filings", "earnings"]}
+     ]
+   }
+   ```
 
 5. **Present findings.** Organize by priority:
    - **Material alerts** first — what changed and why it matters.

--- a/.github/skills/research-digest/SKILL.md
+++ b/.github/skills/research-digest/SKILL.md
@@ -10,6 +10,20 @@ tools:
   - shell
 ---
 
+## Environment Setup
+
+Before running any `finance-os` CLI commands, activate the Python environment:
+
+```bash
+cd agents && source .venv/bin/activate
+```
+
+If the venv doesn't exist, create it first:
+
+```bash
+cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+```
+
 ## Procedure
 
 1. **Identify the ticker watchlist.** Ask the user for tickers if not provided.

--- a/.github/skills/research-digest/SKILL.md
+++ b/.github/skills/research-digest/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   classifies macro regime, scores materiality, and generates alerts. Use when
   asked for a research digest, daily briefing, watchlist update, or market
   overview for specific tickers.
+model: claude-sonnet-4
 tools:
   - shell
 ---

--- a/.github/skills/risk-assessment/SKILL.md
+++ b/.github/skills/risk-assessment/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Analyze portfolio risk including scenario stress tests, concentration analysis,
   and tail-risk simulations. Use when asked about portfolio risk, stress testing,
   drawdown analysis, VaR, or position sizing.
+model: claude-sonnet-4
 tools:
   - shell
 ---

--- a/.github/skills/risk-assessment/SKILL.md
+++ b/.github/skills/risk-assessment/SKILL.md
@@ -9,6 +9,20 @@ tools:
   - shell
 ---
 
+## Environment Setup
+
+Before running any `finance-os` CLI commands, activate the Python environment:
+
+```bash
+cd agents && source .venv/bin/activate
+```
+
+If the venv doesn't exist, create it first:
+
+```bash
+cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+```
+
 ## Procedure
 
 1. **Gather portfolio context.** Ask the user for:

--- a/.github/skills/risk-assessment/SKILL.md
+++ b/.github/skills/risk-assessment/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: risk-assessment
+description: >-
+  Analyze portfolio risk including scenario stress tests, concentration analysis,
+  and tail-risk simulations. Use when asked about portfolio risk, stress testing,
+  drawdown analysis, VaR, or position sizing.
+tools:
+  - shell
+---
+
+## Procedure
+
+1. **Gather portfolio context.** Ask the user for:
+   - Current positions (tickers and weights or dollar amounts).
+   - Any specific risk scenarios to stress-test.
+   - Return series or time period for analysis.
+
+2. **Run the risk agent.**
+
+   ```bash
+   finance-os run risk-analyst --prompt "Assess portfolio risk" \
+     --prompt "<portfolio_description_and_positions>"
+   ```
+
+   Pass structured data via the prompt: positions, scenarios, or return series.
+   The agent performs:
+   - Value-at-Risk (VaR) estimation.
+   - Concentration analysis (single-name, sector, factor).
+   - Scenario stress tests (user-defined or standard: recession, rate shock, etc.).
+   - Correlation analysis across holdings.
+
+3. **Review risk output.** The agent returns:
+   - Risk metrics (VaR, max drawdown, volatility).
+   - Concentration warnings (positions exceeding thresholds).
+   - Scenario outcomes (portfolio impact under each stress scenario).
+   - Recommendations for risk reduction.
+
+4. **Cross-reference with macro regime.** Check if the current macro
+   environment amplifies identified risks.
+
+   ```bash
+   finance-os run macro-regime
+   ```
+
+   Or via MCP tool `classify_macro`. If regime is CONTRACTION, risk
+   tolerances should tighten.
+
+5. **Synthesize.** Present:
+   - Top risk exposures and their magnitudes.
+   - Worst-case scenario outcomes.
+   - Diversification gaps.
+   - Actionable recommendations: rebalance, hedge, or reduce positions.

--- a/.github/skills/risk-assessment/SKILL.md
+++ b/.github/skills/risk-assessment/SKILL.md
@@ -11,16 +11,8 @@ tools:
 
 ## Environment Setup
 
-Before running any `finance-os` CLI commands, activate the Python environment:
-
 ```bash
-cd agents && source .venv/bin/activate
-```
-
-If the venv doesn't exist, create it first:
-
-```bash
-cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+source agents/scripts/ensure-env.sh
 ```
 
 ## Procedure

--- a/.github/skills/risk-assessment/SKILL.md
+++ b/.github/skills/risk-assessment/SKILL.md
@@ -25,11 +25,26 @@ source agents/scripts/ensure-env.sh
 2. **Run the risk agent.**
 
    ```bash
-   finance-os run risk-analyst --prompt "Assess portfolio risk" \
-     --prompt "<portfolio_description_and_positions>"
+   finance-os run risk-analyst
    ```
 
-   Pass structured data via the prompt: positions, scenarios, or return series.
+   The CLI runs a baseline risk assessment. For structured inputs
+   (positions, scenarios, return series), use MCP tool `orchestrate`:
+
+   ```json
+   {
+     "tasks": [{
+       "agent_name": "risk_analyst",
+       "prompt": "Assess portfolio risk",
+       "task_id": "risk",
+       "kwargs": {
+         "positions": [{"ticker": "AAPL", "weight": 0.3}],
+         "scenarios": ["recession", "rate_shock"]
+       }
+     }]
+   }
+   ```
+
    The agent performs:
    - Value-at-Risk (VaR) estimation.
    - Concentration analysis (single-name, sector, factor).

--- a/.github/skills/thesis-evaluation/SKILL.md
+++ b/.github/skills/thesis-evaluation/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: thesis-evaluation
+description: >-
+  Evaluate an investment thesis by running adversarial challenges, identifying
+  blind spots, and computing conviction scores. Use when asked to evaluate,
+  challenge, stress-test, or critique an investment thesis.
+tools:
+  - shell
+---
+
+## Procedure
+
+1. **Gather the thesis.** Ask the user for:
+   - The ticker symbol.
+   - The investment thesis (bull case, key assumptions, catalysts).
+   - Any position sizing or time horizon context.
+
+2. **Run the adversarial agent** to challenge the thesis.
+
+   ```bash
+   finance-os run adversarial --ticker <TICKER> --prompt "Challenge the investment thesis for <TICKER>: <thesis_text>"
+   ```
+
+   Or via MCP tool `orchestrate` with a single adversarial task:
+   ```json
+   {
+     "tasks": [{"agent_name": "adversarial", "prompt": "Challenge: <thesis>", "task_id": "challenge"}],
+     "ticker": "<TICKER>"
+   }
+   ```
+
+3. **Review adversarial output.** The agent returns:
+   - `conviction_score`: 0.0–1.0 post-challenge conviction.
+   - `counter_count`: Number of counter-arguments found.
+   - `blind_spot_count`: Unaddressed risk categories.
+   - Counter-arguments ranked by strength (STRONG, MODERATE, WEAK).
+   - Blind spots ranked by severity (HIGH, MEDIUM, LOW).
+
+4. **Run the thesis guardian** if the user has an active thesis to monitor.
+
+   ```bash
+   finance-os run thesis-guardian --ticker <TICKER> --prompt "Monitor thesis assumptions"
+   ```
+
+   Pass structured theses via kwargs for richer analysis.
+
+5. **Cross-reference with filings.** Run the filing analyst to check if recent
+   SEC filings support or contradict thesis assumptions.
+
+   ```bash
+   finance-os run filing-analyst --ticker <TICKER>
+   ```
+
+6. **Synthesize.** Present:
+   - Post-challenge conviction score and what it means.
+   - The strongest counter-arguments and how they could invalidate the thesis.
+   - Critical blind spots the thesis doesn't address.
+   - Recommendations: strengthen thesis, reduce position, or abandon.

--- a/.github/skills/thesis-evaluation/SKILL.md
+++ b/.github/skills/thesis-evaluation/SKILL.md
@@ -45,11 +45,29 @@ source agents/scripts/ensure-env.sh
 
 4. **Run the thesis guardian** if the user has an active thesis to monitor.
 
-   ```bash
-   finance-os run thesis-guardian --ticker <TICKER> --prompt "Monitor thesis assumptions"
+   Use MCP tool `orchestrate` to pass structured thesis definitions:
+
+   ```json
+   {
+     "tasks": [{
+       "agent_name": "thesis_guardian",
+       "prompt": "Monitor thesis assumptions",
+       "task_id": "monitor",
+       "kwargs": {
+         "theses": [{
+           "ticker": "<TICKER>",
+           "thesis": "<bull_case>",
+           "assumptions": ["<assumption_1>", "<assumption_2>"],
+           "catalysts": ["<catalyst_1>"],
+           "risks": ["<risk_1>"]
+         }]
+       }
+     }]
+   }
    ```
 
-   Pass structured theses via kwargs for richer analysis.
+   The CLI `finance-os run thesis-guardian` runs without structured data and
+   requires theses to be passed via MCP or the application layer directly.
 
 5. **Cross-reference with filings.** Run the filing analyst to check if recent
    SEC filings support or contradict thesis assumptions.

--- a/.github/skills/thesis-evaluation/SKILL.md
+++ b/.github/skills/thesis-evaluation/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Evaluate an investment thesis by running adversarial challenges, identifying
   blind spots, and computing conviction scores. Use when asked to evaluate,
   challenge, stress-test, or critique an investment thesis.
+model: claude-opus-4
 tools:
   - shell
 ---

--- a/.github/skills/thesis-evaluation/SKILL.md
+++ b/.github/skills/thesis-evaluation/SKILL.md
@@ -9,6 +9,20 @@ tools:
   - shell
 ---
 
+## Environment Setup
+
+Before running any `finance-os` CLI commands, activate the Python environment:
+
+```bash
+cd agents && source .venv/bin/activate
+```
+
+If the venv doesn't exist, create it first:
+
+```bash
+cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+```
+
 ## Procedure
 
 1. **Gather the thesis.** Ask the user for:

--- a/.github/skills/thesis-evaluation/SKILL.md
+++ b/.github/skills/thesis-evaluation/SKILL.md
@@ -11,16 +11,8 @@ tools:
 
 ## Environment Setup
 
-Before running any `finance-os` CLI commands, activate the Python environment:
-
 ```bash
-cd agents && source .venv/bin/activate
-```
-
-If the venv doesn't exist, create it first:
-
-```bash
-cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+source agents/scripts/ensure-env.sh
 ```
 
 ## Procedure

--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ python -m src.mcp_server    # direct invocation
 
 Tools available: `analyze_earnings`, `classify_macro`, `research_digest`, `orchestrate`. See [docs/tools.md](docs/tools.md) for details.
 
+### Copilot Skills
+
+Copilot Skills (`.github/skills/`) teach Copilot how to use finance-os tools together for investment analysis workflows. They are auto-detected by Copilot in IDE and CLI.
+
+| Skill | Trigger | What it does |
+|-------|---------|-------------|
+| `earnings-analysis` | "analyze earnings for AAPL" | Run earnings interpreter, score sentiment, extract guidance |
+| `thesis-evaluation` | "challenge my bull thesis on MSFT" | Adversarial challenge + blind spots + conviction scoring |
+| `research-digest` | "daily briefing for my watchlist" | Auto-fetch filings, classify macro, generate alerts |
+| `risk-assessment` | "stress test my portfolio" | VaR, concentration, scenario analysis |
+| `macro-overview` | "what's the macro regime?" | FRED-based regime classification + implications |
+
 ### Preflight (run before every push)
 
 From the repo root:

--- a/agents/scripts/ensure-env.sh
+++ b/agents/scripts/ensure-env.sh
@@ -1,14 +1,25 @@
 #!/usr/bin/env bash
 # Ensure the finance-os Python environment is ready.
 # Source this script: source agents/scripts/ensure-env.sh
-set -euo pipefail
 
-AGENTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+__ensure_env_saved_opts="$(set +o)"
 
-if [ ! -d "$AGENTS_DIR/.venv" ]; then
-    python3 -m venv "$AGENTS_DIR/.venv"
-    source "$AGENTS_DIR/.venv/bin/activate"
-    pip install -e "$AGENTS_DIR[dev]"
-else
-    source "$AGENTS_DIR/.venv/bin/activate"
-fi
+__ensure_env_main() {
+    set -euo pipefail
+
+    local agents_dir
+    agents_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+    if [ ! -d "$agents_dir/.venv" ]; then
+        python3 -m venv "$agents_dir/.venv"
+    fi
+
+    source "$agents_dir/.venv/bin/activate"
+    python -m pip install --quiet -e "$agents_dir[dev]"
+}
+
+__ensure_env_main
+__ensure_env_rc=$?
+eval "$__ensure_env_saved_opts"
+unset __ensure_env_saved_opts __ensure_env_rc
+return 0 2>/dev/null || exit 0

--- a/agents/scripts/ensure-env.sh
+++ b/agents/scripts/ensure-env.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Ensure the finance-os Python environment is ready.
+# Source this script: source agents/scripts/ensure-env.sh
+set -euo pipefail
+
+AGENTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -d "$AGENTS_DIR/.venv" ]; then
+    python3 -m venv "$AGENTS_DIR/.venv"
+    source "$AGENTS_DIR/.venv/bin/activate"
+    pip install -e "$AGENTS_DIR[dev]"
+else
+    source "$AGENTS_DIR/.venv/bin/activate"
+fi

--- a/agents/tests/test_skills.py
+++ b/agents/tests/test_skills.py
@@ -1,0 +1,112 @@
+"""Structural validation tests for Copilot Skills.
+
+Ensures every skill directory contains a valid SKILL.md with required
+YAML frontmatter fields, and that referenced resources exist.
+"""
+
+import re
+from pathlib import Path
+
+SKILLS_DIR = Path(__file__).resolve().parents[2] / ".github" / "skills"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_FIELDS = {"name", "description"}
+
+
+def _parse_frontmatter(path: Path) -> dict[str, str]:
+    """Extract YAML frontmatter key-value pairs from a SKILL.md file."""
+    text = path.read_text()
+    if not text.startswith("---"):
+        return {}
+    end = text.index("---", 3)
+    block = text[3:end]
+    result: dict[str, str] = {}
+
+    # Handle multi-line values (>- or | style) first
+    for match in re.finditer(
+        r"^(\w[\w-]*):\s*>-?\s*\n((?:\s+.+\n?)+)", block, re.MULTILINE
+    ):
+        result[match.group(1)] = " ".join(
+            line.strip() for line in match.group(2).splitlines() if line.strip()
+        )
+
+    # Then single-line values (skip keys already parsed as multi-line)
+    for match in re.finditer(r"^(\w[\w-]*):\s*(.+?)$", block, re.MULTILINE):
+        key, val = match.group(1), match.group(2).strip()
+        if key not in result and val not in (">-", ">", "|"):
+            result[key] = val
+
+    return result
+
+
+def _all_skill_dirs() -> list[Path]:
+    """Return all subdirectories under .github/skills/."""
+    if not SKILLS_DIR.exists():
+        return []
+    return sorted(d for d in SKILLS_DIR.iterdir() if d.is_dir())
+
+
+class TestSkillStructure:
+    """Validate that all skill directories have valid SKILL.md files."""
+
+    def test_skills_directory_exists(self) -> None:
+        assert SKILLS_DIR.exists(), f"{SKILLS_DIR} does not exist"
+
+    def test_every_skill_dir_has_skill_md(self) -> None:
+        for skill_dir in _all_skill_dirs():
+            skill_file = skill_dir / "SKILL.md"
+            assert skill_file.exists(), f"{skill_dir.name}/ missing SKILL.md"
+
+    def test_frontmatter_has_required_fields(self) -> None:
+        for skill_dir in _all_skill_dirs():
+            skill_file = skill_dir / "SKILL.md"
+            if not skill_file.exists():
+                continue
+            fm = _parse_frontmatter(skill_file)
+            missing = REQUIRED_FIELDS - set(fm.keys())
+            assert not missing, (
+                f"{skill_dir.name}/SKILL.md missing frontmatter: {missing}"
+            )
+
+    def test_frontmatter_name_matches_directory(self) -> None:
+        for skill_dir in _all_skill_dirs():
+            skill_file = skill_dir / "SKILL.md"
+            if not skill_file.exists():
+                continue
+            fm = _parse_frontmatter(skill_file)
+            assert fm.get("name") == skill_dir.name, (
+                f"{skill_dir.name}/SKILL.md name '{fm.get('name')}' "
+                f"doesn't match directory name"
+            )
+
+    def test_frontmatter_description_not_empty(self) -> None:
+        for skill_dir in _all_skill_dirs():
+            skill_file = skill_dir / "SKILL.md"
+            if not skill_file.exists():
+                continue
+            fm = _parse_frontmatter(skill_file)
+            desc = fm.get("description", "")
+            assert desc and len(desc.strip()) > 10, (
+                f"{skill_dir.name}/SKILL.md description too short or empty"
+            )
+
+    def test_referenced_scripts_exist(self) -> None:
+        for skill_dir in _all_skill_dirs():
+            skill_file = skill_dir / "SKILL.md"
+            if not skill_file.exists():
+                continue
+            text = skill_file.read_text()
+            # Find `source <path>` references in code blocks
+            for line in text.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("source ") and not stripped.startswith("source_"):
+                    script_path = stripped.split("source ", 1)[1].strip()
+                    full_path = REPO_ROOT / script_path
+                    assert full_path.exists(), (
+                        f"{skill_dir.name}/SKILL.md references "
+                        f"'{script_path}' which doesn't exist"
+                    )
+
+    def test_at_least_one_skill_exists(self) -> None:
+        dirs = _all_skill_dirs()
+        assert len(dirs) >= 1, "No skills found under .github/skills/"

--- a/agents/tests/test_skills.py
+++ b/agents/tests/test_skills.py
@@ -18,11 +18,14 @@ def _parse_frontmatter(path: Path) -> dict[str, str]:
     text = path.read_text()
     if not text.startswith("---"):
         return {}
-    end = text.index("---", 3)
+    try:
+        end = text.index("---", 3)
+    except ValueError:
+        return {}
     block = text[3:end]
     result: dict[str, str] = {}
 
-    # Handle multi-line values (>- or | style) first
+    # Handle multi-line values (>- style) first
     for match in re.finditer(
         r"^(\w[\w-]*):\s*>-?\s*\n((?:\s+.+\n?)+)", block, re.MULTILINE
     ):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@
 | LLM Gateway | Pluggable — OpenAI, Anthropic, ollama, or host LLM via MCP |
 | Data Sources | SEC EDGAR (free), FRED (free API key), Yahoo Finance, QIF |
 | CLI | Python (`finance-os` console script) |
-| Copilot Skills | Markdown workflow definitions (`.github/skills/`, planned) |
+| Copilot Skills | Markdown workflow definitions (`.github/skills/`) — earnings, thesis, digest, risk, macro |
 | Testing | Vitest (TypeScript), pytest with markers (Python) — unit and integration separated |
 | Linting | ESLint (TypeScript), ruff (Python) |
 | CI/CD | GitHub Actions |
@@ -213,4 +213,4 @@ Shared prompt templates organized by strategy:
 | Application layer (contracts, LLM gateway, services, config) | #49 | ✅ Complete |
 | Agent CLI | #50 | ✅ Complete |
 | Python MCP server | #51 | ✅ Complete |
-| Copilot Skills | #53 | Next |
+| Copilot Skills | #53 | ✅ Complete |


### PR DESCRIPTION
Add 5 Copilot Skills under `.github/skills/` that teach Copilot how to use finance-os tools together for investment analysis workflows.

## Skills Added

| Skill | Trigger Example | What It Does |
|-------|----------------|-------------|
| `earnings-analysis` | "analyze earnings for AAPL" | Earnings interpreter → sentiment + guidance |
| `thesis-evaluation` | "challenge my bull thesis" | Adversarial + blind spots + conviction |
| `research-digest` | "daily briefing for watchlist" | Auto-fetch filings, macro, alerts |
| `risk-assessment` | "stress test my portfolio" | VaR, concentration, scenarios |
| `macro-overview` | "what's the macro regime?" | FRED regime classification |

Each skill has YAML frontmatter (name, description, tools) and step-by-step procedures referencing CLI commands (`finance-os run`, `finance-os pipeline`, `finance-os digest`) and MCP tools (`analyze_earnings`, `classify_macro`, `research_digest`, `orchestrate`).

## Also Updated
- `copilot-instructions.md`: Added skills to repo structure
- `README.md`: Added Copilot Skills table
- `docs/architecture.md`: Marked Copilot Skills as complete

Closes #53