### PR TITLE
feat: FastAPI Web API — REST layer for application services

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ Agents perform deterministic data processing and construct prompts but **do not 
 |---|---|---|
 | MCP (Copilot, Claude Desktop) | Host LLM reasons | Skipped |
 | CLI | LLM gateway calls provider | Used |
-| Web API (future) | LLM gateway calls provider | Used |
+| Web API | LLM gateway calls provider | Used |
 
 ## Data Flow
 
@@ -68,6 +68,7 @@ Research Output (memos, alerts, signals)
 | LLM Gateway | Pluggable — OpenAI, Anthropic, ollama, or host LLM via MCP |
 | Data Sources | SEC EDGAR (free), FRED (free), Yahoo Finance (yfinance), QIF files |
 | CLI | Python (`finance-os` console script) |
+| Web API | Python (`finance-os-api` console script, FastAPI + uvicorn) |
 | MCP Server entry | Python (`finance-os-mcp` console script, stdio transport) |
 | Copilot Skills | Markdown workflow definitions (`.github/skills/`) |
 | Testing | Vitest (TS), pytest (Python) |
@@ -284,6 +285,7 @@ finance-os/
 │   │   ├── application/            # Shared contracts, LLM gateway, services, registry
 │   │   ├── cli/                    # CLI entry points (finance-os command)
 │   │   ├── mcp_server.py           # Python MCP server (finance-os-mcp command)
+│   │   ├── web_api.py              # FastAPI web server (finance-os-api command)
 │   │   ├── tools/                  # Quant tools
 │   │   └── pipelines/             # Data ingestion pipelines
 │   └── tests/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ finance-os/
 │       ├── application/ # Contracts, LLM gateway, services, config, registry
 │       ├── cli/         # CLI entry points (finance-os command)
 │       ├── mcp_server.py # Python MCP server (finance-os-mcp command)
+│       ├── web_api.py   # FastAPI web server (finance-os-api command)
 │       └── pipelines/   # Research digest pipeline
 ├── prompts/             # Shared prompt library
 ├── docs/                # Architecture, agent, and tool documentation
@@ -121,6 +122,17 @@ python -m src.mcp_server    # direct invocation
 ```
 
 Tools available: `analyze_earnings`, `classify_macro`, `research_digest`, `orchestrate`. See [docs/tools.md](docs/tools.md) for details.
+
+### Web API
+
+REST API wrapping the same application layer as CLI and MCP server:
+
+```bash
+finance-os-api              # starts on http://127.0.0.1:8000
+uvicorn src.web_api:app --reload  # development mode
+```
+
+Endpoints: `GET /health`, `GET /agents`, `POST /agents/{name}` (7 agents), `POST /pipeline`, `POST /digest`. Interactive docs at `/docs` (Swagger UI).
 
 ### Copilot Skills
 

--- a/README.md
+++ b/README.md
@@ -125,14 +125,55 @@ Tools available: `analyze_earnings`, `classify_macro`, `research_digest`, `orche
 
 ### Web API
 
-REST API wrapping the same application layer as CLI and MCP server:
+REST API wrapping the same application layer as CLI and MCP server.
 
 ```bash
-finance-os-api              # starts on http://127.0.0.1:8000
-uvicorn src.web_api:app --reload  # development mode
+# Setup (one-time, from agents/ directory)
+cd agents
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+
+# Start the server
+finance-os-api                              # production (127.0.0.1:8000)
+uvicorn src.web_api:app --reload            # development with auto-reload
+uvicorn src.web_api:app --host 0.0.0.0      # expose to local network
 ```
 
-Endpoints: `GET /health`, `GET /agents`, `POST /agents/{name}` (7 agents), `POST /pipeline`, `POST /digest`. Interactive docs at `/docs` (Swagger UI).
+Once running, open http://127.0.0.1:8000/docs for interactive Swagger UI.
+
+**Endpoints:**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Health check |
+| GET | `/agents` | List available agents |
+| POST | `/agents/earnings_interpreter` | Analyze earnings transcripts |
+| POST | `/agents/macro_regime` | Classify macro regime |
+| POST | `/agents/filing_analyst` | Search SEC filings |
+| POST | `/agents/quant_signal` | Generate quant signals |
+| POST | `/agents/thesis_guardian` | Evaluate investment theses |
+| POST | `/agents/risk_analyst` | Portfolio risk analysis |
+| POST | `/agents/adversarial` | Challenge thesis adversarially |
+| POST | `/pipeline` | Multi-agent research pipeline |
+| POST | `/digest` | Research digest for watchlist |
+
+**Example:**
+
+```bash
+# Health check
+curl http://127.0.0.1:8000/health
+
+# Run a research digest
+curl -X POST http://127.0.0.1:8000/digest \
+  -H "Content-Type: application/json" \
+  -d '{"tickers": ["AAPL", "MSFT"], "lookback_days": 7}'
+
+# Search SEC filings
+curl -X POST http://127.0.0.1:8000/agents/filing_analyst \
+  -H "Content-Type: application/json" \
+  -d '{"ticker": "AAPL", "form_type": "10-K"}'
+```
 
 ### Copilot Skills
 

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "azure-identity>=1.19",
     "aiohttp>=3.11",
     "mcp>=1.27.0",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.34.0",
 ]
 
 [project.optional-dependencies]
