### PR TITLE
feat: Knowledge graph — entity extraction and relationship mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ React frontend consuming the Web API. Requires the API server to be running.
 # Terminal 1 — start the API server
 cd agents && source .venv/bin/activate && finance-os-api
 
-# Terminal 2 — start the frontend dev server
+# Terminal 2 — install dependencies and start the frontend dev server
 cd web-ui
+npm install
 npm run dev    # opens http://localhost:5173 with API proxy
 ```
 

--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ curl -X POST http://127.0.0.1:8000/agents/filing_analyst \
 React frontend consuming the Web API. Requires the API server to be running.
 
 ```bash
-# Start the API server first (in a separate terminal)
+# Terminal 1 — start the API server
 cd agents && source .venv/bin/activate && finance-os-api
 
-# Start the frontend dev server
+# Terminal 2 — start the frontend dev server
 cd web-ui
 npm run dev    # opens http://localhost:5173 with API proxy
 ```

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "mcp>=1.27.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
+    "networkx>=3.4",
 ]
 
 [project.optional-dependencies]

--- a/agents/src/application/contracts/knowledge_graph.py
+++ b/agents/src/application/contracts/knowledge_graph.py
@@ -1,0 +1,119 @@
+"""Pydantic request/response contracts for the knowledge graph.
+
+Contracts for entity extraction, graph queries, and graph statistics.
+"""
+
+from pydantic import BaseModel, Field
+
+# ── Entity / Relationship serialization ──────────────────────
+
+
+class EntityModel(BaseModel):
+    """Serialized entity for API responses."""
+
+    entity_id: str
+    name: str
+    entity_type: str
+    ticker: str | None = None
+    cik: str | None = None
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+
+class RelationshipModel(BaseModel):
+    """Serialized relationship for API responses."""
+
+    source_id: str
+    target_id: str
+    rel_type: str
+    evidence: str = ""
+    source_doc: str = ""
+    confidence: str = "0.5"
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+
+# ── Extract ──────────────────────────────────────────────────
+
+
+class ExtractEntitiesRequest(BaseModel):
+    """Request to extract entities and relationships from text."""
+
+    text: str = Field(min_length=1, description="Text to extract entities from")
+    source_doc: str = Field(default="", description="Source document identifier for provenance")
+    ticker: str | None = Field(
+        default=None, description="Company ticker to associate with extraction",
+    )
+
+
+class ExtractEntitiesResponse(BaseModel):
+    """Response from entity extraction."""
+
+    entities: list[EntityModel]
+    relationships: list[RelationshipModel]
+    entity_count: int
+    relationship_count: int
+
+
+# ── Query: Related ───────────────────────────────────────────
+
+
+class QueryRelatedRequest(BaseModel):
+    """Request to find entities related to a given entity."""
+
+    entity_id: str = Field(min_length=1, description="Canonical entity ID to query from")
+    max_depth: int = Field(default=2, ge=1, le=5, description="Maximum traversal depth")
+
+
+class QueryRelatedResponse(BaseModel):
+    """Response with related entities."""
+
+    entity_id: str
+    related: list[EntityModel]
+    count: int
+
+
+# ── Query: Supply Chain ──────────────────────────────────────
+
+
+class QuerySupplyChainRequest(BaseModel):
+    """Request to trace the supply chain from an entity."""
+
+    entity_id: str = Field(min_length=1, description="Canonical entity ID to trace from")
+    direction: str = Field(default="upstream", pattern="^(upstream|downstream)$")
+
+
+class QuerySupplyChainResponse(BaseModel):
+    """Response with supply chain trace."""
+
+    entity_id: str
+    direction: str
+    chain: list[EntityModel]
+    count: int
+
+
+# ── Query: Shared Risks ──────────────────────────────────────
+
+
+class QuerySharedRisksRequest(BaseModel):
+    """Request to find risks shared by multiple entities."""
+
+    entity_ids: list[str] = Field(min_length=2, description="At least two entity IDs")
+
+
+class QuerySharedRisksResponse(BaseModel):
+    """Response with shared risk entities."""
+
+    entity_ids: list[str]
+    shared_risks: list[EntityModel]
+    count: int
+
+
+# ── Stats ─────────────────────────────────────────────────────
+
+
+class KGStatsResponse(BaseModel):
+    """Knowledge graph summary statistics."""
+
+    entity_count: int
+    relationship_count: int
+    entities_by_type: dict[str, int]
+    relationships_by_type: dict[str, int]

--- a/agents/src/application/services/kg_service.py
+++ b/agents/src/application/services/kg_service.py
@@ -1,0 +1,173 @@
+"""Knowledge graph service — entity extraction, ingestion, and graph queries.
+
+Process-level graph store: the KnowledgeGraph persists across requests
+within the same process (like a database connection), unlike agent services
+which are fresh per request.
+"""
+
+from src.application.contracts.knowledge_graph import (
+    EntityModel,
+    ExtractEntitiesRequest,
+    ExtractEntitiesResponse,
+    KGStatsResponse,
+    QueryRelatedRequest,
+    QueryRelatedResponse,
+    QuerySharedRisksRequest,
+    QuerySharedRisksResponse,
+    QuerySupplyChainRequest,
+    QuerySupplyChainResponse,
+    RelationshipModel,
+)
+from src.core.entity_extraction import extract_entities, extract_relationships
+from src.core.knowledge_graph import Entity, KnowledgeGraph, Relationship
+
+
+def _entity_to_model(entity: Entity) -> EntityModel:
+    """Convert core Entity to API model."""
+    return EntityModel(
+        entity_id=entity.entity_id,
+        name=entity.name,
+        entity_type=entity.entity_type.value,
+        ticker=entity.ticker,
+        cik=entity.cik,
+        metadata=entity.metadata,
+    )
+
+
+def _rel_to_model(rel: Relationship) -> RelationshipModel:
+    """Convert core Relationship to API model."""
+    return RelationshipModel(
+        source_id=rel.source_id,
+        target_id=rel.target_id,
+        rel_type=rel.rel_type.value,
+        evidence=rel.evidence,
+        source_doc=rel.source_doc,
+        confidence=str(rel.confidence),
+        metadata=rel.metadata,
+    )
+
+
+class KnowledgeGraphService:
+    """Service layer for knowledge graph operations.
+
+    Wraps a KnowledgeGraph instance and provides typed contract-based
+    methods for extraction, querying, and statistics.
+    """
+
+    def __init__(self, graph: KnowledgeGraph | None = None) -> None:
+        self._graph = graph or KnowledgeGraph()
+
+    @property
+    def graph(self) -> KnowledgeGraph:
+        """Access the underlying graph (for testing/inspection)."""
+        return self._graph
+
+    def extract_and_ingest(self, request: ExtractEntitiesRequest) -> ExtractEntitiesResponse:
+        """Extract entities and relationships from text and add them to the graph.
+
+        Args:
+            request: Extraction request with text and provenance info.
+
+        Returns:
+            Response with extracted entities and relationships.
+        """
+        entities = extract_entities(request.text, source_doc=request.source_doc)
+
+        # If a ticker is provided, try to associate it with the first company entity
+        if request.ticker:
+            promoted: list[Entity] = []
+            ticker_assigned = False
+            for ent in entities:
+                if ent.entity_type.value == "company" and not ticker_assigned and not ent.ticker:
+                    promoted.append(Entity(
+                        name=ent.name,
+                        entity_type=ent.entity_type,
+                        ticker=request.ticker.upper(),
+                        cik=ent.cik,
+                        metadata=ent.metadata,
+                    ))
+                    ticker_assigned = True
+                else:
+                    promoted.append(ent)
+            entities = promoted
+
+        # Add entities to graph
+        entity_ids: dict[str, str] = {}
+        for ent in entities:
+            eid = self._graph.add_entity(ent)
+            entity_ids[ent.entity_id] = eid
+
+        # Extract and add relationships
+        relationships = extract_relationships(
+            request.text, entities, source_doc=request.source_doc,
+        )
+
+        added_rels: list[Relationship] = []
+        for rel in relationships:
+            src = entity_ids.get(rel.source_id, rel.source_id)
+            tgt = entity_ids.get(rel.target_id, rel.target_id)
+            if src in self._graph._graph and tgt in self._graph._graph:
+                mapped_rel = Relationship(
+                    source_id=src,
+                    target_id=tgt,
+                    rel_type=rel.rel_type,
+                    evidence=rel.evidence,
+                    source_doc=rel.source_doc,
+                    confidence=rel.confidence,
+                    metadata=rel.metadata,
+                )
+                self._graph.add_relationship(mapped_rel)
+                added_rels.append(mapped_rel)
+
+        entity_models = [_entity_to_model(e) for e in entities]
+        rel_models = [_rel_to_model(r) for r in added_rels]
+
+        return ExtractEntitiesResponse(
+            entities=entity_models,
+            relationships=rel_models,
+            entity_count=len(entity_models),
+            relationship_count=len(rel_models),
+        )
+
+    def query_related(self, request: QueryRelatedRequest) -> QueryRelatedResponse:
+        """Find entities related to a given entity."""
+        related = self._graph.find_related(request.entity_id, max_depth=request.max_depth)
+        models = [_entity_to_model(e) for e in related]
+        return QueryRelatedResponse(
+            entity_id=request.entity_id,
+            related=models,
+            count=len(models),
+        )
+
+    def query_supply_chain(self, request: QuerySupplyChainRequest) -> QuerySupplyChainResponse:
+        """Trace the supply chain from an entity."""
+        chain = self._graph.trace_supply_chain(
+            request.entity_id, direction=request.direction,
+        )
+        models = [_entity_to_model(e) for e in chain]
+        return QuerySupplyChainResponse(
+            entity_id=request.entity_id,
+            direction=request.direction,
+            chain=models,
+            count=len(models),
+        )
+
+    def query_shared_risks(self, request: QuerySharedRisksRequest) -> QuerySharedRisksResponse:
+        """Find risks shared across multiple entities."""
+        shared = self._graph.find_shared_risks(request.entity_ids)
+        models = [_entity_to_model(e) for e in shared]
+        return QuerySharedRisksResponse(
+            entity_ids=request.entity_ids,
+            shared_risks=models,
+            count=len(models),
+        )
+
+    def get_stats(self) -> KGStatsResponse:
+        """Get summary statistics of the knowledge graph."""
+        s = self._graph.stats()
+        return KGStatsResponse(
+            entity_count=s["entity_count"],
+            relationship_count=s["relationship_count"],
+            entities_by_type=s["entities_by_type"],
+            relationships_by_type=s["relationships_by_type"],
+        )

--- a/agents/src/application/services/kg_service.py
+++ b/agents/src/application/services/kg_service.py
@@ -106,18 +106,20 @@ class KnowledgeGraphService:
         for rel in relationships:
             src = entity_ids.get(rel.source_id, rel.source_id)
             tgt = entity_ids.get(rel.target_id, rel.target_id)
-            if src in self._graph._graph and tgt in self._graph._graph:
-                mapped_rel = Relationship(
-                    source_id=src,
-                    target_id=tgt,
-                    rel_type=rel.rel_type,
-                    evidence=rel.evidence,
-                    source_doc=rel.source_doc,
-                    confidence=rel.confidence,
-                    metadata=rel.metadata,
-                )
+            mapped_rel = Relationship(
+                source_id=src,
+                target_id=tgt,
+                rel_type=rel.rel_type,
+                evidence=rel.evidence,
+                source_doc=rel.source_doc,
+                confidence=rel.confidence,
+                metadata=rel.metadata,
+            )
+            try:
                 self._graph.add_relationship(mapped_rel)
-                added_rels.append(mapped_rel)
+            except ValueError:
+                continue
+            added_rels.append(mapped_rel)
 
         entity_models = [_entity_to_model(e) for e in entities]
         rel_models = [_rel_to_model(r) for r in added_rels]

--- a/agents/src/application/services/kg_service.py
+++ b/agents/src/application/services/kg_service.py
@@ -5,6 +5,8 @@ within the same process (like a database connection), unlike agent services
 which are fresh per request.
 """
 
+import logging
+
 from src.application.contracts.knowledge_graph import (
     EntityModel,
     ExtractEntitiesRequest,
@@ -53,6 +55,8 @@ class KnowledgeGraphService:
     Wraps a KnowledgeGraph instance and provides typed contract-based
     methods for extraction, querying, and statistics.
     """
+
+    _logger = logging.getLogger(__name__)
 
     def __init__(self, graph: KnowledgeGraph | None = None) -> None:
         self._graph = graph or KnowledgeGraph()
@@ -118,6 +122,10 @@ class KnowledgeGraphService:
             try:
                 self._graph.add_relationship(mapped_rel)
             except ValueError:
+                self._logger.warning(
+                    "Dropped relationship %s -> %s (%s): missing entity in graph",
+                    src, tgt, rel.rel_type.value,
+                )
                 continue
             added_rels.append(mapped_rel)
 

--- a/agents/src/application/services/kg_service.py
+++ b/agents/src/application/services/kg_service.py
@@ -21,7 +21,7 @@ from src.application.contracts.knowledge_graph import (
     RelationshipModel,
 )
 from src.core.entity_extraction import extract_entities, extract_relationships
-from src.core.knowledge_graph import Entity, KnowledgeGraph, Relationship
+from src.core.knowledge_graph import Entity, EntityType, KnowledgeGraph, Relationship
 
 
 def _entity_to_model(entity: Entity) -> EntityModel:
@@ -82,7 +82,7 @@ class KnowledgeGraphService:
             promoted: list[Entity] = []
             ticker_assigned = False
             for ent in entities:
-                if ent.entity_type.value == "company" and not ticker_assigned and not ent.ticker:
+                if ent.entity_type == EntityType.COMPANY and not ticker_assigned and not ent.ticker:
                     promoted.append(Entity(
                         name=ent.name,
                         entity_type=ent.entity_type,

--- a/agents/src/core/entity_extraction.py
+++ b/agents/src/core/entity_extraction.py
@@ -17,12 +17,6 @@ from src.core.knowledge_graph import (
 
 # ── Company patterns ─────────────────────────────────────────
 
-_TICKER_PATTERN = re.compile(
-    r"\b([A-Z]{1,5})\b"
-    r"(?=\s*\(|,|\s+(?:Inc|Corp|Ltd|LLC|Company|Co\.|Group|Holdings|Enterprises))",
-    re.IGNORECASE,
-)
-
 _COMPANY_SUFFIX_PATTERN = re.compile(
     r"\b([A-Z][A-Za-z&\s]+?)"
     r"\s*(?:Inc\.?|Corp\.?|Corporation|Ltd\.?|LLC|Company|Co\.|Group|Holdings|Enterprises)"

--- a/agents/src/core/entity_extraction.py
+++ b/agents/src/core/entity_extraction.py
@@ -220,7 +220,7 @@ def extract_relationships(
     # Build entity mention positions
     entity_positions: list[tuple[int, int, Entity]] = []
     for entity in entities:
-        pattern = re.compile(re.escape(entity.name), re.IGNORECASE)
+        pattern = re.compile(r"\b" + re.escape(entity.name) + r"\b", re.IGNORECASE)
         for match in pattern.finditer(text):
             entity_positions.append((match.start(), match.end(), entity))
     entity_positions.sort(key=lambda x: x[0])

--- a/agents/src/core/entity_extraction.py
+++ b/agents/src/core/entity_extraction.py
@@ -1,0 +1,280 @@
+"""Entity and relationship extraction from financial text.
+
+v1 uses high-precision regex patterns and keyword taxonomies.
+Designed for low recall, high precision — every extraction carries
+provenance (evidence text and source document).
+"""
+
+import re
+from decimal import Decimal
+
+from src.core.knowledge_graph import (
+    Entity,
+    EntityType,
+    Relationship,
+    RelationshipType,
+)
+
+# ── Company patterns ─────────────────────────────────────────
+
+_TICKER_PATTERN = re.compile(
+    r"\b([A-Z]{1,5})\b"
+    r"(?=\s*\(|,|\s+(?:Inc|Corp|Ltd|LLC|Company|Co\.|Group|Holdings|Enterprises))",
+    re.IGNORECASE,
+)
+
+_COMPANY_SUFFIX_PATTERN = re.compile(
+    r"\b([A-Z][A-Za-z&\s]+?)"
+    r"\s*(?:Inc\.?|Corp\.?|Corporation|Ltd\.?|LLC|Company|Co\.|Group|Holdings|Enterprises)"
+    r"\b",
+)
+
+# ── Risk taxonomy ─────────────────────────────────────────────
+
+_RISK_KEYWORDS: dict[str, str] = {
+    "supply chain disruption": "supply_chain",
+    "supply chain risk": "supply_chain",
+    "cybersecurity": "cybersecurity",
+    "cyber risk": "cybersecurity",
+    "data breach": "cybersecurity",
+    "regulatory risk": "regulatory",
+    "regulatory change": "regulatory",
+    "compliance risk": "regulatory",
+    "interest rate risk": "market",
+    "currency risk": "market",
+    "foreign exchange risk": "market",
+    "inflation risk": "market",
+    "credit risk": "credit",
+    "counterparty risk": "credit",
+    "litigation risk": "legal",
+    "legal proceedings": "legal",
+    "geopolitical risk": "geopolitical",
+    "climate risk": "environmental",
+    "environmental risk": "environmental",
+    "concentration risk": "concentration",
+    "liquidity risk": "liquidity",
+}
+
+_RISK_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(k) for k in _RISK_KEYWORDS) + r")\b",
+    re.IGNORECASE,
+)
+
+# ── Technology patterns ───────────────────────────────────────
+
+_TECH_KEYWORDS = [
+    "artificial intelligence",
+    "machine learning",
+    "cloud computing",
+    "blockchain",
+    "5G",
+    "IoT",
+    "quantum computing",
+    "edge computing",
+    "SaaS",
+    "PaaS",
+    "IaaS",
+    "ERP",
+    "CRM",
+    "API",
+    "microservices",
+]
+
+_TECH_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(k) for k in _TECH_KEYWORDS) + r")\b",
+    re.IGNORECASE,
+)
+
+# ── Relationship patterns ────────────────────────────────────
+
+_RELATIONSHIP_PATTERNS: list[tuple[re.Pattern[str], RelationshipType, str]] = [
+    (
+        re.compile(r"(?:supplier|supplies|supply)\s+\w*\s*(?:to|of|for)\b", re.IGNORECASE),
+        RelationshipType.SUPPLIER,
+        "outgoing",
+    ),
+    (
+        re.compile(r"(?:sourced?|procured?|purchased?)\s+from\b", re.IGNORECASE),
+        RelationshipType.SUPPLIER,
+        "incoming",
+    ),
+    (
+        re.compile(r"\bcompete[sd]?\s+with\b", re.IGNORECASE),
+        RelationshipType.COMPETITOR,
+        "outgoing",
+    ),
+    (
+        re.compile(r"\bcustomer\s+of\b", re.IGNORECASE),
+        RelationshipType.CUSTOMER,
+        "outgoing",
+    ),
+    (
+        re.compile(r"\bsubsidiary\s+of\b", re.IGNORECASE),
+        RelationshipType.SUBSIDIARY,
+        "outgoing",
+    ),
+    (
+        re.compile(r"\bacquired?\b", re.IGNORECASE),
+        RelationshipType.SUBSIDIARY,
+        "incoming",
+    ),
+    (
+        re.compile(r"\bpartner(?:ship|ed|s)?\s+with\b", re.IGNORECASE),
+        RelationshipType.PARTNER,
+        "outgoing",
+    ),
+    (
+        re.compile(r"\buses?\b.*\b(?:technology|platform|software|system)\b", re.IGNORECASE),
+        RelationshipType.TECHNOLOGY_USER,
+        "outgoing",
+    ),
+    (
+        re.compile(r"\bsubject\s+to\b.*\bregulat", re.IGNORECASE),
+        RelationshipType.REGULATORY,
+        "outgoing",
+    ),
+]
+
+
+def _context_window(text: str, start: int, end: int, window: int = 100) -> str:
+    """Extract surrounding context for provenance."""
+    ctx_start = max(0, start - window)
+    ctx_end = min(len(text), end + window)
+    return text[ctx_start:ctx_end].strip()
+
+
+def extract_entities(text: str, source_doc: str = "") -> list[Entity]:
+    """Extract entities from financial text.
+
+    High-precision, low-recall: only extracts entities matching
+    well-defined patterns.
+
+    Args:
+        text: The text to extract from.
+        source_doc: Source document identifier for provenance.
+
+    Returns:
+        Deduplicated list of extracted entities.
+    """
+    seen: dict[str, Entity] = {}
+
+    # Companies via suffix pattern (e.g., "Apple Inc.")
+    for match in _COMPANY_SUFFIX_PATTERN.finditer(text):
+        name = match.group(0).strip()
+        entity = Entity(
+            name=name,
+            entity_type=EntityType.COMPANY,
+            metadata={"source_doc": source_doc, "evidence": _context_window(text, *match.span())},
+        )
+        key = entity.entity_id
+        if key not in seen:
+            seen[key] = entity
+
+    # Risks via taxonomy
+    for match in _RISK_PATTERN.finditer(text):
+        risk_name = match.group(1).lower()
+        category = _RISK_KEYWORDS.get(risk_name, "unknown")
+        entity = Entity(
+            name=risk_name,
+            entity_type=EntityType.RISK,
+            metadata={
+                "category": category,
+                "source_doc": source_doc,
+                "evidence": _context_window(text, *match.span()),
+            },
+        )
+        key = entity.entity_id
+        if key not in seen:
+            seen[key] = entity
+
+    # Technologies via keywords
+    for match in _TECH_PATTERN.finditer(text):
+        tech_name = match.group(1)
+        entity = Entity(
+            name=tech_name,
+            entity_type=EntityType.TECHNOLOGY,
+            metadata={"source_doc": source_doc, "evidence": _context_window(text, *match.span())},
+        )
+        key = entity.entity_id
+        if key not in seen:
+            seen[key] = entity
+
+    return list(seen.values())
+
+
+def extract_relationships(
+    text: str,
+    entities: list[Entity],
+    source_doc: str = "",
+) -> list[Relationship]:
+    """Extract relationships between entities found in text.
+
+    Scans for relationship indicator phrases near entity mentions.
+    Only creates relationships between entities already extracted.
+
+    Args:
+        text: The text to scan for relationship patterns.
+        entities: Entities previously extracted from the same text.
+        source_doc: Source document identifier for provenance.
+
+    Returns:
+        List of extracted relationships with evidence.
+    """
+    if len(entities) < 2:
+        return []
+
+    # Build entity mention positions
+    entity_positions: list[tuple[int, int, Entity]] = []
+    for entity in entities:
+        pattern = re.compile(re.escape(entity.name), re.IGNORECASE)
+        for match in pattern.finditer(text):
+            entity_positions.append((match.start(), match.end(), entity))
+    entity_positions.sort(key=lambda x: x[0])
+
+    relationships: list[Relationship] = []
+    seen_keys: set[str] = set()
+
+    for rel_pattern, rel_type, direction in _RELATIONSHIP_PATTERNS:
+        for match in rel_pattern.finditer(text):
+            rel_start, rel_end = match.span()
+
+            # Find nearest entity before and after the relationship phrase
+            before = [
+                (s, e, ent) for s, e, ent in entity_positions
+                if e <= rel_start and rel_start - e < 200
+            ]
+            after = [
+                (s, e, ent) for s, e, ent in entity_positions
+                if s >= rel_end and s - rel_end < 200
+            ]
+
+            if not before or not after:
+                continue
+
+            subject = before[-1][2]
+            obj = after[0][2]
+
+            if subject.entity_id == obj.entity_id:
+                continue
+
+            if direction == "outgoing":
+                src, tgt = subject.entity_id, obj.entity_id
+            else:
+                src, tgt = obj.entity_id, subject.entity_id
+
+            evidence = _context_window(text, rel_start, rel_end, window=150)
+            rel = Relationship(
+                source_id=src,
+                target_id=tgt,
+                rel_type=rel_type,
+                evidence=evidence,
+                source_doc=source_doc,
+                confidence=Decimal("0.6"),
+                metadata={},
+            )
+
+            if rel.edge_key not in seen_keys:
+                seen_keys.add(rel.edge_key)
+                relationships.append(rel)
+
+    return relationships

--- a/agents/src/core/entity_extraction.py
+++ b/agents/src/core/entity_extraction.py
@@ -20,7 +20,7 @@ from src.core.knowledge_graph import (
 _COMPANY_SUFFIX_PATTERN = re.compile(
     r"\b([A-Z][A-Za-z&\s]+?)"
     r"\s*(?:Inc\.?|Corp\.?|Corporation|Ltd\.?|LLC|Company|Co\.|Group|Holdings|Enterprises)"
-    r"\b",
+    r"(?:\b|(?=\s|$|,|;))",
 )
 
 # ── Risk taxonomy ─────────────────────────────────────────────
@@ -154,7 +154,7 @@ def extract_entities(text: str, source_doc: str = "") -> list[Entity]:
 
     # Companies via suffix pattern (e.g., "Apple Inc.")
     for match in _COMPANY_SUFFIX_PATTERN.finditer(text):
-        name = match.group(0).strip()
+        name = match.group(0).strip().rstrip(".")
         entity = Entity(
             name=name,
             entity_type=EntityType.COMPANY,

--- a/agents/src/core/knowledge_graph.py
+++ b/agents/src/core/knowledge_graph.py
@@ -107,7 +107,7 @@ class KnowledgeGraph:
             "entity_type": entity.entity_type.value,
             "ticker": entity.ticker,
             "cik": entity.cik,
-            "metadata": entity.metadata,
+            "metadata": dict(entity.metadata),
         }
         if eid in self._graph:
             # Merge metadata when same entity_id is added again
@@ -139,7 +139,7 @@ class KnowledgeGraph:
             evidence=rel.evidence,
             source_doc=rel.source_doc,
             confidence=str(rel.confidence),
-            metadata=rel.metadata,
+            metadata=dict(rel.metadata),
         )
         return key
 

--- a/agents/src/core/knowledge_graph.py
+++ b/agents/src/core/knowledge_graph.py
@@ -110,11 +110,11 @@ class KnowledgeGraph:
             "metadata": entity.metadata,
         }
         if eid in self._graph:
-            # Merge metadata, prefer new values
+            # Merge metadata when same entity_id is added again
             existing = self._graph.nodes[eid]
             merged_meta = {**existing.get("metadata", {}), **entity.metadata}
             attrs["metadata"] = merged_meta
-            # Promote ticker/cik if previously missing
+            # Enrich ticker/cik on the existing node if previously missing
             if entity.ticker and not existing.get("ticker"):
                 attrs["ticker"] = entity.ticker
             if entity.cik and not existing.get("cik"):
@@ -337,12 +337,14 @@ class KnowledgeGraph:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:
-        """Deserialize a graph from a dict."""
+        """Deserialize a graph from a dict (does not mutate the input)."""
         kg = cls()
         for node in data.get("entities", []):
+            node = dict(node)
             nid = node.pop("id")
             kg._graph.add_node(nid, **node)
         for edge in data.get("relationships", []):
+            edge = dict(edge)
             src = edge.pop("source")
             tgt = edge.pop("target")
             key = edge.pop("key", None)

--- a/agents/src/core/knowledge_graph.py
+++ b/agents/src/core/knowledge_graph.py
@@ -223,7 +223,7 @@ class KnowledgeGraph:
         """Find all entities reachable within max_depth hops (undirected traversal)."""
         if entity_id not in self._graph:
             return []
-        undirected = self._graph.to_undirected()
+        undirected = self._graph.to_undirected(as_view=True)
         visited: set[str] = set()
         frontier = {entity_id}
         for _ in range(max_depth):

--- a/agents/src/core/knowledge_graph.py
+++ b/agents/src/core/knowledge_graph.py
@@ -155,7 +155,7 @@ class KnowledgeGraph:
             entity_type=EntityType(data["entity_type"]),
             ticker=data.get("ticker"),
             cik=data.get("cik"),
-            metadata=data.get("metadata", {}),
+            metadata=dict(data.get("metadata", {})),
         )
 
     def find_by_name(self, name: str) -> Entity | None:
@@ -215,7 +215,7 @@ class KnowledgeGraph:
                 evidence=data.get("evidence", ""),
                 source_doc=data.get("source_doc", ""),
                 confidence=Decimal(data.get("confidence", "0.5")),
-                metadata=data.get("metadata", {}),
+                metadata=dict(data.get("metadata", {})),
             ))
         return result
 

--- a/agents/src/core/knowledge_graph.py
+++ b/agents/src/core/knowledge_graph.py
@@ -6,6 +6,7 @@ financial-domain query operations.
 
 import hashlib
 import json
+from collections import deque
 from dataclasses import dataclass, field
 from decimal import Decimal
 from enum import StrEnum
@@ -263,16 +264,16 @@ class KnowledgeGraph:
         Args:
             entity_id: Starting entity.
             direction: "upstream" follows SUPPLIER edges backward (who supplies to me),
-                       "downstream" follows CUSTOMER edges forward (who buys from me).
+                       "downstream" follows SUPPLIER edges forward (who I supply to).
         """
         if entity_id not in self._graph:
             return []
         chain: list[str] = []
         visited: set[str] = {entity_id}
-        frontier = [entity_id]
+        frontier: deque[str] = deque([entity_id])
 
         while frontier:
-            current = frontier.pop(0)
+            current = frontier.popleft()
             if direction == "upstream":
                 edges = self._graph.in_edges(current, data=True)
                 candidates = [
@@ -283,7 +284,7 @@ class KnowledgeGraph:
                 edges = self._graph.out_edges(current, data=True)
                 candidates = [
                     v for _, v, d in edges
-                    if d.get("rel_type") == RelationshipType.CUSTOMER.value
+                    if d.get("rel_type") == RelationshipType.SUPPLIER.value
                 ]
             for nid in candidates:
                 if nid not in visited:

--- a/agents/src/core/knowledge_graph.py
+++ b/agents/src/core/knowledge_graph.py
@@ -1,0 +1,371 @@
+"""Knowledge graph for company/entity relationship mapping.
+
+Wraps networkx.MultiDiGraph with typed entities, relationships, and
+financial-domain query operations.
+"""
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import StrEnum
+from typing import Any, Self
+
+import networkx as nx
+
+
+class EntityType(StrEnum):
+    """Types of entities in the knowledge graph."""
+
+    COMPANY = "company"
+    PRODUCT = "product"
+    RISK = "risk"
+    TECHNOLOGY = "technology"
+    PERSON = "person"
+    SECTOR = "sector"
+
+
+class RelationshipType(StrEnum):
+    """Types of directed relationships between entities.
+
+    Edge direction conventions (source → target):
+        SUPPLIER:        source supplies to target
+        CUSTOMER:        source is a customer of target
+        COMPETITOR:      source competes with target (bidirectional semantics)
+        TECHNOLOGY_USER: source uses technology target
+        REGULATORY:      source is subject to regulatory target
+        SUBSIDIARY:      source is a subsidiary of target
+        PARTNER:         source partners with target (bidirectional semantics)
+    """
+
+    SUPPLIER = "supplier"
+    CUSTOMER = "customer"
+    COMPETITOR = "competitor"
+    TECHNOLOGY_USER = "technology_user"
+    REGULATORY = "regulatory"
+    SUBSIDIARY = "subsidiary"
+    PARTNER = "partner"
+
+
+@dataclass(frozen=True)
+class Entity:
+    """A node in the knowledge graph."""
+
+    name: str
+    entity_type: EntityType
+    ticker: str | None = None
+    cik: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def entity_id(self) -> str:
+        """Canonical identity: ticker > cik > normalized name."""
+        if self.ticker:
+            return f"ticker:{self.ticker.upper()}"
+        if self.cik:
+            return f"cik:{self.cik}"
+        return f"name:{self.name.lower().strip()}"
+
+
+@dataclass(frozen=True)
+class Relationship:
+    """A directed edge in the knowledge graph with provenance."""
+
+    source_id: str
+    target_id: str
+    rel_type: RelationshipType
+    evidence: str = ""
+    source_doc: str = ""
+    confidence: Decimal = Decimal("0.5")
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def edge_key(self) -> str:
+        """Deterministic key for dedup across ingestions."""
+        raw = f"{self.source_id}|{self.target_id}|{self.rel_type.value}|{self.evidence}"
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+class KnowledgeGraph:
+    """In-memory knowledge graph backed by networkx.MultiDiGraph.
+
+    Supports multiple relationship types between the same entity pair,
+    provenance tracking, and financial-domain queries.
+    """
+
+    def __init__(self) -> None:
+        self._graph = nx.MultiDiGraph()
+
+    # ── Mutation ──────────────────────────────────────────────
+
+    def add_entity(self, entity: Entity) -> str:
+        """Add or update an entity node. Returns the entity_id."""
+        eid = entity.entity_id
+        attrs = {
+            "name": entity.name,
+            "entity_type": entity.entity_type.value,
+            "ticker": entity.ticker,
+            "cik": entity.cik,
+            "metadata": entity.metadata,
+        }
+        if eid in self._graph:
+            # Merge metadata, prefer new values
+            existing = self._graph.nodes[eid]
+            merged_meta = {**existing.get("metadata", {}), **entity.metadata}
+            attrs["metadata"] = merged_meta
+            # Promote ticker/cik if previously missing
+            if entity.ticker and not existing.get("ticker"):
+                attrs["ticker"] = entity.ticker
+            if entity.cik and not existing.get("cik"):
+                attrs["cik"] = entity.cik
+        self._graph.add_node(eid, **attrs)
+        return eid
+
+    def add_relationship(self, rel: Relationship) -> str:
+        """Add a relationship edge. Returns the edge key."""
+        if rel.source_id not in self._graph:
+            msg = f"Source entity '{rel.source_id}' not in graph"
+            raise ValueError(msg)
+        if rel.target_id not in self._graph:
+            msg = f"Target entity '{rel.target_id}' not in graph"
+            raise ValueError(msg)
+        key = rel.edge_key
+        self._graph.add_edge(
+            rel.source_id,
+            rel.target_id,
+            key=key,
+            rel_type=rel.rel_type.value,
+            evidence=rel.evidence,
+            source_doc=rel.source_doc,
+            confidence=str(rel.confidence),
+            metadata=rel.metadata,
+        )
+        return key
+
+    # ── Queries ───────────────────────────────────────────────
+
+    def get_entity(self, entity_id: str) -> Entity | None:
+        """Look up an entity by its canonical ID."""
+        if entity_id not in self._graph:
+            return None
+        data = self._graph.nodes[entity_id]
+        return Entity(
+            name=data["name"],
+            entity_type=EntityType(data["entity_type"]),
+            ticker=data.get("ticker"),
+            cik=data.get("cik"),
+            metadata=data.get("metadata", {}),
+        )
+
+    def find_by_name(self, name: str) -> Entity | None:
+        """Resolve an entity by name (case-insensitive)."""
+        normalized = name.lower().strip()
+        for nid, data in self._graph.nodes(data=True):
+            if data["name"].lower().strip() == normalized:
+                return self.get_entity(nid)
+            if data.get("ticker") and data["ticker"].upper() == name.upper().strip():
+                return self.get_entity(nid)
+        return None
+
+    def find_by_type(self, entity_type: EntityType) -> list[Entity]:
+        """Return all entities of a given type."""
+        result = []
+        for nid, data in self._graph.nodes(data=True):
+            if data.get("entity_type") == entity_type.value:
+                entity = self.get_entity(nid)
+                if entity:
+                    result.append(entity)
+        return result
+
+    def get_relationships(
+        self,
+        entity_id: str,
+        rel_type: RelationshipType | None = None,
+        direction: str = "both",
+    ) -> list[Relationship]:
+        """Get relationships for an entity, optionally filtered by type and direction.
+
+        Args:
+            entity_id: The canonical entity ID.
+            rel_type: Optional filter by relationship type.
+            direction: "outgoing", "incoming", or "both".
+        """
+        if entity_id not in self._graph:
+            return []
+        edges: list[tuple[str, str, dict[str, Any]]] = []
+        if direction in ("outgoing", "both"):
+            edges.extend(
+                (u, v, d)
+                for u, v, d in self._graph.out_edges(entity_id, data=True)
+            )
+        if direction in ("incoming", "both"):
+            edges.extend(
+                (u, v, d)
+                for u, v, d in self._graph.in_edges(entity_id, data=True)
+            )
+        result = []
+        for u, v, data in edges:
+            if rel_type and data.get("rel_type") != rel_type.value:
+                continue
+            result.append(Relationship(
+                source_id=u,
+                target_id=v,
+                rel_type=RelationshipType(data["rel_type"]),
+                evidence=data.get("evidence", ""),
+                source_doc=data.get("source_doc", ""),
+                confidence=Decimal(data.get("confidence", "0.5")),
+                metadata=data.get("metadata", {}),
+            ))
+        return result
+
+    def find_related(self, entity_id: str, max_depth: int = 2) -> list[Entity]:
+        """Find all entities reachable within max_depth hops (undirected traversal)."""
+        if entity_id not in self._graph:
+            return []
+        undirected = self._graph.to_undirected()
+        visited: set[str] = set()
+        frontier = {entity_id}
+        for _ in range(max_depth):
+            next_frontier: set[str] = set()
+            for nid in frontier:
+                for neighbor in undirected.neighbors(nid):
+                    if neighbor not in visited and neighbor != entity_id:
+                        next_frontier.add(neighbor)
+            visited.update(frontier)
+            frontier = next_frontier - visited
+        visited.update(frontier)
+        visited.discard(entity_id)
+        return [e for eid in visited if (e := self.get_entity(eid)) is not None]
+
+    def find_shared_risks(self, entity_ids: list[str]) -> list[Entity]:
+        """Find RISK entities connected to all of the given entities."""
+        if len(entity_ids) < 2:
+            return []
+        risk_sets: list[set[str]] = []
+        for eid in entity_ids:
+            connected_risks: set[str] = set()
+            for rel in self.get_relationships(eid):
+                target = rel.target_id if rel.source_id == eid else rel.source_id
+                entity = self.get_entity(target)
+                if entity and entity.entity_type == EntityType.RISK:
+                    connected_risks.add(target)
+            risk_sets.append(connected_risks)
+        shared = risk_sets[0]
+        for rs in risk_sets[1:]:
+            shared = shared & rs
+        return [e for rid in shared if (e := self.get_entity(rid)) is not None]
+
+    def trace_supply_chain(
+        self, entity_id: str, direction: str = "upstream"
+    ) -> list[Entity]:
+        """Trace the supply chain from an entity.
+
+        Args:
+            entity_id: Starting entity.
+            direction: "upstream" follows SUPPLIER edges backward (who supplies to me),
+                       "downstream" follows CUSTOMER edges forward (who buys from me).
+        """
+        if entity_id not in self._graph:
+            return []
+        chain: list[str] = []
+        visited: set[str] = {entity_id}
+        frontier = [entity_id]
+
+        while frontier:
+            current = frontier.pop(0)
+            if direction == "upstream":
+                edges = self._graph.in_edges(current, data=True)
+                candidates = [
+                    u for u, _, d in edges
+                    if d.get("rel_type") == RelationshipType.SUPPLIER.value
+                ]
+            else:
+                edges = self._graph.out_edges(current, data=True)
+                candidates = [
+                    v for _, v, d in edges
+                    if d.get("rel_type") == RelationshipType.CUSTOMER.value
+                ]
+            for nid in candidates:
+                if nid not in visited:
+                    visited.add(nid)
+                    chain.append(nid)
+                    frontier.append(nid)
+
+        return [e for eid in chain if (e := self.get_entity(eid)) is not None]
+
+    # ── Stats ─────────────────────────────────────────────────
+
+    @property
+    def entity_count(self) -> int:
+        """Total number of entities."""
+        return self._graph.number_of_nodes()
+
+    @property
+    def relationship_count(self) -> int:
+        """Total number of relationships."""
+        return self._graph.number_of_edges()
+
+    def stats(self) -> dict[str, Any]:
+        """Summary statistics of the graph."""
+        type_counts: dict[str, int] = {}
+        for _, data in self._graph.nodes(data=True):
+            t = data.get("entity_type", "unknown")
+            type_counts[t] = type_counts.get(t, 0) + 1
+        rel_counts: dict[str, int] = {}
+        for _, _, data in self._graph.edges(data=True):
+            r = data.get("rel_type", "unknown")
+            rel_counts[r] = rel_counts.get(r, 0) + 1
+        return {
+            "entity_count": self.entity_count,
+            "relationship_count": self.relationship_count,
+            "entities_by_type": type_counts,
+            "relationships_by_type": rel_counts,
+        }
+
+    # ── Serialization ─────────────────────────────────────────
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the graph to a JSON-compatible dict."""
+        entities = []
+        for nid, data in self._graph.nodes(data=True):
+            entities.append({"id": nid, **data})
+        relationships = []
+        for u, v, _key, data in self._graph.edges(keys=True, data=True):
+            relationships.append({"source": u, "target": v, "key": _key, **data})
+        return {"entities": entities, "relationships": relationships}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        """Deserialize a graph from a dict."""
+        kg = cls()
+        for node in data.get("entities", []):
+            nid = node.pop("id")
+            kg._graph.add_node(nid, **node)
+        for edge in data.get("relationships", []):
+            src = edge.pop("source")
+            tgt = edge.pop("target")
+            key = edge.pop("key", None)
+            kg._graph.add_edge(src, tgt, key=key, **edge)
+        return kg
+
+    def to_json(self) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Deserialize from JSON string."""
+        return cls.from_dict(json.loads(json_str))
+
+    def merge(self, other: Self) -> None:
+        """Merge another graph into this one. Deduplicates by entity_id and edge_key."""
+        for nid, data in other._graph.nodes(data=True):
+            if nid in self._graph:
+                existing = self._graph.nodes[nid]
+                merged_meta = {**existing.get("metadata", {}), **data.get("metadata", {})}
+                self._graph.nodes[nid].update({**data, "metadata": merged_meta})
+            else:
+                self._graph.add_node(nid, **data)
+        for u, v, key, data in other._graph.edges(keys=True, data=True):
+            if not self._graph.has_edge(u, v, key=key):
+                self._graph.add_edge(u, v, key=key, **data)

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -212,35 +212,42 @@ def _kg_service() -> KnowledgeGraphService:
 async def kg_extract(request: ExtractEntitiesRequest) -> Any:
     """Extract entities and relationships from text and ingest into the graph."""
     async with _kg_lock:
-        response = _kg_service().extract_and_ingest(request)
+        loop = asyncio.get_running_loop()
+        response = await loop.run_in_executor(
+            None, _kg_service().extract_and_ingest, request,
+        )
     return response.model_dump(mode="json")
 
 
 @app.post("/kg/query/related", response_model=QueryRelatedResponse)
-def kg_query_related(request: QueryRelatedRequest) -> Any:
+async def kg_query_related(request: QueryRelatedRequest) -> Any:
     """Find entities related to a given entity."""
-    response = _kg_service().query_related(request)
+    async with _kg_lock:
+        response = _kg_service().query_related(request)
     return response.model_dump(mode="json")
 
 
 @app.post("/kg/query/supply-chain", response_model=QuerySupplyChainResponse)
-def kg_query_supply_chain(request: QuerySupplyChainRequest) -> Any:
+async def kg_query_supply_chain(request: QuerySupplyChainRequest) -> Any:
     """Trace the supply chain from an entity."""
-    response = _kg_service().query_supply_chain(request)
+    async with _kg_lock:
+        response = _kg_service().query_supply_chain(request)
     return response.model_dump(mode="json")
 
 
 @app.post("/kg/query/shared-risks", response_model=QuerySharedRisksResponse)
-def kg_query_shared_risks(request: QuerySharedRisksRequest) -> Any:
+async def kg_query_shared_risks(request: QuerySharedRisksRequest) -> Any:
     """Find risks shared across multiple entities."""
-    response = _kg_service().query_shared_risks(request)
+    async with _kg_lock:
+        response = _kg_service().query_shared_risks(request)
     return response.model_dump(mode="json")
 
 
 @app.get("/kg/stats", response_model=KGStatsResponse)
-def kg_stats() -> Any:
+async def kg_stats() -> Any:
     """Get knowledge graph summary statistics."""
-    response = _kg_service().get_stats()
+    async with _kg_lock:
+        response = _kg_service().get_stats()
     return response.model_dump(mode="json")
 
 

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -223,7 +223,10 @@ async def kg_extract(request: ExtractEntitiesRequest) -> Any:
 async def kg_query_related(request: QueryRelatedRequest) -> Any:
     """Find entities related to a given entity."""
     async with _kg_lock:
-        response = _kg_service().query_related(request)
+        loop = asyncio.get_running_loop()
+        response = await loop.run_in_executor(
+            None, _kg_service().query_related, request,
+        )
     return response.model_dump(mode="json")
 
 
@@ -231,7 +234,10 @@ async def kg_query_related(request: QueryRelatedRequest) -> Any:
 async def kg_query_supply_chain(request: QuerySupplyChainRequest) -> Any:
     """Trace the supply chain from an entity."""
     async with _kg_lock:
-        response = _kg_service().query_supply_chain(request)
+        loop = asyncio.get_running_loop()
+        response = await loop.run_in_executor(
+            None, _kg_service().query_supply_chain, request,
+        )
     return response.model_dump(mode="json")
 
 
@@ -239,7 +245,10 @@ async def kg_query_supply_chain(request: QuerySupplyChainRequest) -> Any:
 async def kg_query_shared_risks(request: QuerySharedRisksRequest) -> Any:
     """Find risks shared across multiple entities."""
     async with _kg_lock:
-        response = _kg_service().query_shared_risks(request)
+        loop = asyncio.get_running_loop()
+        response = await loop.run_in_executor(
+            None, _kg_service().query_shared_risks, request,
+        )
     return response.model_dump(mode="json")
 
 
@@ -247,7 +256,10 @@ async def kg_query_shared_risks(request: QuerySharedRisksRequest) -> Any:
 async def kg_stats() -> Any:
     """Get knowledge graph summary statistics."""
     async with _kg_lock:
-        response = _kg_service().get_stats()
+        loop = asyncio.get_running_loop()
+        response = await loop.run_in_executor(
+            None, _kg_service().get_stats,
+        )
     return response.model_dump(mode="json")
 
 

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -1,14 +1,19 @@
 """FastAPI web service wrapping the finance-os application layer.
 
 Thin REST wrapper over the same services used by CLI and MCP server.
-Each endpoint creates fresh service instances per request to avoid
+Agent endpoints create fresh service instances per request to avoid
 cross-request state leakage (agents maintain internal history).
+
+Knowledge graph endpoints share a process-level graph store that
+persists across requests (like a database), guarded by an asyncio
+lock for thread safety.
 
 Run locally:
     uvicorn src.web_api:app --reload
     finance-os-api              # console script
 """
 
+import asyncio
 import logging
 from functools import lru_cache
 from typing import Any
@@ -60,6 +65,7 @@ logger = logging.getLogger(__name__)
 
 # Process-level knowledge graph store (persists across requests like a DB)
 _kg_graph = KnowledgeGraph()
+_kg_lock = asyncio.Lock()
 
 app = FastAPI(
     title="finance-os",
@@ -205,33 +211,34 @@ def _kg_service() -> KnowledgeGraphService:
 @app.post("/kg/extract", response_model=ExtractEntitiesResponse)
 async def kg_extract(request: ExtractEntitiesRequest) -> Any:
     """Extract entities and relationships from text and ingest into the graph."""
-    response = _kg_service().extract_and_ingest(request)
+    async with _kg_lock:
+        response = _kg_service().extract_and_ingest(request)
     return response.model_dump(mode="json")
 
 
 @app.post("/kg/query/related", response_model=QueryRelatedResponse)
-async def kg_query_related(request: QueryRelatedRequest) -> Any:
+def kg_query_related(request: QueryRelatedRequest) -> Any:
     """Find entities related to a given entity."""
     response = _kg_service().query_related(request)
     return response.model_dump(mode="json")
 
 
 @app.post("/kg/query/supply-chain", response_model=QuerySupplyChainResponse)
-async def kg_query_supply_chain(request: QuerySupplyChainRequest) -> Any:
+def kg_query_supply_chain(request: QuerySupplyChainRequest) -> Any:
     """Trace the supply chain from an entity."""
     response = _kg_service().query_supply_chain(request)
     return response.model_dump(mode="json")
 
 
 @app.post("/kg/query/shared-risks", response_model=QuerySharedRisksResponse)
-async def kg_query_shared_risks(request: QuerySharedRisksRequest) -> Any:
+def kg_query_shared_risks(request: QuerySharedRisksRequest) -> Any:
     """Find risks shared across multiple entities."""
     response = _kg_service().query_shared_risks(request)
     return response.model_dump(mode="json")
 
 
 @app.get("/kg/stats", response_model=KGStatsResponse)
-async def kg_stats() -> Any:
+def kg_stats() -> Any:
     """Get knowledge graph summary statistics."""
     response = _kg_service().get_stats()
     return response.model_dump(mode="json")

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -39,11 +39,27 @@ from src.application.contracts.agents import (
     SearchFilingsRequest,
     SearchFilingsResponse,
 )
+from src.application.contracts.knowledge_graph import (
+    ExtractEntitiesRequest,
+    ExtractEntitiesResponse,
+    KGStatsResponse,
+    QueryRelatedRequest,
+    QueryRelatedResponse,
+    QuerySharedRisksRequest,
+    QuerySharedRisksResponse,
+    QuerySupplyChainRequest,
+    QuerySupplyChainResponse,
+)
 from src.application.registry import AGENT_CATALOG, create_pipeline_service
 from src.application.services.agent_service import AgentService
 from src.application.services.digest_service import DigestService
+from src.application.services.kg_service import KnowledgeGraphService
+from src.core.knowledge_graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
+
+# Process-level knowledge graph store (persists across requests like a DB)
+_kg_graph = KnowledgeGraph()
 
 app = FastAPI(
     title="finance-os",
@@ -175,6 +191,49 @@ async def run_digest(request: RunDigestRequest) -> Any:
     """Run a research digest for a watchlist of tickers."""
     service = DigestService(get_config())
     response = await service.run_digest(request)
+    return response.model_dump(mode="json")
+
+
+# --- Knowledge Graph ---
+
+
+def _kg_service() -> KnowledgeGraphService:
+    """Create a KG service wrapping the process-level graph."""
+    return KnowledgeGraphService(_kg_graph)
+
+
+@app.post("/kg/extract", response_model=ExtractEntitiesResponse)
+async def kg_extract(request: ExtractEntitiesRequest) -> Any:
+    """Extract entities and relationships from text and ingest into the graph."""
+    response = _kg_service().extract_and_ingest(request)
+    return response.model_dump(mode="json")
+
+
+@app.post("/kg/query/related", response_model=QueryRelatedResponse)
+async def kg_query_related(request: QueryRelatedRequest) -> Any:
+    """Find entities related to a given entity."""
+    response = _kg_service().query_related(request)
+    return response.model_dump(mode="json")
+
+
+@app.post("/kg/query/supply-chain", response_model=QuerySupplyChainResponse)
+async def kg_query_supply_chain(request: QuerySupplyChainRequest) -> Any:
+    """Trace the supply chain from an entity."""
+    response = _kg_service().query_supply_chain(request)
+    return response.model_dump(mode="json")
+
+
+@app.post("/kg/query/shared-risks", response_model=QuerySharedRisksResponse)
+async def kg_query_shared_risks(request: QuerySharedRisksRequest) -> Any:
+    """Find risks shared across multiple entities."""
+    response = _kg_service().query_shared_risks(request)
+    return response.model_dump(mode="json")
+
+
+@app.get("/kg/stats", response_model=KGStatsResponse)
+async def kg_stats() -> Any:
+    """Get knowledge graph summary statistics."""
+    response = _kg_service().get_stats()
     return response.model_dump(mode="json")
 
 

--- a/agents/tests/test_entity_extraction.py
+++ b/agents/tests/test_entity_extraction.py
@@ -129,16 +129,16 @@ class TestRelationshipExtraction:
         text = "Intel Corp. supplies processors to Apple Inc. every quarter."
         entities = extract_entities(text)
         rels = extract_relationships(text, entities)
-        if rels:
-            assert rels[0].evidence != ""
-            assert len(rels[0].evidence) > 0
+        assert len(rels) >= 1
+        assert rels[0].evidence != ""
+        assert len(rels[0].evidence) > 0
 
     def test_relationship_source_doc_propagated(self) -> None:
         text = "Intel Corp. supplies chips to Apple Inc. for production."
         entities = extract_entities(text, source_doc="10-K")
         rels = extract_relationships(text, entities, source_doc="10-K")
-        if rels:
-            assert rels[0].source_doc == "10-K"
+        assert len(rels) >= 1
+        assert rels[0].source_doc == "10-K"
 
     def test_subsidiary_relationship(self) -> None:
         text = "YouTube LLC is a subsidiary of Alphabet Inc. since 2006."

--- a/agents/tests/test_entity_extraction.py
+++ b/agents/tests/test_entity_extraction.py
@@ -1,0 +1,156 @@
+"""Tests for entity and relationship extraction from financial text."""
+
+from src.core.entity_extraction import extract_entities, extract_relationships
+from src.core.knowledge_graph import EntityType, RelationshipType
+
+# ── Entity Extraction ─────────────────────────────────────────
+
+
+class TestCompanyExtraction:
+    def test_extracts_company_with_suffix(self) -> None:
+        text = "Apple Inc. reported strong earnings this quarter."
+        entities = extract_entities(text)
+        companies = [e for e in entities if e.entity_type == EntityType.COMPANY]
+        assert len(companies) >= 1
+        names = {e.name for e in companies}
+        assert any("Apple" in n for n in names)
+
+    def test_extracts_multiple_companies(self) -> None:
+        text = "Apple Inc. competes with Microsoft Corp. in the cloud market."
+        entities = extract_entities(text)
+        companies = [e for e in entities if e.entity_type == EntityType.COMPANY]
+        assert len(companies) >= 2
+
+    def test_no_companies_in_plain_text(self) -> None:
+        text = "The weather is nice today and the birds are singing."
+        entities = extract_entities(text)
+        companies = [e for e in entities if e.entity_type == EntityType.COMPANY]
+        assert len(companies) == 0
+
+
+class TestRiskExtraction:
+    def test_extracts_risk_keywords(self) -> None:
+        text = "The company faces significant cybersecurity and regulatory risk."
+        entities = extract_entities(text)
+        risks = [e for e in entities if e.entity_type == EntityType.RISK]
+        assert len(risks) >= 1
+        names = {e.name for e in risks}
+        assert "cybersecurity" in names or "regulatory risk" in names
+
+    def test_risk_has_category_metadata(self) -> None:
+        text = "Supply chain disruption poses a major threat."
+        entities = extract_entities(text)
+        risks = [e for e in entities if e.entity_type == EntityType.RISK]
+        assert len(risks) >= 1
+        risk = risks[0]
+        assert risk.metadata.get("category") == "supply_chain"
+
+    def test_no_risks_in_clean_text(self) -> None:
+        text = "Revenue grew 15% year over year."
+        entities = extract_entities(text)
+        risks = [e for e in entities if e.entity_type == EntityType.RISK]
+        assert len(risks) == 0
+
+
+class TestTechnologyExtraction:
+    def test_extracts_technology_keywords(self) -> None:
+        text = "The company is investing heavily in artificial intelligence and cloud computing."
+        entities = extract_entities(text)
+        techs = [e for e in entities if e.entity_type == EntityType.TECHNOLOGY]
+        assert len(techs) >= 1
+        names = {e.name.lower() for e in techs}
+        assert "artificial intelligence" in names or "cloud computing" in names
+
+    def test_no_tech_in_non_tech_text(self) -> None:
+        text = "The company sells shoes and clothing."
+        entities = extract_entities(text)
+        techs = [e for e in entities if e.entity_type == EntityType.TECHNOLOGY]
+        assert len(techs) == 0
+
+
+class TestEntityProvenance:
+    def test_source_doc_propagated(self) -> None:
+        text = "Apple Inc. is a major technology company."
+        entities = extract_entities(text, source_doc="10-K-2024")
+        companies = [e for e in entities if e.entity_type == EntityType.COMPANY]
+        assert len(companies) >= 1
+        assert companies[0].metadata.get("source_doc") == "10-K-2024"
+
+    def test_evidence_captured(self) -> None:
+        text = "Apple Inc. reported record revenue."
+        entities = extract_entities(text)
+        companies = [e for e in entities if e.entity_type == EntityType.COMPANY]
+        assert len(companies) >= 1
+        assert companies[0].metadata.get("evidence") is not None
+        assert len(companies[0].metadata["evidence"]) > 0
+
+
+class TestEntityDeduplication:
+    def test_same_entity_mentioned_twice_deduped(self) -> None:
+        text = "Apple Inc. is growing. Apple Inc. reported earnings."
+        entities = extract_entities(text)
+        companies = [e for e in entities if e.entity_type == EntityType.COMPANY]
+        apple_count = sum(1 for c in companies if "Apple" in c.name)
+        assert apple_count == 1
+
+
+# ── Relationship Extraction ──────────────────────────────────
+
+
+class TestRelationshipExtraction:
+    def test_supplier_relationship(self) -> None:
+        text = "Intel Corp. supplies chips to Apple Inc. for their devices."
+        entities = extract_entities(text)
+        rels = extract_relationships(text, entities)
+        supplier_rels = [r for r in rels if r.rel_type == RelationshipType.SUPPLIER]
+        assert len(supplier_rels) >= 1
+
+    def test_competitor_relationship(self) -> None:
+        text = "Apple Inc. competes with Microsoft Corp. in the tablet market."
+        entities = extract_entities(text)
+        rels = extract_relationships(text, entities)
+        competitor_rels = [r for r in rels if r.rel_type == RelationshipType.COMPETITOR]
+        assert len(competitor_rels) >= 1
+
+    def test_no_relationships_with_single_entity(self) -> None:
+        text = "Apple Inc. is a great company."
+        entities = extract_entities(text)
+        rels = extract_relationships(text, entities)
+        assert len(rels) == 0
+
+    def test_no_relationships_without_indicators(self) -> None:
+        text = "Apple Inc. and Microsoft Corp. are both in technology."
+        entities = extract_entities(text)
+        rels = extract_relationships(text, entities)
+        # "and" is not a relationship indicator
+        assert len(rels) == 0
+
+    def test_relationship_has_evidence(self) -> None:
+        text = "Intel Corp. supplies processors to Apple Inc. every quarter."
+        entities = extract_entities(text)
+        rels = extract_relationships(text, entities)
+        if rels:
+            assert rels[0].evidence != ""
+            assert len(rels[0].evidence) > 0
+
+    def test_relationship_source_doc_propagated(self) -> None:
+        text = "Intel Corp. supplies chips to Apple Inc. for production."
+        entities = extract_entities(text, source_doc="10-K")
+        rels = extract_relationships(text, entities, source_doc="10-K")
+        if rels:
+            assert rels[0].source_doc == "10-K"
+
+    def test_subsidiary_relationship(self) -> None:
+        text = "YouTube LLC is a subsidiary of Alphabet Inc. since 2006."
+        entities = extract_entities(text)
+        rels = extract_relationships(text, entities)
+        sub_rels = [r for r in rels if r.rel_type == RelationshipType.SUBSIDIARY]
+        assert len(sub_rels) >= 1
+
+    def test_empty_text_yields_no_entities(self) -> None:
+        entities = extract_entities("")
+        assert len(entities) == 0
+
+    def test_empty_text_yields_no_relationships(self) -> None:
+        rels = extract_relationships("", [])
+        assert len(rels) == 0

--- a/agents/tests/test_kg_service.py
+++ b/agents/tests/test_kg_service.py
@@ -1,5 +1,8 @@
 """Tests for the knowledge graph service layer."""
 
+import pydantic
+import pytest
+
 from src.application.contracts.knowledge_graph import (
     ExtractEntitiesRequest,
     QueryRelatedRequest,
@@ -78,12 +81,8 @@ class TestExtractAndIngest:
         assert apple_entities[0].ticker == "AAPL"
 
     def test_empty_text_rejected(self) -> None:
-        import pydantic
-        try:
+        with pytest.raises(pydantic.ValidationError):
             ExtractEntitiesRequest(text="")
-            assert False, "Should have raised validation error"
-        except pydantic.ValidationError:
-            pass
 
     def test_extract_with_relationships(self) -> None:
         svc = KnowledgeGraphService()
@@ -127,12 +126,8 @@ class TestQueryRelated:
         assert resp.related == []
 
     def test_query_related_empty_id_rejected(self) -> None:
-        import pydantic
-        try:
+        with pytest.raises(pydantic.ValidationError):
             QueryRelatedRequest(entity_id="")
-            assert False, "Should have raised validation error"
-        except pydantic.ValidationError:
-            pass
 
 
 # ── Query Supply Chain ────────────────────────────────────────
@@ -155,12 +150,8 @@ class TestQuerySupplyChain:
         assert resp.count == 0
 
     def test_invalid_direction_rejected(self) -> None:
-        import pydantic
-        try:
+        with pytest.raises(pydantic.ValidationError):
             QuerySupplyChainRequest(entity_id="ticker:AAPL", direction="sideways")
-            assert False, "Should have raised validation error"
-        except pydantic.ValidationError:
-            pass
 
 
 # ── Query Shared Risks ───────────────────────────────────────
@@ -184,12 +175,8 @@ class TestQuerySharedRisks:
         assert resp.count == 0
 
     def test_fewer_than_two_entities_rejected(self) -> None:
-        import pydantic
-        try:
+        with pytest.raises(pydantic.ValidationError):
             QuerySharedRisksRequest(entity_ids=["ticker:AAPL"])
-            assert False, "Should have raised validation error"
-        except pydantic.ValidationError:
-            pass
 
 
 # ── Stats ─────────────────────────────────────────────────────

--- a/agents/tests/test_kg_service.py
+++ b/agents/tests/test_kg_service.py
@@ -1,0 +1,211 @@
+"""Tests for the knowledge graph service layer."""
+
+from src.application.contracts.knowledge_graph import (
+    ExtractEntitiesRequest,
+    QueryRelatedRequest,
+    QuerySharedRisksRequest,
+    QuerySupplyChainRequest,
+)
+from src.application.services.kg_service import KnowledgeGraphService
+from src.core.knowledge_graph import (
+    Entity,
+    EntityType,
+    KnowledgeGraph,
+    Relationship,
+    RelationshipType,
+)
+
+
+def _seeded_service() -> KnowledgeGraphService:
+    """Create a service with a pre-populated graph for query tests."""
+    graph = KnowledgeGraph()
+    apple = Entity(name="Apple Inc.", entity_type=EntityType.COMPANY, ticker="AAPL")
+    intel = Entity(name="Intel Corp.", entity_type=EntityType.COMPANY, ticker="INTC")
+    msft = Entity(name="Microsoft Corp.", entity_type=EntityType.COMPANY, ticker="MSFT")
+    cyber = Entity(name="cybersecurity", entity_type=EntityType.RISK)
+
+    graph.add_entity(apple)
+    graph.add_entity(intel)
+    graph.add_entity(msft)
+    graph.add_entity(cyber)
+
+    graph.add_relationship(Relationship(
+        source_id="ticker:INTC", target_id="ticker:AAPL",
+        rel_type=RelationshipType.SUPPLIER, evidence="Intel supplies to Apple",
+    ))
+    graph.add_relationship(Relationship(
+        source_id="ticker:AAPL", target_id="name:cybersecurity",
+        rel_type=RelationshipType.REGULATORY,
+    ))
+    graph.add_relationship(Relationship(
+        source_id="ticker:MSFT", target_id="name:cybersecurity",
+        rel_type=RelationshipType.REGULATORY,
+    ))
+    return KnowledgeGraphService(graph)
+
+
+# ── Extract & Ingest ──────────────────────────────────────────
+
+
+class TestExtractAndIngest:
+    def test_extracts_entities_from_text(self) -> None:
+        svc = KnowledgeGraphService()
+        req = ExtractEntitiesRequest(
+            text="Apple Inc. is facing cybersecurity concerns.",
+            source_doc="10-K-2024",
+        )
+        resp = svc.extract_and_ingest(req)
+        assert resp.entity_count >= 1
+        assert len(resp.entities) == resp.entity_count
+
+    def test_ingested_entities_persist_in_graph(self) -> None:
+        svc = KnowledgeGraphService()
+        req = ExtractEntitiesRequest(
+            text="Microsoft Corp. invests in artificial intelligence.",
+        )
+        svc.extract_and_ingest(req)
+        assert svc.graph.entity_count >= 1
+
+    def test_ticker_associated_with_first_company(self) -> None:
+        svc = KnowledgeGraphService()
+        req = ExtractEntitiesRequest(
+            text="Apple Inc. reported record revenue.",
+            ticker="AAPL",
+        )
+        resp = svc.extract_and_ingest(req)
+        apple_entities = [e for e in resp.entities if "Apple" in e.name]
+        assert len(apple_entities) >= 1
+        assert apple_entities[0].ticker == "AAPL"
+
+    def test_empty_text_rejected(self) -> None:
+        import pydantic
+        try:
+            ExtractEntitiesRequest(text="")
+            assert False, "Should have raised validation error"
+        except pydantic.ValidationError:
+            pass
+
+    def test_extract_with_relationships(self) -> None:
+        svc = KnowledgeGraphService()
+        req = ExtractEntitiesRequest(
+            text="Intel Corp. supplies processors to Apple Inc. for their products.",
+        )
+        resp = svc.extract_and_ingest(req)
+        # Should have at least entities; relationships depend on pattern matching
+        assert resp.entity_count >= 2
+
+    def test_multiple_extractions_accumulate(self) -> None:
+        svc = KnowledgeGraphService()
+        svc.extract_and_ingest(ExtractEntitiesRequest(
+            text="Apple Inc. is a technology company.",
+        ))
+        svc.extract_and_ingest(ExtractEntitiesRequest(
+            text="Microsoft Corp. is also a technology company.",
+        ))
+        assert svc.graph.entity_count >= 2
+
+
+# ── Query Related ─────────────────────────────────────────────
+
+
+class TestQueryRelated:
+    def test_query_related_returns_neighbors(self) -> None:
+        svc = _seeded_service()
+        resp = svc.query_related(QueryRelatedRequest(
+            entity_id="ticker:AAPL", max_depth=1,
+        ))
+        assert resp.count >= 1
+        ids = {e.entity_id for e in resp.related}
+        assert "ticker:INTC" in ids
+
+    def test_query_related_nonexistent_entity(self) -> None:
+        svc = _seeded_service()
+        resp = svc.query_related(QueryRelatedRequest(
+            entity_id="ticker:FAKE", max_depth=1,
+        ))
+        assert resp.count == 0
+        assert resp.related == []
+
+    def test_query_related_empty_id_rejected(self) -> None:
+        import pydantic
+        try:
+            QueryRelatedRequest(entity_id="")
+            assert False, "Should have raised validation error"
+        except pydantic.ValidationError:
+            pass
+
+
+# ── Query Supply Chain ────────────────────────────────────────
+
+
+class TestQuerySupplyChain:
+    def test_upstream_supply_chain(self) -> None:
+        svc = _seeded_service()
+        resp = svc.query_supply_chain(QuerySupplyChainRequest(
+            entity_id="ticker:AAPL", direction="upstream",
+        ))
+        ids = [e.entity_id for e in resp.chain]
+        assert "ticker:INTC" in ids
+
+    def test_supply_chain_nonexistent_entity(self) -> None:
+        svc = _seeded_service()
+        resp = svc.query_supply_chain(QuerySupplyChainRequest(
+            entity_id="ticker:FAKE",
+        ))
+        assert resp.count == 0
+
+    def test_invalid_direction_rejected(self) -> None:
+        import pydantic
+        try:
+            QuerySupplyChainRequest(entity_id="ticker:AAPL", direction="sideways")
+            assert False, "Should have raised validation error"
+        except pydantic.ValidationError:
+            pass
+
+
+# ── Query Shared Risks ───────────────────────────────────────
+
+
+class TestQuerySharedRisks:
+    def test_finds_shared_risks(self) -> None:
+        svc = _seeded_service()
+        resp = svc.query_shared_risks(QuerySharedRisksRequest(
+            entity_ids=["ticker:AAPL", "ticker:MSFT"],
+        ))
+        assert resp.count >= 1
+        risk_names = {r.name for r in resp.shared_risks}
+        assert "cybersecurity" in risk_names
+
+    def test_no_shared_risks(self) -> None:
+        svc = _seeded_service()
+        resp = svc.query_shared_risks(QuerySharedRisksRequest(
+            entity_ids=["ticker:AAPL", "ticker:INTC"],
+        ))
+        assert resp.count == 0
+
+    def test_fewer_than_two_entities_rejected(self) -> None:
+        import pydantic
+        try:
+            QuerySharedRisksRequest(entity_ids=["ticker:AAPL"])
+            assert False, "Should have raised validation error"
+        except pydantic.ValidationError:
+            pass
+
+
+# ── Stats ─────────────────────────────────────────────────────
+
+
+class TestGetStats:
+    def test_stats_reflects_graph(self) -> None:
+        svc = _seeded_service()
+        resp = svc.get_stats()
+        assert resp.entity_count == 4
+        assert resp.relationship_count == 3
+        assert resp.entities_by_type["company"] == 3
+        assert resp.entities_by_type["risk"] == 1
+
+    def test_stats_empty_graph(self) -> None:
+        svc = KnowledgeGraphService()
+        resp = svc.get_stats()
+        assert resp.entity_count == 0
+        assert resp.relationship_count == 0

--- a/agents/tests/test_knowledge_graph.py
+++ b/agents/tests/test_knowledge_graph.py
@@ -320,6 +320,22 @@ class TestTraceSupplyChain:
         assert "ticker:CMP" in ids
         assert "ticker:RAW" in ids
 
+    def test_trace_downstream(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Raw Materials Inc.", ticker="RAW"))
+        kg.add_entity(_company("Components Corp.", ticker="CMP"))
+        kg.add_entity(_company("Final Product Co.", ticker="FIN"))
+        kg.add_relationship(
+            _relationship("ticker:RAW", "ticker:CMP", RelationshipType.SUPPLIER),
+        )
+        kg.add_relationship(
+            _relationship("ticker:CMP", "ticker:FIN", RelationshipType.SUPPLIER),
+        )
+        chain = kg.trace_supply_chain("ticker:RAW", direction="downstream")
+        ids = [e.entity_id for e in chain]
+        assert "ticker:CMP" in ids
+        assert "ticker:FIN" in ids
+
     def test_trace_nonexistent_entity(self) -> None:
         kg = KnowledgeGraph()
         assert kg.trace_supply_chain("ticker:FAKE") == []

--- a/agents/tests/test_knowledge_graph.py
+++ b/agents/tests/test_knowledge_graph.py
@@ -1,0 +1,448 @@
+"""Tests for core knowledge graph operations."""
+
+from decimal import Decimal
+
+import pytest
+
+from src.core.knowledge_graph import (
+    Entity,
+    EntityType,
+    KnowledgeGraph,
+    Relationship,
+    RelationshipType,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+
+def _company(name: str, ticker: str | None = None) -> Entity:
+    return Entity(name=name, entity_type=EntityType.COMPANY, ticker=ticker)
+
+
+def _risk(name: str) -> Entity:
+    return Entity(name=name, entity_type=EntityType.RISK)
+
+
+def _relationship(
+    src: str, tgt: str, rel_type: RelationshipType, evidence: str = ""
+) -> Relationship:
+    return Relationship(
+        source_id=src, target_id=tgt, rel_type=rel_type, evidence=evidence,
+    )
+
+
+# ── Entity CRUD ───────────────────────────────────────────────
+
+
+class TestAddEntity:
+    def test_add_entity_returns_canonical_id(self) -> None:
+        kg = KnowledgeGraph()
+        eid = kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        assert eid == "ticker:AAPL"
+
+    def test_add_entity_without_ticker_uses_name(self) -> None:
+        kg = KnowledgeGraph()
+        eid = kg.add_entity(_risk("supply chain disruption"))
+        assert eid.startswith("name:")
+
+    def test_add_entity_increments_count(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        kg.add_entity(_company("Microsoft Corp.", ticker="MSFT"))
+        assert kg.entity_count == 2
+
+    def test_add_duplicate_entity_merges_metadata(self) -> None:
+        kg = KnowledgeGraph()
+        e1 = Entity(
+            name="Apple Inc.", entity_type=EntityType.COMPANY,
+            ticker="AAPL", metadata={"source": "10-K"},
+        )
+        e2 = Entity(
+            name="Apple Inc.", entity_type=EntityType.COMPANY,
+            ticker="AAPL", metadata={"sector": "tech"},
+        )
+        kg.add_entity(e1)
+        kg.add_entity(e2)
+        assert kg.entity_count == 1
+        retrieved = kg.get_entity("ticker:AAPL")
+        assert retrieved is not None
+        assert retrieved.metadata["source"] == "10-K"
+        assert retrieved.metadata["sector"] == "tech"
+
+    def test_add_entity_promotes_ticker(self) -> None:
+        kg = KnowledgeGraph()
+        # First add without ticker (uses name-based ID)
+        eid = kg.add_entity(_company("Apple Inc."))
+        assert eid == "name:apple inc."
+        # Add with ticker — different ID, different node
+        eid2 = kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        assert eid2 == "ticker:AAPL"
+        assert kg.entity_count == 2
+
+
+class TestGetEntity:
+    def test_get_existing_entity(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        entity = kg.get_entity("ticker:AAPL")
+        assert entity is not None
+        assert entity.name == "Apple Inc."
+        assert entity.entity_type == EntityType.COMPANY
+
+    def test_get_nonexistent_entity_returns_none(self) -> None:
+        kg = KnowledgeGraph()
+        assert kg.get_entity("ticker:FAKE") is None
+
+
+class TestFindByName:
+    def test_find_by_name_case_insensitive(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        entity = kg.find_by_name("apple inc.")
+        assert entity is not None
+        assert entity.ticker == "AAPL"
+
+    def test_find_by_ticker(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        entity = kg.find_by_name("AAPL")
+        assert entity is not None
+        assert entity.name == "Apple Inc."
+
+    def test_find_by_name_not_found(self) -> None:
+        kg = KnowledgeGraph()
+        assert kg.find_by_name("Nonexistent") is None
+
+
+class TestFindByType:
+    def test_find_companies(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        kg.add_entity(_company("Microsoft Corp.", ticker="MSFT"))
+        kg.add_entity(_risk("regulatory risk"))
+        companies = kg.find_by_type(EntityType.COMPANY)
+        assert len(companies) == 2
+        names = {e.name for e in companies}
+        assert "Apple Inc." in names
+        assert "Microsoft Corp." in names
+
+    def test_find_by_type_empty(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        assert kg.find_by_type(EntityType.TECHNOLOGY) == []
+
+
+# ── Relationships ─────────────────────────────────────────────
+
+
+class TestRelationships:
+    def test_add_relationship(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Intel Corp.", ticker="INTC"))
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        rel = _relationship("ticker:INTC", "ticker:AAPL", RelationshipType.SUPPLIER)
+        kg.add_relationship(rel)
+        assert kg.relationship_count == 1
+
+    def test_add_relationship_missing_source_raises(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        rel = _relationship("ticker:FAKE", "ticker:AAPL", RelationshipType.SUPPLIER)
+        with pytest.raises(ValueError):
+            kg.add_relationship(rel)
+
+    def test_add_relationship_missing_target_raises(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Intel Corp.", ticker="INTC"))
+        rel = _relationship("ticker:INTC", "ticker:FAKE", RelationshipType.SUPPLIER)
+        with pytest.raises(ValueError):
+            kg.add_relationship(rel)
+
+    def test_multiple_relationships_same_pair(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Intel Corp.", ticker="INTC"))
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        kg.add_relationship(
+            _relationship("ticker:INTC", "ticker:AAPL", RelationshipType.SUPPLIER),
+        )
+        kg.add_relationship(
+            _relationship("ticker:INTC", "ticker:AAPL", RelationshipType.COMPETITOR),
+        )
+        assert kg.relationship_count == 2
+
+    def test_get_relationships_outgoing(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Intel Corp.", ticker="INTC"))
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        kg.add_relationship(
+            _relationship("ticker:INTC", "ticker:AAPL", RelationshipType.SUPPLIER),
+        )
+        rels = kg.get_relationships("ticker:INTC", direction="outgoing")
+        assert len(rels) == 1
+        assert rels[0].target_id == "ticker:AAPL"
+        assert rels[0].rel_type == RelationshipType.SUPPLIER
+
+    def test_get_relationships_filtered_by_type(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Intel Corp.", ticker="INTC"))
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        kg.add_relationship(
+            _relationship("ticker:INTC", "ticker:AAPL", RelationshipType.SUPPLIER),
+        )
+        kg.add_relationship(
+            _relationship("ticker:INTC", "ticker:AAPL", RelationshipType.COMPETITOR),
+        )
+        rels = kg.get_relationships(
+            "ticker:INTC", rel_type=RelationshipType.SUPPLIER,
+        )
+        assert len(rels) == 1
+        assert rels[0].rel_type == RelationshipType.SUPPLIER
+
+    def test_get_relationships_nonexistent_entity(self) -> None:
+        kg = KnowledgeGraph()
+        assert kg.get_relationships("ticker:FAKE") == []
+
+    def test_relationship_preserves_provenance(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Intel Corp.", ticker="INTC"))
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        rel = Relationship(
+            source_id="ticker:INTC",
+            target_id="ticker:AAPL",
+            rel_type=RelationshipType.SUPPLIER,
+            evidence="Intel supplies chips to Apple",
+            source_doc="10-K-2024",
+            confidence=Decimal("0.9"),
+        )
+        kg.add_relationship(rel)
+        retrieved = kg.get_relationships("ticker:INTC")[0]
+        assert retrieved.evidence == "Intel supplies chips to Apple"
+        assert retrieved.source_doc == "10-K-2024"
+        assert retrieved.confidence == Decimal("0.9")
+
+
+# ── Graph Queries ─────────────────────────────────────────────
+
+
+class TestFindRelated:
+    def test_find_related_depth_1(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("A Corp.", ticker="A"))
+        kg.add_entity(_company("B Corp.", ticker="B"))
+        kg.add_entity(_company("C Corp.", ticker="C"))
+        kg.add_relationship(
+            _relationship("ticker:A", "ticker:B", RelationshipType.SUPPLIER),
+        )
+        kg.add_relationship(
+            _relationship("ticker:B", "ticker:C", RelationshipType.SUPPLIER),
+        )
+        related = kg.find_related("ticker:A", max_depth=1)
+        ids = {e.entity_id for e in related}
+        assert "ticker:B" in ids
+        assert "ticker:C" not in ids
+
+    def test_find_related_depth_2(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("A Corp.", ticker="A"))
+        kg.add_entity(_company("B Corp.", ticker="B"))
+        kg.add_entity(_company("C Corp.", ticker="C"))
+        kg.add_relationship(
+            _relationship("ticker:A", "ticker:B", RelationshipType.SUPPLIER),
+        )
+        kg.add_relationship(
+            _relationship("ticker:B", "ticker:C", RelationshipType.SUPPLIER),
+        )
+        related = kg.find_related("ticker:A", max_depth=2)
+        ids = {e.entity_id for e in related}
+        assert "ticker:B" in ids
+        assert "ticker:C" in ids
+
+    def test_find_related_nonexistent_entity(self) -> None:
+        kg = KnowledgeGraph()
+        assert kg.find_related("ticker:FAKE") == []
+
+
+class TestFindSharedRisks:
+    def test_shared_risks(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        kg.add_entity(_company("Microsoft Corp.", ticker="MSFT"))
+        kg.add_entity(_risk("cybersecurity"))
+        kg.add_entity(_risk("regulatory risk"))
+        # Both companies share cybersecurity risk
+        kg.add_relationship(
+            _relationship("ticker:AAPL", "name:cybersecurity", RelationshipType.REGULATORY),
+        )
+        kg.add_relationship(
+            _relationship("ticker:MSFT", "name:cybersecurity", RelationshipType.REGULATORY),
+        )
+        # Only Apple has regulatory risk
+        kg.add_relationship(
+            _relationship("ticker:AAPL", "name:regulatory risk", RelationshipType.REGULATORY),
+        )
+        shared = kg.find_shared_risks(["ticker:AAPL", "ticker:MSFT"])
+        assert len(shared) == 1
+        assert shared[0].name == "cybersecurity"
+
+    def test_shared_risks_needs_at_least_two_entities(self) -> None:
+        kg = KnowledgeGraph()
+        assert kg.find_shared_risks(["ticker:AAPL"]) == []
+
+    def test_shared_risks_no_overlap(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("A Corp.", ticker="A"))
+        kg.add_entity(_company("B Corp.", ticker="B"))
+        kg.add_entity(_risk("risk_a"))
+        kg.add_entity(_risk("risk_b"))
+        kg.add_relationship(
+            _relationship("ticker:A", "name:risk_a", RelationshipType.REGULATORY),
+        )
+        kg.add_relationship(
+            _relationship("ticker:B", "name:risk_b", RelationshipType.REGULATORY),
+        )
+        assert kg.find_shared_risks(["ticker:A", "ticker:B"]) == []
+
+
+class TestTraceSupplyChain:
+    def test_trace_upstream(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Raw Materials Inc.", ticker="RAW"))
+        kg.add_entity(_company("Components Corp.", ticker="CMP"))
+        kg.add_entity(_company("Final Product Co.", ticker="FIN"))
+        kg.add_relationship(
+            _relationship("ticker:RAW", "ticker:CMP", RelationshipType.SUPPLIER),
+        )
+        kg.add_relationship(
+            _relationship("ticker:CMP", "ticker:FIN", RelationshipType.SUPPLIER),
+        )
+        chain = kg.trace_supply_chain("ticker:FIN", direction="upstream")
+        ids = [e.entity_id for e in chain]
+        assert "ticker:CMP" in ids
+        assert "ticker:RAW" in ids
+
+    def test_trace_nonexistent_entity(self) -> None:
+        kg = KnowledgeGraph()
+        assert kg.trace_supply_chain("ticker:FAKE") == []
+
+    def test_trace_no_chain(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Isolated Corp.", ticker="ISO"))
+        assert kg.trace_supply_chain("ticker:ISO") == []
+
+
+# ── Serialization ─────────────────────────────────────────────
+
+
+class TestSerialization:
+    def test_roundtrip_to_dict(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        kg.add_entity(_company("Intel Corp.", ticker="INTC"))
+        kg.add_relationship(
+            _relationship("ticker:INTC", "ticker:AAPL", RelationshipType.SUPPLIER),
+        )
+        data = kg.to_dict()
+        restored = KnowledgeGraph.from_dict(data)
+        assert restored.entity_count == 2
+        assert restored.relationship_count == 1
+        entity = restored.get_entity("ticker:AAPL")
+        assert entity is not None
+        assert entity.name == "Apple Inc."
+
+    def test_roundtrip_to_json(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        json_str = kg.to_json()
+        restored = KnowledgeGraph.from_json(json_str)
+        assert restored.entity_count == 1
+
+    def test_serialization_preserves_provenance(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("A Corp.", ticker="A"))
+        kg.add_entity(_company("B Corp.", ticker="B"))
+        rel = Relationship(
+            source_id="ticker:A",
+            target_id="ticker:B",
+            rel_type=RelationshipType.PARTNER,
+            evidence="A partners with B",
+            source_doc="annual-report-2024",
+            confidence=Decimal("0.8"),
+        )
+        kg.add_relationship(rel)
+        restored = KnowledgeGraph.from_dict(kg.to_dict())
+        rels = restored.get_relationships("ticker:A")
+        assert len(rels) == 1
+        assert rels[0].evidence == "A partners with B"
+        assert rels[0].source_doc == "annual-report-2024"
+
+
+# ── Merge ─────────────────────────────────────────────────────
+
+
+class TestMerge:
+    def test_merge_adds_new_entities(self) -> None:
+        kg1 = KnowledgeGraph()
+        kg1.add_entity(_company("A Corp.", ticker="A"))
+        kg2 = KnowledgeGraph()
+        kg2.add_entity(_company("B Corp.", ticker="B"))
+        kg1.merge(kg2)
+        assert kg1.entity_count == 2
+
+    def test_merge_deduplicates_entities(self) -> None:
+        kg1 = KnowledgeGraph()
+        kg1.add_entity(_company("Apple Inc.", ticker="AAPL"))
+        kg2 = KnowledgeGraph()
+        kg2.add_entity(
+            Entity(
+                name="Apple Inc.", entity_type=EntityType.COMPANY,
+                ticker="AAPL", metadata={"extra": "data"},
+            ),
+        )
+        kg1.merge(kg2)
+        assert kg1.entity_count == 1
+        entity = kg1.get_entity("ticker:AAPL")
+        assert entity is not None
+        assert entity.metadata.get("extra") == "data"
+
+    def test_merge_deduplicates_edges(self) -> None:
+        kg1 = KnowledgeGraph()
+        kg1.add_entity(_company("A Corp.", ticker="A"))
+        kg1.add_entity(_company("B Corp.", ticker="B"))
+        rel = _relationship("ticker:A", "ticker:B", RelationshipType.SUPPLIER, evidence="same")
+        kg1.add_relationship(rel)
+
+        kg2 = KnowledgeGraph()
+        kg2.add_entity(_company("A Corp.", ticker="A"))
+        kg2.add_entity(_company("B Corp.", ticker="B"))
+        kg2.add_relationship(rel)
+
+        kg1.merge(kg2)
+        assert kg1.relationship_count == 1
+
+
+# ── Stats ─────────────────────────────────────────────────────
+
+
+class TestStats:
+    def test_stats_counts(self) -> None:
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("A Corp.", ticker="A"))
+        kg.add_entity(_risk("cybersecurity"))
+        kg.add_entity(_company("B Corp.", ticker="B"))
+        kg.add_relationship(
+            _relationship("ticker:A", "ticker:B", RelationshipType.COMPETITOR),
+        )
+        stats = kg.stats()
+        assert stats["entity_count"] == 3
+        assert stats["relationship_count"] == 1
+        assert stats["entities_by_type"]["company"] == 2
+        assert stats["entities_by_type"]["risk"] == 1
+        assert stats["relationships_by_type"]["competitor"] == 1
+
+    def test_stats_empty_graph(self) -> None:
+        kg = KnowledgeGraph()
+        stats = kg.stats()
+        assert stats["entity_count"] == 0
+        assert stats["relationship_count"] == 0
+        assert stats["entities_by_type"] == {}
+        assert stats["relationships_by_type"] == {}

--- a/agents/tests/test_knowledge_graph.py
+++ b/agents/tests/test_knowledge_graph.py
@@ -391,6 +391,15 @@ class TestSerialization:
         assert rels[0].evidence == "A partners with B"
         assert rels[0].source_doc == "annual-report-2024"
 
+    def test_from_dict_does_not_mutate_input(self) -> None:
+        """from_dict must not mutate the caller-provided data structure."""
+        kg = KnowledgeGraph()
+        kg.add_entity(_company("A Corp.", ticker="A"))
+        data = kg.to_dict()
+        original_entity_keys = set(data["entities"][0].keys())
+        KnowledgeGraph.from_dict(data)
+        assert set(data["entities"][0].keys()) == original_entity_keys
+
 
 # ── Merge ─────────────────────────────────────────────────────
 

--- a/agents/tests/test_web_api.py
+++ b/agents/tests/test_web_api.py
@@ -451,3 +451,110 @@ class TestCORS:
     def test_response_includes_cors_header(self, client):
         resp = client.get("/health", headers={"Origin": "http://localhost:3000"})
         assert resp.headers.get("access-control-allow-origin") is not None
+
+
+# --- Knowledge Graph Endpoints ---
+
+
+class TestKGExtract:
+    def test_extract_entities_from_text(self, client):
+        resp = client.post("/kg/extract", json={
+            "text": "Apple Inc. faces cybersecurity and regulatory risk.",
+            "source_doc": "10-K-2024",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entity_count"] >= 1
+        assert len(data["entities"]) == data["entity_count"]
+
+    def test_extract_with_ticker(self, client):
+        resp = client.post("/kg/extract", json={
+            "text": "Apple Inc. reported record revenue.",
+            "ticker": "AAPL",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        apple_entities = [e for e in data["entities"] if "Apple" in e["name"]]
+        assert len(apple_entities) >= 1
+        assert apple_entities[0]["ticker"] == "AAPL"
+
+    def test_extract_empty_text_422(self, client):
+        resp = client.post("/kg/extract", json={"text": ""})
+        assert resp.status_code == 422
+
+    def test_extract_missing_text_422(self, client):
+        resp = client.post("/kg/extract", json={})
+        assert resp.status_code == 422
+
+
+class TestKGQueryRelated:
+    def test_query_related_returns_response(self, client):
+        # Seed the graph first
+        client.post("/kg/extract", json={
+            "text": "Intel Corp. supplies chips to Apple Inc. every year.",
+        })
+        resp = client.post("/kg/query/related", json={
+            "entity_id": "name:intel corp.",
+            "max_depth": 1,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "related" in data
+        assert "count" in data
+
+    def test_query_related_nonexistent_entity(self, client):
+        resp = client.post("/kg/query/related", json={
+            "entity_id": "ticker:NONEXISTENT",
+        })
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 0
+
+    def test_query_related_empty_id_422(self, client):
+        resp = client.post("/kg/query/related", json={"entity_id": ""})
+        assert resp.status_code == 422
+
+
+class TestKGQuerySupplyChain:
+    def test_supply_chain_returns_response(self, client):
+        resp = client.post("/kg/query/supply-chain", json={
+            "entity_id": "ticker:AAPL",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["direction"] == "upstream"
+        assert "chain" in data
+
+    def test_supply_chain_invalid_direction_422(self, client):
+        resp = client.post("/kg/query/supply-chain", json={
+            "entity_id": "ticker:AAPL",
+            "direction": "sideways",
+        })
+        assert resp.status_code == 422
+
+
+class TestKGQuerySharedRisks:
+    def test_shared_risks_returns_response(self, client):
+        resp = client.post("/kg/query/shared-risks", json={
+            "entity_ids": ["ticker:AAPL", "ticker:MSFT"],
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "shared_risks" in data
+        assert "count" in data
+
+    def test_shared_risks_fewer_than_two_422(self, client):
+        resp = client.post("/kg/query/shared-risks", json={
+            "entity_ids": ["ticker:AAPL"],
+        })
+        assert resp.status_code == 422
+
+
+class TestKGStats:
+    def test_stats_returns_counts(self, client):
+        resp = client.get("/kg/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "entity_count" in data
+        assert "relationship_count" in data
+        assert "entities_by_type" in data
+        assert "relationships_by_type" in data

--- a/agents/tests/test_web_api.py
+++ b/agents/tests/test_web_api.py
@@ -550,7 +550,9 @@ class TestKGQuerySharedRisks:
 
         graph = _web_api_module._kg_graph
         graph.add_entity(Entity(name="Apple Inc", entity_type=EntityType.COMPANY, ticker="AAPL"))
-        graph.add_entity(Entity(name="Microsoft Corp", entity_type=EntityType.COMPANY, ticker="MSFT"))
+        graph.add_entity(Entity(
+            name="Microsoft Corp", entity_type=EntityType.COMPANY, ticker="MSFT",
+        ))
         graph.add_entity(Entity(name="cybersecurity", entity_type=EntityType.RISK))
         graph.add_relationship(Relationship(
             source_id="ticker:AAPL", target_id="name:cybersecurity",

--- a/agents/tests/test_web_api.py
+++ b/agents/tests/test_web_api.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+import src.web_api as _web_api_module
 from src.application.contracts.agents import (
     AnalyzeEarningsResponse,
     AssessRiskResponse,
@@ -22,15 +23,19 @@ from src.application.contracts.agents import (
     SearchFilingsResponse,
 )
 from src.application.registry import AGENT_CATALOG
+from src.core.knowledge_graph import KnowledgeGraph
 from src.web_api import app, get_config
 
 
 @pytest.fixture
 def client():
-    """TestClient for the FastAPI app."""
+    """TestClient for the FastAPI app with fresh KG graph per test."""
     get_config.cache_clear()
+    original_graph = _web_api_module._kg_graph
+    _web_api_module._kg_graph = KnowledgeGraph()
     with TestClient(app) as test_client:
         yield test_client
+    _web_api_module._kg_graph = original_graph
     get_config.cache_clear()
 
 
@@ -494,13 +499,13 @@ class TestKGQueryRelated:
             "text": "Intel Corp. supplies chips to Apple Inc. every year.",
         })
         resp = client.post("/kg/query/related", json={
-            "entity_id": "name:intel corp.",
+            "entity_id": "name:intel corp",
             "max_depth": 1,
         })
         assert resp.status_code == 200
         data = resp.json()
-        assert "related" in data
-        assert "count" in data
+        assert data["count"] >= 1
+        assert len(data["related"]) == data["count"]
 
     def test_query_related_nonexistent_entity(self, client):
         resp = client.post("/kg/query/related", json={
@@ -534,13 +539,19 @@ class TestKGQuerySupplyChain:
 
 class TestKGQuerySharedRisks:
     def test_shared_risks_returns_response(self, client):
+        # Seed: two companies sharing the same risk
+        client.post("/kg/extract", json={
+            "text": (
+                "Apple Inc. faces cybersecurity threats."
+                " Microsoft Corp. also faces cybersecurity risks."
+            ),
+        })
         resp = client.post("/kg/query/shared-risks", json={
-            "entity_ids": ["ticker:AAPL", "ticker:MSFT"],
+            "entity_ids": ["name:apple inc.", "name:microsoft corp."],
         })
         assert resp.status_code == 200
         data = resp.json()
-        assert "shared_risks" in data
-        assert "count" in data
+        assert len(data["shared_risks"]) == data["count"]
 
     def test_shared_risks_fewer_than_two_422(self, client):
         resp = client.post("/kg/query/shared-risks", json={
@@ -554,7 +565,16 @@ class TestKGStats:
         resp = client.get("/kg/stats")
         assert resp.status_code == 200
         data = resp.json()
-        assert "entity_count" in data
-        assert "relationship_count" in data
-        assert "entities_by_type" in data
-        assert "relationships_by_type" in data
+        assert isinstance(data["entity_count"], int)
+        assert isinstance(data["relationship_count"], int)
+        assert isinstance(data["entities_by_type"], dict)
+        assert isinstance(data["relationships_by_type"], dict)
+
+    def test_stats_reflects_extraction(self, client):
+        client.post("/kg/extract", json={
+            "text": "Apple Inc. is facing cybersecurity concerns.",
+        })
+        resp = client.get("/kg/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entity_count"] >= 1

--- a/agents/tests/test_web_api.py
+++ b/agents/tests/test_web_api.py
@@ -521,13 +521,19 @@ class TestKGQueryRelated:
 
 class TestKGQuerySupplyChain:
     def test_supply_chain_returns_response(self, client):
+        # Seed a supplier relationship
+        client.post("/kg/extract", json={
+            "text": "Intel Corp. supplies chips to Dell Inc.",
+        })
         resp = client.post("/kg/query/supply-chain", json={
-            "entity_id": "ticker:AAPL",
+            "entity_id": "name:dell inc",
+            "direction": "upstream",
         })
         assert resp.status_code == 200
         data = resp.json()
         assert data["direction"] == "upstream"
-        assert "chain" in data
+        chain_names = [e["name"] for e in data["chain"]]
+        assert any("intel" in n.lower() for n in chain_names)
 
     def test_supply_chain_invalid_direction_422(self, client):
         resp = client.post("/kg/query/supply-chain", json={
@@ -539,19 +545,29 @@ class TestKGQuerySupplyChain:
 
 class TestKGQuerySharedRisks:
     def test_shared_risks_returns_response(self, client):
-        # Seed: two companies sharing the same risk
-        client.post("/kg/extract", json={
-            "text": (
-                "Apple Inc. faces cybersecurity threats."
-                " Microsoft Corp. also faces cybersecurity risks."
-            ),
-        })
+        # Seed graph directly — extract doesn't create company→risk relationships
+        from src.core.knowledge_graph import Entity, EntityType, Relationship, RelationshipType
+
+        graph = _web_api_module._kg_graph
+        graph.add_entity(Entity(name="Apple Inc", entity_type=EntityType.COMPANY, ticker="AAPL"))
+        graph.add_entity(Entity(name="Microsoft Corp", entity_type=EntityType.COMPANY, ticker="MSFT"))
+        graph.add_entity(Entity(name="cybersecurity", entity_type=EntityType.RISK))
+        graph.add_relationship(Relationship(
+            source_id="ticker:AAPL", target_id="name:cybersecurity",
+            rel_type=RelationshipType.PARTNER, evidence="AAPL faces cyber risk",
+        ))
+        graph.add_relationship(Relationship(
+            source_id="ticker:MSFT", target_id="name:cybersecurity",
+            rel_type=RelationshipType.PARTNER, evidence="MSFT faces cyber risk",
+        ))
         resp = client.post("/kg/query/shared-risks", json={
-            "entity_ids": ["name:apple inc.", "name:microsoft corp."],
+            "entity_ids": ["ticker:AAPL", "ticker:MSFT"],
         })
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data["shared_risks"]) == data["count"]
+        assert data["count"] >= 1
+        risk_names = [r["name"] for r in data["shared_risks"]]
+        assert any("cyber" in n.lower() for n in risk_names)
 
     def test_shared_risks_fewer_than_two_422(self, client):
         resp = client.post("/kg/query/shared-risks", json={


### PR DESCRIPTION
## Summary
Knowledge graph implementation for company/entity relationship mapping using networkx.

## What's included

### Core graph engine (`src/core/knowledge_graph.py`)
- `KnowledgeGraph` wrapping `networkx.MultiDiGraph` — supports multiple relationship types per entity pair
- Canonical entity identity: ticker → CIK → normalized name
- Entity types: company, product, risk, technology, person, sector
- Relationship types: supplier, customer, competitor, technology_user, regulatory, subsidiary, partner
- Graph queries: find related (BFS), trace supply chain, find shared risks
- JSON serialization roundtrip and graph merge with dedup
- Provenance on every relationship (evidence text, source document, confidence)

### Entity extraction (`src/core/entity_extraction.py`)
- High-precision regex patterns for company names (corporate suffixes)
- Risk taxonomy (20 categories: cybersecurity, regulatory, supply chain, etc.)
- Technology keyword extraction
- Relationship indicator patterns with confidence scoring
- Provenance tracking on every extraction

### Application layer
- Pydantic contracts for extract, query (related/supply-chain/shared-risks), stats
- `KnowledgeGraphService` wrapping core graph with typed API
- Process-level graph store (persists across requests)

### Web API (5 new endpoints)
- `POST /kg/extract` — extract and ingest entities from text
- `POST /kg/query/related` — find related entities by traversal depth
- `POST /kg/query/supply-chain` — trace upstream/downstream supply chain
- `POST /kg/query/shared-risks` — find risk entities shared across companies
- `GET /kg/stats` — graph summary statistics

### Tests (86 new)
- 37 core graph tests (CRUD, queries, serialization, merge)
- 20 entity extraction tests (company, risk, technology, relationship, provenance)
- 17 service layer tests (extract/ingest, query, stats, validation)
- 12 web API endpoint tests (positive + negative per endpoint)

### Dependencies
- Added `networkx>=3.4` to `pyproject.toml`

Part of #54