@@ -29,6 +31,7 @@ dev = [
 [project.scripts]
 finance-os = "src.cli.main:main"
 finance-os-mcp = "src.mcp_server:main"
+finance-os-api = "src.web_api:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -1,0 +1,191 @@
+"""FastAPI web service wrapping the finance-os application layer.
+
+Thin REST wrapper over the same services used by CLI and MCP server.
+Each endpoint creates fresh service instances per request to avoid
+cross-request state leakage (agents maintain internal history).
+
+Run locally:
+    uvicorn src.web_api:app --reload
+    finance-os-api              # console script
+"""
+
+import logging
+from functools import lru_cache
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from src.application.config import AppConfig
+from src.application.contracts.agents import (
+    AnalyzeEarningsRequest,
+    AnalyzeEarningsResponse,
+    AssessRiskRequest,
+    AssessRiskResponse,
+    ChallengeThesisRequest,
+    ChallengeThesisResponse,
+    ClassifyMacroRequest,
+    ClassifyMacroResponse,
+    EvaluateThesisRequest,
+    EvaluateThesisResponse,
+    GenerateSignalsRequest,
+    GenerateSignalsResponse,
+    RunDigestRequest,
+    RunDigestResponse,
+    RunPipelineRequest,
+    RunPipelineResponse,
+    SearchFilingsRequest,
+    SearchFilingsResponse,
+)
+from src.application.registry import AGENT_CATALOG, create_pipeline_service
+from src.application.services.agent_service import AgentService
+from src.application.services.digest_service import DigestService
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="finance-os",
+    description="Personal investment intelligence API",
+    version="0.1.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+VALID_AGENT_NAMES = frozenset(info["name"] for info in AGENT_CATALOG)
+
+
+@lru_cache(maxsize=1)
+def get_config() -> AppConfig:
+    """Lazy-loaded, cached application configuration."""
+    return AppConfig()
+
+
+@app.exception_handler(ValueError)
+async def value_error_handler(_request: Request, exc: ValueError) -> JSONResponse:
+    """Map domain ValueError (bad input, unknown agent) to 400."""
+    return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+
+# --- Health & Info ---
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Health check."""
+    return {"status": "ok"}
+
+
+@app.get("/agents")
+async def list_agents() -> list[dict[str, str]]:
+    """List available agents."""
+    return list(AGENT_CATALOG)
+
+
+# --- Agent Endpoints ---
+
+
+@app.post("/agents/earnings_interpreter", response_model=AnalyzeEarningsResponse)
+async def analyze_earnings(request: AnalyzeEarningsRequest) -> Any:
+    """Analyze an earnings call transcript for tone, sentiment, and guidance."""
+    service = AgentService()
+    response = await service.analyze_earnings(request)
+    return response.model_dump(mode="json")
+
+
+@app.post("/agents/macro_regime", response_model=ClassifyMacroResponse)
+async def classify_macro(request: ClassifyMacroRequest) -> Any:
+    """Classify the current macroeconomic regime from FRED data."""
+    if not request.api_key:
+        request = request.model_copy(update={"api_key": get_config().fred_api_key})
+    service = AgentService()
+    response = await service.classify_macro(request)
+    return response.model_dump(mode="json")
+
+
+@app.post("/agents/filing_analyst", response_model=SearchFilingsResponse)
+async def search_filings(request: SearchFilingsRequest) -> Any:
+    """Search SEC filings for a company."""
+    service = AgentService()
+    response = await service.search_filings(request)
+    return response.model_dump(mode="json")
+
+
+@app.post("/agents/quant_signal", response_model=GenerateSignalsResponse)
+async def generate_signals(request: GenerateSignalsRequest) -> Any:
+    """Generate composite quantitative signals."""
+    service = AgentService()
+    response = await service.generate_signals(request)
+    return response.model_dump(mode="json")
+
+
+@app.post("/agents/thesis_guardian", response_model=EvaluateThesisResponse)
+async def evaluate_thesis(request: EvaluateThesisRequest) -> Any:
+    """Evaluate investment theses against observed data."""
+    service = AgentService()
+    response = await service.evaluate_thesis(request)
+    return response.model_dump(mode="json")
+
+
+@app.post("/agents/risk_analyst", response_model=AssessRiskResponse)
+async def assess_risk(request: AssessRiskRequest) -> Any:
+    """Run risk analysis on a portfolio."""
+    service = AgentService()
+    response = await service.assess_risk(request)
+    return response.model_dump(mode="json")
+
+
+@app.post("/agents/adversarial", response_model=ChallengeThesisResponse)
+async def challenge_thesis(request: ChallengeThesisRequest) -> Any:
+    """Adversarially challenge investment claims or thesis."""
+    service = AgentService()
+    response = await service.challenge_thesis(request)
+    return response.model_dump(mode="json")
+
+
+# --- Pipeline & Digest ---
+
+
+@app.post("/pipeline", response_model=RunPipelineResponse)
+async def run_pipeline(
+    request: RunPipelineRequest,
+    ticker: str = "",
+    date: str = "",
+) -> Any:
+    """Run a multi-agent research pipeline with dependency ordering."""
+    for task in request.tasks:
+        if task.agent_name not in VALID_AGENT_NAMES:
+            valid = ", ".join(sorted(VALID_AGENT_NAMES))
+            msg = f"Unknown agent '{task.agent_name}'. Valid agents: {valid}"
+            raise ValueError(msg)
+    service = create_pipeline_service(get_config())
+    response = await service.run_pipeline(request, ticker=ticker, date=date)
+    return response.model_dump(mode="json")
+
+
+@app.post("/digest", response_model=RunDigestResponse)
+async def run_digest(request: RunDigestRequest) -> Any:
+    """Run a research digest for a watchlist of tickers."""
+    service = DigestService(get_config())
+    response = await service.run_digest(request)
+    return response.model_dump(mode="json")
+
+
+def main() -> None:
+    """Entry point for the Web API server."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    uvicorn.run(app, host="127.0.0.1", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/tests/test_web_api.py
+++ b/agents/tests/test_web_api.py
@@ -1,0 +1,302 @@
+"""Tests for the FastAPI web API layer.
+
+Uses FastAPI TestClient with mocked services to verify endpoint behavior
+without making external API or LLM calls.
+"""
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.application.contracts.agents import (
+    AnalyzeEarningsResponse,
+    AssessRiskResponse,
+    ChallengeThesisResponse,
+    ClassifyMacroResponse,
+    EvaluateThesisResponse,
+    GenerateSignalsResponse,
+    RunDigestResponse,
+    RunPipelineResponse,
+    SearchFilingsResponse,
+)
+from src.web_api import app, get_config
+
+
+@pytest.fixture
+def client():
+    """TestClient for the FastAPI app."""
+    return TestClient(app)
+
+
+# --- Health & Info ---
+
+
+class TestHealth:
+    def test_health_returns_ok(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_list_agents_returns_catalog(self, client):
+        resp = client.get("/agents")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) >= 7
+        names = {a["name"] for a in data}
+        assert "macro_regime" in names
+        assert "filing_analyst" in names
+        assert "adversarial" in names
+        for agent in data:
+            assert "name" in agent
+            assert "description" in agent
+
+
+# --- Agent Endpoints ---
+
+
+def _mock_response(response_cls, **kwargs):
+    """Build a mock service response."""
+    defaults = {"content": "test output"}
+    defaults.update(kwargs)
+    return response_cls(**defaults)
+
+
+class TestEarningsEndpoint:
+    @patch("src.web_api.AgentService")
+    def test_analyze_earnings_success(self, mock_cls, client):
+        mock_svc = mock_cls.return_value
+        mock_svc.analyze_earnings = AsyncMock(return_value=_mock_response(
+            AnalyzeEarningsResponse,
+            tone="positive", net_sentiment=0.7, confidence="high",
+            guidance_direction="raised", guidance_count=3, key_phrase_count=5,
+        ))
+        resp = client.post("/agents/earnings_interpreter", json={
+            "transcript": "Good quarter, revenue up 15%",
+            "ticker": "AAPL",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["tone"] == "positive"
+        assert data["guidance_count"] == 3
+
+    def test_analyze_earnings_empty_transcript_422(self, client):
+        resp = client.post("/agents/earnings_interpreter", json={
+            "transcript": "",
+        })
+        assert resp.status_code == 422
+
+
+class TestMacroEndpoint:
+    @patch("src.web_api.AgentService")
+    def test_classify_macro_success(self, mock_cls, client):
+        mock_svc = mock_cls.return_value
+        mock_svc.classify_macro = AsyncMock(return_value=_mock_response(
+            ClassifyMacroResponse,
+            regime="expansion", indicators_fetched=5, indicators_with_data=4,
+        ))
+        resp = client.post("/agents/macro_regime", json={
+            "indicators": ["GDP", "UNRATE"],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["regime"] == "expansion"
+
+    @patch("src.web_api.AgentService")
+    def test_classify_macro_injects_api_key(self, mock_cls, client):
+        mock_svc = mock_cls.return_value
+        mock_svc.classify_macro = AsyncMock(return_value=_mock_response(
+            ClassifyMacroResponse,
+            regime="transition", indicators_fetched=0, indicators_with_data=0,
+        ))
+        resp = client.post("/agents/macro_regime", json={})
+        assert resp.status_code == 200
+        call_args = mock_svc.classify_macro.call_args[0][0]
+        assert call_args.api_key == get_config().fred_api_key
+
+
+class TestFilingEndpoint:
+    @patch("src.web_api.AgentService")
+    def test_search_filings_success(self, mock_cls, client):
+        mock_svc = mock_cls.return_value
+        mock_svc.search_filings = AsyncMock(return_value=_mock_response(
+            SearchFilingsResponse,
+            cik="320193", form_type="10-K", filing_count=5,
+        ))
+        resp = client.post("/agents/filing_analyst", json={
+            "ticker": "AAPL",
+        })
+        assert resp.status_code == 200
+        assert resp.json()["filing_count"] == 5
+
+
+class TestQuantSignalEndpoint:
+    @patch("src.web_api.AgentService")
+    def test_generate_signals_success(self, mock_cls, client):
+        mock_svc = mock_cls.return_value
+        mock_svc.generate_signals = AsyncMock(return_value=_mock_response(
+            GenerateSignalsResponse,
+            agent="quant_signal", composite={"score": 0.7}, signals=[],
+        ))
+        resp = client.post("/agents/quant_signal", json={
+            "signals": [{"name": "momentum", "value": 0.8, "weight": 1.0, "direction": "long"}],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["composite"]["score"] == 0.7
+
+
+class TestThesisGuardianEndpoint:
+    @patch("src.web_api.AgentService")
+    def test_evaluate_thesis_success(self, mock_cls, client):
+        mock_svc = mock_cls.return_value
+        mock_svc.evaluate_thesis = AsyncMock(return_value=_mock_response(
+            EvaluateThesisResponse,
+            theses_checked=2, alerts_generated=1, critical_alerts=0,
+        ))
+        resp = client.post("/agents/thesis_guardian", json={
+            "theses": [{"ticker": "AAPL", "hypothesis": "bull"}],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["theses_checked"] == 2
+
+
+class TestRiskEndpoint:
+    @patch("src.web_api.AgentService")
+    def test_assess_risk_success(self, mock_cls, client):
+        mock_svc = mock_cls.return_value
+        mock_svc.assess_risk = AsyncMock(return_value=_mock_response(
+            AssessRiskResponse,
+        ))
+        resp = client.post("/agents/risk_analyst", json={})
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "test output"
+
+
+class TestAdversarialEndpoint:
+    @patch("src.web_api.AgentService")
+    def test_challenge_thesis_success(self, mock_cls, client):
+        mock_svc = mock_cls.return_value
+        mock_svc.challenge_thesis = AsyncMock(return_value=_mock_response(
+            ChallengeThesisResponse,
+            conviction_score="0.65", counter_count=4, blind_spot_count=2,
+        ))
+        resp = client.post("/agents/adversarial", json={
+            "claims": ["AAPL will grow revenue 20% YoY"],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["counter_count"] == 4
+
+
+# --- Pipeline & Digest ---
+
+
+class TestPipelineEndpoint:
+    @patch("src.web_api.create_pipeline_service")
+    def test_run_pipeline_success(self, mock_create, client):
+        mock_svc = mock_create.return_value
+        mock_svc.run_pipeline = AsyncMock(return_value=RunPipelineResponse(
+            results=[{"task_id": "t1", "status": "success"}],
+            total_duration_ms=150,
+            successful=1,
+            failed=0,
+            memo=None,
+        ))
+        resp = client.post("/pipeline?ticker=AAPL", json={
+            "tasks": [
+                {"agent_name": "macro_regime", "prompt": "classify", "task_id": "t1"},
+            ],
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["successful"] == 1
+        assert data["total_duration_ms"] == 150
+
+    def test_run_pipeline_unknown_agent_400(self, client):
+        resp = client.post("/pipeline", json={
+            "tasks": [
+                {"agent_name": "nonexistent_agent", "prompt": "test"},
+            ],
+        })
+        assert resp.status_code == 400
+        assert "nonexistent_agent" in resp.json()["detail"]
+
+    def test_run_pipeline_empty_agent_name_422(self, client):
+        resp = client.post("/pipeline", json={
+            "tasks": [
+                {"agent_name": "", "prompt": "test"},
+            ],
+        })
+        assert resp.status_code == 422
+
+
+class TestDigestEndpoint:
+    @patch("src.web_api.DigestService")
+    def test_run_digest_success(self, mock_cls, client):
+        mock_svc = mock_cls.return_value
+        mock_svc.run_digest = AsyncMock(return_value=RunDigestResponse(
+            ticker_count=2,
+            entry_count=5,
+            alert_count=1,
+            material_count=1,
+            content="AAPL: positive; MSFT: neutral",
+        ))
+        resp = client.post("/digest", json={
+            "tickers": ["AAPL", "MSFT"],
+            "lookback_days": 7,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ticker_count"] == 2
+        assert data["entry_count"] == 5
+
+    @patch("src.web_api.DigestService")
+    def test_run_digest_custom_threshold(self, mock_cls, client):
+        mock_svc = mock_cls.return_value
+        mock_svc.run_digest = AsyncMock(return_value=RunDigestResponse(
+            ticker_count=1, entry_count=0, alert_count=0,
+            material_count=0, content="No material changes",
+        ))
+        resp = client.post("/digest", json={
+            "tickers": ["IVV"],
+            "alert_threshold": "0.8",
+        })
+        assert resp.status_code == 200
+        call_req = mock_svc.run_digest.call_args[0][0]
+        assert call_req.alert_threshold == Decimal("0.8")
+
+
+# --- Error Handling ---
+
+
+class TestErrorHandling:
+    @patch("src.web_api.AgentService")
+    def test_domain_value_error_returns_400(self, mock_cls, client):
+        mock_svc = mock_cls.return_value
+        mock_svc.analyze_earnings = AsyncMock(
+            side_effect=ValueError("Invalid transcript format")
+        )
+        resp = client.post("/agents/earnings_interpreter", json={
+            "transcript": "some text",
+        })
+        assert resp.status_code == 400
+        assert "Invalid transcript format" in resp.json()["detail"]
+
+
+# --- CORS ---
+
+
+class TestCORS:
+    def test_preflight_options_returns_cors_headers(self, client):
+        resp = client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.headers.get("access-control-allow-origin") is not None
+        assert "GET" in resp.headers.get("access-control-allow-methods", "")
+
+    def test_response_includes_cors_header(self, client):
+        resp = client.get("/health", headers={"Origin": "http://localhost:3000"})
+        assert resp.headers.get("access-control-allow-origin") is not None

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -80,6 +80,43 @@ python -m src.mcp_server  # direct invocation
 - **Agent validation** — `orchestrate` rejects unknown agent names upfront (no silent skip)
 - **LLM gateway skipped** — host LLM reasons; agents return structured data
 
+## Web API (FastAPI)
+
+The Web API (`agents/src/web_api.py`) exposes the same application layer services as the MCP server, but over HTTP/REST for web frontends and programmatic access.
+
+### Running
+
+```bash
+cd agents && source .venv/bin/activate
+finance-os-api            # via console script (127.0.0.1:8000)
+uvicorn src.web_api:app --reload  # development mode
+```
+
+### Endpoint Catalog
+
+| Endpoint | Wraps | Purpose |
+|---|---|---|
+| `POST /agents/earnings_interpreter` | `AgentService.analyze_earnings()` | Earnings transcript analysis — tone, sentiment, guidance |
+| `POST /agents/macro_regime` | `AgentService.classify_macro()` | Macro regime classification from FRED data |
+| `POST /agents/filing_analyst` | `AgentService.search_filings()` | SEC filing search |
+| `POST /agents/quant_signal` | `AgentService.generate_signals()` | Quant signal generation |
+| `POST /agents/thesis_guardian` | `AgentService.evaluate_thesis()` | Thesis evaluation |
+| `POST /agents/risk_analyst` | `AgentService.assess_risk()` | Portfolio risk analysis |
+| `POST /agents/adversarial` | `AgentService.challenge_thesis()` | Adversarial thesis challenge |
+| `POST /pipeline` | `PipelineService.run_pipeline()` | Multi-agent pipeline with dependency ordering |
+| `POST /digest` | `DigestService.run_digest()` | Watchlist digest — materiality scoring, alerts |
+| `GET /agents` | `AGENT_CATALOG` | List available agents |
+| `GET /health` | — | Health check |
+
+### Design
+
+- **Per-request services** — fresh agent instances per request to avoid state leakage
+- **Pydantic contracts** — same request/response models as MCP server; FastAPI auto-validates and generates OpenAPI schema
+- **Lazy config** — `AppConfig` via `@lru_cache`, injected into services on each request
+- **Error mapping** — domain `ValueError` → HTTP 400; Pydantic validation → 422
+- **CORS** — enabled for local frontend development
+- **LLM gateway available** — Web API path can invoke LLM gateway for synthesis (unlike MCP path)
+
 ## Research Pipeline
 
 The `ResearchPipeline` (`agents/src/pipelines/research_digest.py`) automates analysis:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,11 +5,11 @@
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │                        UX Layer                              │
-│  Copilot CLI │ Agent CLI │ Copilot Skills │ Web UI (future)  │
+│  Copilot CLI │ Agent CLI │ Copilot Skills │ Web API │ Web UI (future)  │
 ├──────────────────────────────────────────────────────────────┤
 │                    Interface Layer                            │
 │  TS MCP Server (data tools) │ Python MCP Server (agents)     │
-│                             │ Web API / FastAPI (future)      │
+│                             │ FastAPI Web API                 │
 ├──────────────────────────────────────────────────────────────┤
 │                  Application Layer                            │
 │  Pydantic Contracts │ LLM Gateway │ Agent Services            │
@@ -122,7 +122,7 @@ The LLM gateway is a first-class component in the application layer. It resolves
 | **MCP** (Copilot, Claude Desktop) | Host LLM | `SkipProvider` (no-op) | Included in host |
 | **CLI** (no `--synthesize`) | Nobody — raw output | Not called | Zero |
 | **CLI** (`--synthesize`) | LLM via gateway | `LiteLLMProvider` | Pay-per-call |
-| **Web API** (future) | LLM via gateway | `LiteLLMProvider` | Pay-per-call |
+| **Web API** | LLM via gateway | `LiteLLMProvider` | Pay-per-call |
 
 ## Data Flow
 
@@ -170,7 +170,7 @@ The shared core that all interfaces wrap. Implemented as:
   - `DigestService` — wraps research pipeline with typed I/O
 - **Config** (`config.py`) — `AppConfig` via pydantic-settings. Loads from `~/.config/finance-os/config.json` (user settings) and `FINANCE_OS_*` environment variables (highest priority).
 
-CLI, Python MCP server, and future Web API are thin wrappers over this layer.
+CLI, Python MCP server, and Web API are thin wrappers over this layer.
 
 ### Agent Framework (`agents/`)
 
@@ -202,9 +202,16 @@ Shared prompt templates organized by strategy:
 | 0 | Repository foundation, MCP server, agent framework | ✅ Complete |
 | 1 | Core tools and agents (SEC, earnings, macro, quant, portfolio) | ✅ Complete |
 | 2 | Intelligence layer (thesis, risk, adversarial, orchestrator, pipeline) | ✅ Complete |
-| 3 | Integration layer (application layer + LLM gateway, CLI, Python MCP, Skills) | 🔧 In Progress |
+| 3 | Integration layer (application layer + LLM gateway, CLI, Python MCP, Skills) | ✅ Complete |
 | 4 | Advanced (knowledge graph, alt data, fine-tuning) — Copilot-first | Planned |
-| 5 | Web layer (FastAPI + Web UI) — after Copilot CLI is mostly complete | Planned |
+| 5 | Web layer (FastAPI + Web UI) | 🔧 In Progress |
+
+### Phase 5 Progress
+
+| Component | Issue | Status |
+|---|---|---|
+| Web API (FastAPI) | #58 | ✅ Complete |
+| Web UI | #57 | Planned |
 
 ### Phase 3 Progress
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,7 @@ Host LLM ──→ MCP Protocol ──→ TS MCP Server ──→ Data Tools (Ya
                                                   (gateway skipped)
 ```
 
-### Direct Path (CLI / future Web)
+### Direct Path (CLI / Web API)
 ```
 User ──→ CLI / Web API ──→ Application Layer ──→ Agents ──→ structured data
                                 │                              │
@@ -144,6 +144,27 @@ User ──→ CLI / Web API ──→ Application Layer ──→ Agents ──
                                         │
                                         ↓
                                  synthesized output
+```
+
+### Web API Path Detail
+```
+Client ──→ HTTP request ──→ FastAPI ──→ Application Layer ──→ Agents
+  ↑           (JSON)           │              │                  │
+  │                            │         AppConfig               │
+  │                            │         (@lru_cache)            │
+  │                            │              │                  │
+  │                            │         Fresh service           │
+  │                            │         per request             │
+  │                            │              │                  │
+  │                            ↓              ↓                  │
+  │                      Pydantic         AgentService /         │
+  │                      validation       PipelineService /      │
+  │                      (422 on fail)    DigestService           │
+  │                            │              │                  │
+  │                            │         ValueError ──→ 400      │
+  │                            │              │                  │
+  │                            ↓              ↓                  │
+  └──── JSON response ←── model_dump(mode="json") ←─────────────┘
 ```
 
 ## Component Details
@@ -171,6 +192,38 @@ The shared core that all interfaces wrap. Implemented as:
 - **Config** (`config.py`) — `AppConfig` via pydantic-settings. Loads from `~/.config/finance-os/config.json` (user settings) and `FINANCE_OS_*` environment variables (highest priority).
 
 CLI, Python MCP server, and Web API are thin wrappers over this layer.
+
+### Web API (`agents/src/web_api.py`)
+
+FastAPI REST service exposing the application layer over HTTP. Same shared services as CLI and MCP server — the Web API is the third thin wrapper.
+
+**Entry points:**
+- `finance-os-api` — console script (uvicorn on 127.0.0.1:8000)
+- `uvicorn src.web_api:app --reload` — development mode
+
+**Endpoints:**
+
+| Method | Path | Service | Description |
+|--------|------|---------|-------------|
+| GET | `/health` | — | Health check |
+| GET | `/agents` | — | List agent catalog |
+| POST | `/agents/earnings_interpreter` | `AgentService.analyze_earnings()` | Earnings transcript analysis |
+| POST | `/agents/macro_regime` | `AgentService.classify_macro()` | Macro regime classification |
+| POST | `/agents/filing_analyst` | `AgentService.search_filings()` | SEC filing search |
+| POST | `/agents/quant_signal` | `AgentService.generate_signals()` | Quant signal generation |
+| POST | `/agents/thesis_guardian` | `AgentService.evaluate_thesis()` | Thesis evaluation |
+| POST | `/agents/risk_analyst` | `AgentService.assess_risk()` | Portfolio risk analysis |
+| POST | `/agents/adversarial` | `AgentService.challenge_thesis()` | Adversarial challenge |
+| POST | `/pipeline` | `PipelineService.run_pipeline()` | Multi-agent pipeline |
+| POST | `/digest` | `DigestService.run_digest()` | Research digest |
+
+**Design:**
+- **Per-request services** — fresh `AgentService` / `PipelineService` / `DigestService` per request (agents maintain internal history, so shared instances would leak state)
+- **Lazy config** — `AppConfig` loaded via `@lru_cache` on first request, not at import time
+- **Pydantic validation** — request bodies auto-validated by FastAPI; invalid input → 422
+- **Domain errors** — `ValueError` from agents mapped to HTTP 400 (not 500)
+- **CORS** — enabled for local frontend development (`allow_origins=["*"]`)
+- **OpenAPI** — auto-generated schema at `/docs` (Swagger UI) and `/redoc`
 
 ### Agent Framework (`agents/`)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -114,5 +114,44 @@ When called via MCP, the host LLM does the reasoning — the LLM gateway is **sk
 1. If the agent exists, add a contract pair in `agents/src/application/contracts/agents.py`
 2. Add a service method in `agents/src/application/services/agent_service.py`
 3. Add a `@mcp.tool()` function in `agents/src/mcp_server.py`
-4. Register the agent in `agents/src/application/registry.py` (if new agent)
-5. Add tests in `agents/tests/test_services.py` and `agents/tests/test_mcp_server.py`
+4. Add a `@app.post()` route in `agents/src/web_api.py`
+5. Register the agent in `agents/src/application/registry.py` (if new agent)
+6. Add tests in `agents/tests/test_services.py`, `agents/tests/test_mcp_server.py`, and `agents/tests/test_web_api.py`
+
+## Web API (REST)
+
+The Web API (`agents/src/web_api.py`) exposes the same application services as the Python MCP server, but over HTTP/REST. It uses the same Pydantic contracts for request/response validation.
+
+### Running
+
+```bash
+finance-os-api                        # console script (127.0.0.1:8000)
+uvicorn src.web_api:app --reload      # development mode with auto-reload
+```
+
+### REST Endpoint Catalog
+
+| Method | Path | Contract | Purpose | Status |
+|--------|------|----------|---------|--------|
+| GET | `/health` | — | Health check | ✅ |
+| GET | `/agents` | — | List available agents | ✅ |
+| POST | `/agents/earnings_interpreter` | `AnalyzeEarningsRequest/Response` | Earnings transcript analysis | ✅ |
+| POST | `/agents/macro_regime` | `ClassifyMacroRequest/Response` | Macro regime classification | ✅ |
+| POST | `/agents/filing_analyst` | `SearchFilingsRequest/Response` | SEC filing search | ✅ |
+| POST | `/agents/quant_signal` | `GenerateSignalsRequest/Response` | Quant signal generation | ✅ |
+| POST | `/agents/thesis_guardian` | `EvaluateThesisRequest/Response` | Thesis evaluation | ✅ |
+| POST | `/agents/risk_analyst` | `AssessRiskRequest/Response` | Portfolio risk analysis | ✅ |
+| POST | `/agents/adversarial` | `ChallengeThesisRequest/Response` | Adversarial thesis challenge | ✅ |
+| POST | `/pipeline` | `RunPipelineRequest/Response` | Multi-agent pipeline | ✅ |
+| POST | `/digest` | `RunDigestRequest/Response` | Research digest | ✅ |
+
+### Design differences from MCP server
+
+| Aspect | MCP Server | Web API |
+|--------|-----------|---------|
+| Transport | stdio (MCP protocol) | HTTP/REST (JSON) |
+| Client | LLM host (Copilot, Claude) | Web browser, curl, frontend |
+| LLM gateway | Skipped (host LLM reasons) | Available for synthesis |
+| Discovery | MCP tool listing | OpenAPI schema at `/docs` |
+| Error format | MCP error response | HTTP status codes (400/422/500) |
+| Config injection | Per-call `AppConfig()` | Lazy `@lru_cache` singleton |


### PR DESCRIPTION
## Summary

REST API wrapping the application layer (same shared core as CLI and MCP server) via FastAPI.

### Endpoints

| Method | Path | Service | Description |
|--------|------|---------|-------------|
| GET | `/health` | — | Health check |
| GET | `/agents` | — | List available agents |
| POST | `/agents/earnings_interpreter` | AgentService | Earnings transcript analysis |
| POST | `/agents/macro_regime` | AgentService | Macro regime classification |
| POST | `/agents/filing_analyst` | AgentService | SEC filing search |
| POST | `/agents/quant_signal` | AgentService | Quant signal generation |
| POST | `/agents/thesis_guardian` | AgentService | Thesis evaluation |
| POST | `/agents/risk_analyst` | AgentService | Risk assessment |
| POST | `/agents/adversarial` | AgentService | Adversarial thesis challenge |
| POST | `/pipeline` | PipelineService | Multi-agent pipeline |
| POST | `/digest` | DigestService | Research digest |

### Design

- Fresh service instances per request (avoids cross-request state leakage)
- Lazy-cached `AppConfig` via `@lru_cache` (testable, no import-time side effects)
- Domain `ValueError` → HTTP 400, validation errors → 422 (FastAPI default)
- CORS enabled for local frontend development
- Pydantic contracts auto-generate OpenAPI schema at `/docs`
- Console script: `finance-os-api` (uvicorn on 127.0.0.1:8000)

### Tests

19 unit tests covering all endpoints, validation, error handling, and CORS preflight.

### Dependencies Added

- `fastapi>=0.115.0`
- `uvicorn[standard]>=0.34.0`

Closes #58