### PR TITLE
feat: Persistent watchlists — named ticker lists across sessions

### DIFF
--- a/agents/src/application/watchlists.py
+++ b/agents/src/application/watchlists.py
@@ -19,6 +19,10 @@ from pydantic import BaseModel, Field
 
 from src.application.config import CONFIG_DIR
 
+
+class WatchlistNotFoundError(Exception):
+    """Raised when a watchlist name is not found in the store."""
+
 WATCHLIST_FILE = CONFIG_DIR / "watchlists.json"
 _SLUG_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$|^[a-z0-9]$")
 
@@ -152,7 +156,7 @@ class WatchlistStore:
             data = self._load()
             if slug not in data.watchlists:
                 msg = f"Watchlist '{slug}' not found"
-                raise KeyError(msg)
+                raise WatchlistNotFoundError(msg)
             return data.watchlists[slug].model_dump()
 
     def create(self, name: str, tickers: list[str] | None = None) -> dict[str, Any]:
@@ -176,7 +180,7 @@ class WatchlistStore:
             data = self._load()
             if slug not in data.watchlists:
                 msg = f"Watchlist '{slug}' not found"
-                raise KeyError(msg)
+                raise WatchlistNotFoundError(msg)
             data.watchlists[slug] = Watchlist(tickers=normalized)
             self._save(data)
             return data.watchlists[slug].model_dump()
@@ -188,7 +192,7 @@ class WatchlistStore:
             data = self._load()
             if slug not in data.watchlists:
                 msg = f"Watchlist '{slug}' not found"
-                raise KeyError(msg)
+                raise WatchlistNotFoundError(msg)
             if slug == data.active:
                 msg = "Cannot delete the active watchlist"
                 raise ValueError(msg)
@@ -202,7 +206,7 @@ class WatchlistStore:
             data = self._load()
             if slug not in data.watchlists:
                 msg = f"Watchlist '{slug}' not found"
-                raise KeyError(msg)
+                raise WatchlistNotFoundError(msg)
             data.active = slug
             self._save(data)
             return {

--- a/agents/src/application/watchlists.py
+++ b/agents/src/application/watchlists.py
@@ -9,6 +9,7 @@ non-blocking access from async endpoints).
 
 import json
 import logging
+import os
 import re
 import tempfile
 import threading
@@ -94,6 +95,7 @@ class WatchlistStore:
                 temp_path = Path(fd.name)
                 fd.write(content)
                 fd.flush()
+                os.fsync(fd.fileno())
             temp_path.replace(self._path)
         except BaseException:
             if temp_path is not None:

--- a/agents/src/application/watchlists.py
+++ b/agents/src/application/watchlists.py
@@ -15,7 +15,7 @@ import threading
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from src.application.config import CONFIG_DIR
 
@@ -28,14 +28,14 @@ logger = logging.getLogger(__name__)
 class Watchlist(BaseModel):
     """A named list of ticker symbols."""
 
-    tickers: list[str] = []
+    tickers: list[str] = Field(default_factory=list)
 
 
 class WatchlistData(BaseModel):
     """Root schema for watchlists.json."""
 
     active: str = "default"
-    watchlists: dict[str, Watchlist] = {}
+    watchlists: dict[str, Watchlist] = Field(default_factory=dict)
 
 
 class WatchlistStore:
@@ -52,16 +52,19 @@ class WatchlistStore:
     def _load(self) -> WatchlistData:
         """Load watchlist data from disk, creating defaults if needed."""
         if not self._path.is_file():
-            return self._default_data()
-        try:
-            raw = json.loads(self._path.read_text(encoding="utf-8"))
-            return WatchlistData.model_validate(raw)
-        except (json.JSONDecodeError, ValueError):
-            logger.warning(
-                "Corrupt watchlists.json at %s — resetting to defaults",
-                self._path,
-            )
-            return self._default_data()
+            data = self._default_data()
+        else:
+            try:
+                raw = json.loads(self._path.read_text(encoding="utf-8"))
+                data = WatchlistData.model_validate(raw)
+            except (json.JSONDecodeError, ValueError):
+                logger.warning(
+                    "Corrupt watchlists.json at %s — resetting to defaults",
+                    self._path,
+                )
+                data = self._default_data()
+        self._ensure_invariants(data)
+        return data
 
     def _save(self, data: WatchlistData) -> None:
         """Atomically write watchlist data to disk."""
@@ -112,7 +115,7 @@ class WatchlistStore:
         if not _SLUG_PATTERN.match(slug):
             msg = (
                 f"Invalid watchlist name '{name}'. "
-                "Use lowercase letters, digits, and hyphens (2-50 chars)."
+                "Use lowercase letters, digits, and hyphens (1-50 chars)."
             )
             raise ValueError(msg)
         return slug
@@ -121,7 +124,6 @@ class WatchlistStore:
         """Return all watchlists with active indicator."""
         with self._lock:
             data = self._load()
-            self._ensure_invariants(data)
             return {
                 "active": data.active,
                 "watchlists": {
@@ -149,7 +151,6 @@ class WatchlistStore:
         normalized = self._normalize_tickers(tickers or [])
         with self._lock:
             data = self._load()
-            self._ensure_invariants(data)
             if slug in data.watchlists:
                 msg = f"Watchlist '{slug}' already exists"
                 raise ValueError(msg)
@@ -175,7 +176,6 @@ class WatchlistStore:
         slug = self.validate_name(name)
         with self._lock:
             data = self._load()
-            self._ensure_invariants(data)
             if slug not in data.watchlists:
                 msg = f"Watchlist '{slug}' not found"
                 raise KeyError(msg)

--- a/agents/src/application/watchlists.py
+++ b/agents/src/application/watchlists.py
@@ -1,0 +1,209 @@
+"""Watchlist persistence — named ticker lists stored on disk.
+
+Storage location: ~/.config/finance-os/watchlists.json
+Separate from config.json to keep user state distinct from app config.
+
+Thread-safe via threading.Lock (callers use asyncio.to_thread for
+non-blocking access from async endpoints).
+"""
+
+import json
+import logging
+import re
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from src.application.config import CONFIG_DIR
+
+WATCHLIST_FILE = CONFIG_DIR / "watchlists.json"
+_SLUG_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$|^[a-z0-9]$")
+
+logger = logging.getLogger(__name__)
+
+
+class Watchlist(BaseModel):
+    """A named list of ticker symbols."""
+
+    tickers: list[str] = []
+
+
+class WatchlistData(BaseModel):
+    """Root schema for watchlists.json."""
+
+    active: str = "default"
+    watchlists: dict[str, Watchlist] = {}
+
+
+class WatchlistStore:
+    """Thread-safe watchlist persistence backed by a JSON file.
+
+    All mutations use atomic writes (write to temp + rename) to
+    prevent corruption from interrupted writes.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or WATCHLIST_FILE
+        self._lock = threading.Lock()
+
+    def _load(self) -> WatchlistData:
+        """Load watchlist data from disk, creating defaults if needed."""
+        if not self._path.is_file():
+            return self._default_data()
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            return WatchlistData.model_validate(raw)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning(
+                "Corrupt watchlists.json at %s — resetting to defaults",
+                self._path,
+            )
+            return self._default_data()
+
+    def _save(self, data: WatchlistData) -> None:
+        """Atomically write watchlist data to disk."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        content = json.dumps(
+            data.model_dump(), indent=2, ensure_ascii=False,
+        )
+        fd = tempfile.NamedTemporaryFile(
+            mode="w",
+            dir=self._path.parent,
+            suffix=".tmp",
+            delete=False,
+            encoding="utf-8",
+        )
+        try:
+            fd.write(content)
+            fd.flush()
+            fd.close()
+            Path(fd.name).replace(self._path)
+        except BaseException:
+            Path(fd.name).unlink(missing_ok=True)
+            raise
+
+    @staticmethod
+    def _default_data() -> WatchlistData:
+        return WatchlistData(
+            active="default",
+            watchlists={"default": Watchlist()},
+        )
+
+    @staticmethod
+    def _normalize_tickers(tickers: list[str]) -> list[str]:
+        """Uppercase, deduplicate, sort."""
+        seen: set[str] = set()
+        result: list[str] = []
+        for t in tickers:
+            upper = t.strip().upper()
+            if upper and upper not in seen:
+                seen.add(upper)
+                result.append(upper)
+        result.sort()
+        return result
+
+    @staticmethod
+    def validate_name(name: str) -> str:
+        """Validate and normalize a watchlist name."""
+        slug = name.strip().lower()
+        if not _SLUG_PATTERN.match(slug):
+            msg = (
+                f"Invalid watchlist name '{name}'. "
+                "Use lowercase letters, digits, and hyphens (2-50 chars)."
+            )
+            raise ValueError(msg)
+        return slug
+
+    def list_all(self) -> dict[str, Any]:
+        """Return all watchlists with active indicator."""
+        with self._lock:
+            data = self._load()
+            self._ensure_invariants(data)
+            return {
+                "active": data.active,
+                "watchlists": {
+                    name: wl.model_dump()
+                    for name, wl in data.watchlists.items()
+                },
+                "active_watchlist": data.watchlists[
+                    data.active
+                ].model_dump(),
+            }
+
+    def get(self, name: str) -> dict[str, Any]:
+        """Get a specific watchlist by name."""
+        slug = self.validate_name(name)
+        with self._lock:
+            data = self._load()
+            if slug not in data.watchlists:
+                msg = f"Watchlist '{slug}' not found"
+                raise KeyError(msg)
+            return data.watchlists[slug].model_dump()
+
+    def create(self, name: str, tickers: list[str] | None = None) -> dict[str, Any]:
+        """Create a new watchlist."""
+        slug = self.validate_name(name)
+        normalized = self._normalize_tickers(tickers or [])
+        with self._lock:
+            data = self._load()
+            self._ensure_invariants(data)
+            if slug in data.watchlists:
+                msg = f"Watchlist '{slug}' already exists"
+                raise ValueError(msg)
+            data.watchlists[slug] = Watchlist(tickers=normalized)
+            self._save(data)
+            return data.watchlists[slug].model_dump()
+
+    def update(self, name: str, tickers: list[str]) -> dict[str, Any]:
+        """Replace the ticker list for a watchlist."""
+        slug = self.validate_name(name)
+        normalized = self._normalize_tickers(tickers)
+        with self._lock:
+            data = self._load()
+            if slug not in data.watchlists:
+                msg = f"Watchlist '{slug}' not found"
+                raise KeyError(msg)
+            data.watchlists[slug] = Watchlist(tickers=normalized)
+            self._save(data)
+            return data.watchlists[slug].model_dump()
+
+    def delete(self, name: str) -> None:
+        """Delete a watchlist (cannot delete the active one)."""
+        slug = self.validate_name(name)
+        with self._lock:
+            data = self._load()
+            self._ensure_invariants(data)
+            if slug not in data.watchlists:
+                msg = f"Watchlist '{slug}' not found"
+                raise KeyError(msg)
+            if slug == data.active:
+                msg = "Cannot delete the active watchlist"
+                raise ValueError(msg)
+            del data.watchlists[slug]
+            self._save(data)
+
+    def activate(self, name: str) -> dict[str, Any]:
+        """Set a watchlist as active."""
+        slug = self.validate_name(name)
+        with self._lock:
+            data = self._load()
+            if slug not in data.watchlists:
+                msg = f"Watchlist '{slug}' not found"
+                raise KeyError(msg)
+            data.active = slug
+            self._save(data)
+            return {
+                "active": slug,
+                "watchlist": data.watchlists[slug].model_dump(),
+            }
+
+    def _ensure_invariants(self, data: WatchlistData) -> None:
+        """Guarantee at least one watchlist exists and active is valid."""
+        if not data.watchlists:
+            data.watchlists["default"] = Watchlist()
+            data.active = "default"
+        if data.active not in data.watchlists:
+            data.active = next(iter(data.watchlists))

--- a/agents/src/application/watchlists.py
+++ b/agents/src/application/watchlists.py
@@ -51,8 +51,10 @@ class WatchlistStore:
 
     def _load(self) -> WatchlistData:
         """Load watchlist data from disk, creating defaults if needed."""
+        repaired = False
         if not self._path.is_file():
             data = self._default_data()
+            repaired = True
         else:
             try:
                 raw = json.loads(self._path.read_text(encoding="utf-8"))
@@ -63,7 +65,11 @@ class WatchlistStore:
                     self._path,
                 )
                 data = self._default_data()
+                repaired = True
+        before = data.model_dump()
         self._ensure_invariants(data)
+        if repaired or data.model_dump() != before:
+            self._save(data)
         return data
 
     def _save(self, data: WatchlistData) -> None:
@@ -117,7 +123,9 @@ class WatchlistStore:
         if not _SLUG_PATTERN.match(slug):
             msg = (
                 f"Invalid watchlist name '{name}'. "
-                "Use lowercase letters, digits, and hyphens (1-50 chars)."
+                "Names are case-insensitive and stored in lowercase; use "
+                "letters, digits, and hyphens only, 1-50 characters, and do "
+                "not start or end with a hyphen."
             )
             raise ValueError(msg)
         return slug

--- a/agents/src/application/watchlists.py
+++ b/agents/src/application/watchlists.py
@@ -72,20 +72,22 @@ class WatchlistStore:
         content = json.dumps(
             data.model_dump(), indent=2, ensure_ascii=False,
         )
-        fd = tempfile.NamedTemporaryFile(
-            mode="w",
-            dir=self._path.parent,
-            suffix=".tmp",
-            delete=False,
-            encoding="utf-8",
-        )
+        temp_path: Path | None = None
         try:
-            fd.write(content)
-            fd.flush()
-            fd.close()
-            Path(fd.name).replace(self._path)
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                dir=self._path.parent,
+                suffix=".tmp",
+                delete=False,
+                encoding="utf-8",
+            ) as fd:
+                temp_path = Path(fd.name)
+                fd.write(content)
+                fd.flush()
+            temp_path.replace(self._path)
         except BaseException:
-            Path(fd.name).unlink(missing_ok=True)
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
             raise
 
     @staticmethod

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -25,6 +25,7 @@ import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
 
 from src.application.config import AppConfig
 from src.application.contracts.agents import (
@@ -67,6 +68,19 @@ from src.core.knowledge_graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
 
+
+class CreateWatchlistRequest(BaseModel):
+    """Request body for creating a watchlist."""
+
+    name: str
+    tickers: list[str] = Field(default_factory=list)
+
+
+class UpdateWatchlistRequest(BaseModel):
+    """Request body for updating a watchlist's tickers."""
+
+    tickers: list[str]
+
 # Process-level knowledge graph store (persists across requests like a DB)
 _kg_graph = KnowledgeGraph()
 _kg_lock = asyncio.Lock()
@@ -106,7 +120,8 @@ async def value_error_handler(_request: Request, exc: ValueError) -> JSONRespons
 @app.exception_handler(KeyError)
 async def key_error_handler(_request: Request, exc: KeyError) -> JSONResponse:
     """Map KeyError (not found) to 404."""
-    return JSONResponse(status_code=404, content={"detail": str(exc)})
+    detail = exc.args[0] if exc.args else str(exc)
+    return JSONResponse(status_code=404, content={"detail": detail})
 
 
 # --- Health & Info ---
@@ -286,11 +301,11 @@ async def list_watchlists() -> Any:
 
 
 @app.post("/watchlists", status_code=201)
-async def create_watchlist(body: dict[str, Any]) -> Any:
+async def create_watchlist(body: CreateWatchlistRequest) -> Any:
     """Create a new named watchlist."""
-    name = body.get("name", "")
-    tickers = body.get("tickers", [])
-    return await asyncio.to_thread(_watchlist_store.create, name, tickers)
+    return await asyncio.to_thread(
+        _watchlist_store.create, body.name, body.tickers,
+    )
 
 
 @app.get("/watchlists/{name}")
@@ -300,10 +315,11 @@ async def get_watchlist(name: str) -> Any:
 
 
 @app.put("/watchlists/{name}")
-async def update_watchlist(name: str, body: dict[str, Any]) -> Any:
+async def update_watchlist(name: str, body: UpdateWatchlistRequest) -> Any:
     """Update tickers in a watchlist."""
-    tickers = body.get("tickers", [])
-    return await asyncio.to_thread(_watchlist_store.update, name, tickers)
+    return await asyncio.to_thread(
+        _watchlist_store.update, name, body.tickers,
+    )
 
 
 @app.delete("/watchlists/{name}", status_code=204)

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -63,7 +63,7 @@ from src.application.registry import AGENT_CATALOG, create_pipeline_service
 from src.application.services.agent_service import AgentService
 from src.application.services.digest_service import DigestService
 from src.application.services.kg_service import KnowledgeGraphService
-from src.application.watchlists import WatchlistStore
+from src.application.watchlists import WatchlistNotFoundError, WatchlistStore
 from src.core.knowledge_graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
@@ -117,11 +117,12 @@ async def value_error_handler(_request: Request, exc: ValueError) -> JSONRespons
     return JSONResponse(status_code=400, content={"detail": str(exc)})
 
 
-@app.exception_handler(KeyError)
-async def key_error_handler(_request: Request, exc: KeyError) -> JSONResponse:
-    """Map KeyError (not found) to 404."""
-    detail = exc.args[0] if exc.args else str(exc)
-    return JSONResponse(status_code=404, content={"detail": detail})
+@app.exception_handler(WatchlistNotFoundError)
+async def watchlist_not_found_handler(
+    _request: Request, exc: WatchlistNotFoundError,
+) -> JSONResponse:
+    """Map WatchlistNotFoundError to 404."""
+    return JSONResponse(status_code=404, content={"detail": str(exc)})
 
 
 # --- Health & Info ---

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -8,6 +8,9 @@ Knowledge graph endpoints share a process-level graph store that
 persists across requests (like a database), guarded by an asyncio
 lock for thread safety.
 
+Watchlist endpoints persist named ticker lists to disk at
+~/.config/finance-os/watchlists.json.
+
 Run locally:
     uvicorn src.web_api:app --reload
     finance-os-api              # console script
@@ -59,6 +62,7 @@ from src.application.registry import AGENT_CATALOG, create_pipeline_service
 from src.application.services.agent_service import AgentService
 from src.application.services.digest_service import DigestService
 from src.application.services.kg_service import KnowledgeGraphService
+from src.application.watchlists import WatchlistStore
 from src.core.knowledge_graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
@@ -66,6 +70,9 @@ logger = logging.getLogger(__name__)
 # Process-level knowledge graph store (persists across requests like a DB)
 _kg_graph = KnowledgeGraph()
 _kg_lock = asyncio.Lock()
+
+# Process-level watchlist store (persists to ~/.config/finance-os/watchlists.json)
+_watchlist_store = WatchlistStore()
 
 app = FastAPI(
     title="finance-os",
@@ -94,6 +101,12 @@ def get_config() -> AppConfig:
 async def value_error_handler(_request: Request, exc: ValueError) -> JSONResponse:
     """Map domain ValueError (bad input, unknown agent) to 400."""
     return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+
+@app.exception_handler(KeyError)
+async def key_error_handler(_request: Request, exc: KeyError) -> JSONResponse:
+    """Map KeyError (not found) to 404."""
+    return JSONResponse(status_code=404, content={"detail": str(exc)})
 
 
 # --- Health & Info ---
@@ -261,6 +274,48 @@ async def kg_stats() -> Any:
             None, _kg_service().get_stats,
         )
     return response.model_dump(mode="json")
+
+
+# --- Watchlists ---
+
+
+@app.get("/watchlists")
+async def list_watchlists() -> Any:
+    """List all watchlists with the active watchlist's data."""
+    return await asyncio.to_thread(_watchlist_store.list_all)
+
+
+@app.post("/watchlists", status_code=201)
+async def create_watchlist(body: dict[str, Any]) -> Any:
+    """Create a new named watchlist."""
+    name = body.get("name", "")
+    tickers = body.get("tickers", [])
+    return await asyncio.to_thread(_watchlist_store.create, name, tickers)
+
+
+@app.get("/watchlists/{name}")
+async def get_watchlist(name: str) -> Any:
+    """Get a specific watchlist by name."""
+    return await asyncio.to_thread(_watchlist_store.get, name)
+
+
+@app.put("/watchlists/{name}")
+async def update_watchlist(name: str, body: dict[str, Any]) -> Any:
+    """Update tickers in a watchlist."""
+    tickers = body.get("tickers", [])
+    return await asyncio.to_thread(_watchlist_store.update, name, tickers)
+
+
+@app.delete("/watchlists/{name}", status_code=204)
+async def delete_watchlist(name: str) -> None:
+    """Delete a watchlist (cannot delete the active one)."""
+    await asyncio.to_thread(_watchlist_store.delete, name)
+
+
+@app.put("/watchlists/{name}/activate")
+async def activate_watchlist(name: str) -> Any:
+    """Set a watchlist as the active one."""
+    return await asyncio.to_thread(_watchlist_store.activate, name)
 
 
 def main() -> None:

--- a/agents/tests/test_watchlists.py
+++ b/agents/tests/test_watchlists.py
@@ -1,0 +1,159 @@
+"""Tests for WatchlistStore — CRUD, persistence, invariants."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.application.watchlists import WatchlistStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> WatchlistStore:
+    """WatchlistStore backed by a temp file."""
+    return WatchlistStore(path=tmp_path / "watchlists.json")
+
+
+class TestListAll:
+    def test_empty_store_returns_default(self, store: WatchlistStore) -> None:
+        result = store.list_all()
+        assert result["active"] == "default"
+        assert "default" in result["watchlists"]
+        assert result["active_watchlist"] == {"tickers": []}
+
+    def test_list_includes_active_watchlist_data(
+        self, store: WatchlistStore,
+    ) -> None:
+        store.update("default", ["AAPL", "MSFT"])
+        result = store.list_all()
+        assert result["active_watchlist"]["tickers"] == ["AAPL", "MSFT"]
+
+
+class TestCreate:
+    def test_create_empty(self, store: WatchlistStore) -> None:
+        result = store.create("tech")
+        assert result == {"tickers": []}
+
+    def test_create_with_tickers(self, store: WatchlistStore) -> None:
+        result = store.create("energy", ["xom", "cvx"])
+        assert result["tickers"] == ["CVX", "XOM"]
+
+    def test_create_duplicate_rejects(self, store: WatchlistStore) -> None:
+        store.create("tech")
+        with pytest.raises(ValueError):
+            store.create("tech")
+
+    def test_create_normalizes_tickers(self, store: WatchlistStore) -> None:
+        result = store.create("mixed", ["aapl", "AAPL", " msft "])
+        assert result["tickers"] == ["AAPL", "MSFT"]
+
+
+class TestGet:
+    def test_get_existing(self, store: WatchlistStore) -> None:
+        store.create("tech", ["NVDA"])
+        result = store.get("tech")
+        assert result["tickers"] == ["NVDA"]
+
+    def test_get_nonexistent_raises(self, store: WatchlistStore) -> None:
+        with pytest.raises(KeyError):
+            store.get("nonexistent")
+
+
+class TestUpdate:
+    def test_update_replaces_tickers(self, store: WatchlistStore) -> None:
+        result = store.update("default", ["GOOG", "AMZN"])
+        assert result["tickers"] == ["AMZN", "GOOG"]
+
+    def test_update_nonexistent_raises(self, store: WatchlistStore) -> None:
+        with pytest.raises(KeyError):
+            store.update("nonexistent", ["AAPL"])
+
+    def test_update_deduplicates(self, store: WatchlistStore) -> None:
+        result = store.update("default", ["AAPL", "aapl", "MSFT"])
+        assert result["tickers"] == ["AAPL", "MSFT"]
+
+
+class TestDelete:
+    def test_delete_non_active(self, store: WatchlistStore) -> None:
+        store.create("temp")
+        store.delete("temp")
+        with pytest.raises(KeyError):
+            store.get("temp")
+
+    def test_delete_active_raises(self, store: WatchlistStore) -> None:
+        with pytest.raises(ValueError):
+            store.delete("default")
+
+    def test_delete_nonexistent_raises(self, store: WatchlistStore) -> None:
+        with pytest.raises(KeyError):
+            store.delete("nonexistent")
+
+
+class TestActivate:
+    def test_activate_switches(self, store: WatchlistStore) -> None:
+        store.create("tech", ["NVDA"])
+        result = store.activate("tech")
+        assert result["active"] == "tech"
+        assert result["watchlist"]["tickers"] == ["NVDA"]
+        assert store.list_all()["active"] == "tech"
+
+    def test_activate_nonexistent_raises(
+        self, store: WatchlistStore,
+    ) -> None:
+        with pytest.raises(KeyError):
+            store.activate("nonexistent")
+
+
+class TestNameValidation:
+    def test_valid_names(self, store: WatchlistStore) -> None:
+        for name in ["tech", "my-list", "a", "abc-123"]:
+            assert store.validate_name(name) == name
+
+    def test_invalid_names(self, store: WatchlistStore) -> None:
+        for name in ["", "My List", "has spaces", "-leading", "a/b"]:
+            with pytest.raises(ValueError):
+                store.validate_name(name)
+
+    def test_normalizes_case(self, store: WatchlistStore) -> None:
+        assert store.validate_name("Tech") == "tech"
+
+
+class TestPersistence:
+    def test_survives_reload(self, tmp_path: Path) -> None:
+        path = tmp_path / "watchlists.json"
+        store1 = WatchlistStore(path=path)
+        store1.update("default", ["AAPL", "MSFT"])
+        store2 = WatchlistStore(path=path)
+        assert store2.get("default")["tickers"] == ["AAPL", "MSFT"]
+
+    def test_corrupt_file_resets(self, tmp_path: Path) -> None:
+        path = tmp_path / "watchlists.json"
+        path.write_text("not valid json!!!", encoding="utf-8")
+        store = WatchlistStore(path=path)
+        result = store.list_all()
+        assert result["active"] == "default"
+
+    def test_missing_keys_handled(self, tmp_path: Path) -> None:
+        path = tmp_path / "watchlists.json"
+        path.write_text("{}", encoding="utf-8")
+        store = WatchlistStore(path=path)
+        result = store.list_all()
+        assert result["active"] == "default"
+
+
+class TestInvariants:
+    def test_active_always_exists(self, tmp_path: Path) -> None:
+        path = tmp_path / "watchlists.json"
+        bad_data = {"active": "gone", "watchlists": {"a": {"tickers": []}}}
+        path.write_text(json.dumps(bad_data), encoding="utf-8")
+        store = WatchlistStore(path=path)
+        result = store.list_all()
+        assert result["active"] in result["watchlists"]
+
+    def test_empty_watchlists_gets_default(self, tmp_path: Path) -> None:
+        path = tmp_path / "watchlists.json"
+        bad_data = {"active": "default", "watchlists": {}}
+        path.write_text(json.dumps(bad_data), encoding="utf-8")
+        store = WatchlistStore(path=path)
+        result = store.list_all()
+        assert "default" in result["watchlists"]

--- a/agents/tests/test_watchlists.py
+++ b/agents/tests/test_watchlists.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from src.application.watchlists import WatchlistStore
+from src.application.watchlists import WatchlistNotFoundError, WatchlistStore
 
 
 @pytest.fixture()
@@ -55,7 +55,7 @@ class TestGet:
         assert result["tickers"] == ["NVDA"]
 
     def test_get_nonexistent_raises(self, store: WatchlistStore) -> None:
-        with pytest.raises(KeyError):
+        with pytest.raises(WatchlistNotFoundError):
             store.get("nonexistent")
 
 
@@ -65,7 +65,7 @@ class TestUpdate:
         assert result["tickers"] == ["AMZN", "GOOG"]
 
     def test_update_nonexistent_raises(self, store: WatchlistStore) -> None:
-        with pytest.raises(KeyError):
+        with pytest.raises(WatchlistNotFoundError):
             store.update("nonexistent", ["AAPL"])
 
     def test_update_deduplicates(self, store: WatchlistStore) -> None:
@@ -77,7 +77,7 @@ class TestDelete:
     def test_delete_non_active(self, store: WatchlistStore) -> None:
         store.create("temp")
         store.delete("temp")
-        with pytest.raises(KeyError):
+        with pytest.raises(WatchlistNotFoundError):
             store.get("temp")
 
     def test_delete_active_raises(self, store: WatchlistStore) -> None:
@@ -85,7 +85,7 @@ class TestDelete:
             store.delete("default")
 
     def test_delete_nonexistent_raises(self, store: WatchlistStore) -> None:
-        with pytest.raises(KeyError):
+        with pytest.raises(WatchlistNotFoundError):
             store.delete("nonexistent")
 
 
@@ -100,7 +100,7 @@ class TestActivate:
     def test_activate_nonexistent_raises(
         self, store: WatchlistStore,
     ) -> None:
-        with pytest.raises(KeyError):
+        with pytest.raises(WatchlistNotFoundError):
             store.activate("nonexistent")
 
 

--- a/agents/tests/test_web_api.py
+++ b/agents/tests/test_web_api.py
@@ -28,13 +28,19 @@ from src.web_api import app, get_config
 
 
 @pytest.fixture
-def client():
-    """TestClient for the FastAPI app with fresh KG graph per test."""
+def client(tmp_path):
+    """TestClient with fresh KG graph and temp watchlist store per test."""
     get_config.cache_clear()
     original_graph = _web_api_module._kg_graph
     _web_api_module._kg_graph = KnowledgeGraph()
+    from src.application.watchlists import WatchlistStore
+    original_store = _web_api_module._watchlist_store
+    _web_api_module._watchlist_store = WatchlistStore(
+        path=tmp_path / "watchlists.json",
+    )
     with TestClient(app) as test_client:
         yield test_client
+    _web_api_module._watchlist_store = original_store
     _web_api_module._kg_graph = original_graph
     get_config.cache_clear()
 
@@ -596,3 +602,89 @@ class TestKGStats:
         assert resp.status_code == 200
         data = resp.json()
         assert data["entity_count"] >= 1
+
+
+# --- Watchlists ---
+
+
+class TestWatchlistList:
+    def test_list_returns_default(self, client):
+        resp = client.get("/watchlists")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["active"] == "default"
+        assert "default" in data["watchlists"]
+        assert data["active_watchlist"]["tickers"] == []
+
+
+class TestWatchlistCreate:
+    def test_create_new(self, client):
+        resp = client.post("/watchlists", json={
+            "name": "tech", "tickers": ["NVDA", "AAPL"],
+        })
+        assert resp.status_code == 201
+        assert resp.json()["tickers"] == ["AAPL", "NVDA"]
+
+    def test_create_duplicate_400(self, client):
+        client.post("/watchlists", json={"name": "tech"})
+        resp = client.post("/watchlists", json={"name": "tech"})
+        assert resp.status_code == 400
+
+    def test_create_invalid_name_400(self, client):
+        resp = client.post("/watchlists", json={"name": "Bad Name!"})
+        assert resp.status_code == 400
+
+
+class TestWatchlistGet:
+    def test_get_existing(self, client):
+        resp = client.get("/watchlists/default")
+        assert resp.status_code == 200
+        assert "tickers" in resp.json()
+
+    def test_get_nonexistent_404(self, client):
+        resp = client.get("/watchlists/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestWatchlistUpdate:
+    def test_update_tickers(self, client):
+        resp = client.put("/watchlists/default", json={
+            "tickers": ["MSFT", "GOOG"],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["tickers"] == ["GOOG", "MSFT"]
+        resp2 = client.get("/watchlists/default")
+        assert resp2.json()["tickers"] == ["GOOG", "MSFT"]
+
+    def test_update_nonexistent_404(self, client):
+        resp = client.put("/watchlists/nope", json={"tickers": []})
+        assert resp.status_code == 404
+
+
+class TestWatchlistDelete:
+    def test_delete_non_active(self, client):
+        client.post("/watchlists", json={"name": "temp"})
+        resp = client.delete("/watchlists/temp")
+        assert resp.status_code == 204
+        resp2 = client.get("/watchlists/temp")
+        assert resp2.status_code == 404
+
+    def test_delete_active_400(self, client):
+        resp = client.delete("/watchlists/default")
+        assert resp.status_code == 400
+
+
+class TestWatchlistActivate:
+    def test_activate_switches(self, client):
+        client.post("/watchlists", json={
+            "name": "energy", "tickers": ["XOM"],
+        })
+        resp = client.put("/watchlists/energy/activate")
+        assert resp.status_code == 200
+        assert resp.json()["active"] == "energy"
+        listing = client.get("/watchlists").json()
+        assert listing["active"] == "energy"
+
+    def test_activate_nonexistent_404(self, client):
+        resp = client.put("/watchlists/nope/activate")
+        assert resp.status_code == 404

--- a/web-ui/src/api.ts
+++ b/web-ui/src/api.ts
@@ -1,6 +1,6 @@
 /** Fetch wrapper for the finance-os Web API. */
 
-import type { AgentInfo, DigestRequest, DigestResponse, HealthResponse } from './types';
+import type { AgentInfo, DigestRequest, DigestResponse, HealthResponse, WatchlistData, WatchlistsResponse } from './types';
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? '/api';
 
@@ -36,5 +36,35 @@ export function runDigest(req: DigestRequest): Promise<DigestResponse> {
   return request('/digest', {
     method: 'POST',
     body: JSON.stringify(req),
+  });
+}
+
+export function fetchWatchlists(): Promise<WatchlistsResponse> {
+  return request('/watchlists');
+}
+
+export function updateWatchlist(name: string, tickers: string[]): Promise<WatchlistData> {
+  return request(`/watchlists/${encodeURIComponent(name)}`, {
+    method: 'PUT',
+    body: JSON.stringify({ tickers }),
+  });
+}
+
+export function createWatchlist(name: string, tickers: string[] = []): Promise<WatchlistData> {
+  return request('/watchlists', {
+    method: 'POST',
+    body: JSON.stringify({ name, tickers }),
+  });
+}
+
+export function deleteWatchlist(name: string): Promise<void> {
+  return request(`/watchlists/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  });
+}
+
+export function activateWatchlist(name: string): Promise<{ active: string; watchlist: WatchlistData }> {
+  return request(`/watchlists/${encodeURIComponent(name)}/activate`, {
+    method: 'PUT',
   });
 }

--- a/web-ui/src/api.ts
+++ b/web-ui/src/api.ts
@@ -21,6 +21,7 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     const detail = (body as Record<string, unknown>).detail ?? res.statusText;
     throw new Error(String(detail));
   }
+  if (res.status === 204) return undefined as T;
   return res.json() as Promise<T>;
 }
 

--- a/web-ui/src/components/DigestPanel.tsx
+++ b/web-ui/src/components/DigestPanel.tsx
@@ -38,10 +38,10 @@ export function DigestPanel() {
     saveToWatchlist(value);
   };
 
-  const handleWatchlistChange = (name: string, tickers: string[]) => {
+  const handleWatchlistChange = useCallback((name: string, tickers: string[]) => {
     activeWatchlistRef.current = name;
     setInput(tickers.join(', '));
-  };
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/web-ui/src/components/DigestPanel.tsx
+++ b/web-ui/src/components/DigestPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { runDigest, updateWatchlist } from '../api';
 import type { DigestResponse } from '../types';
 import { WatchlistSelector } from './WatchlistSelector';
@@ -19,15 +19,17 @@ export function DigestPanel() {
   const activeWatchlistRef = useRef('default');
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
+  useEffect(() => {
+    return () => clearTimeout(saveTimerRef.current);
+  }, []);
+
   const saveToWatchlist = useCallback((text: string) => {
     clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
       const tickers = parseTickers(text);
-      if (tickers.length > 0) {
-        updateWatchlist(activeWatchlistRef.current, tickers).catch(() => {
-          /* silent — best-effort save */
-        });
-      }
+      updateWatchlist(activeWatchlistRef.current, tickers).catch(() => {
+        /* silent — best-effort save */
+      });
     }, 1000);
   }, []);
 
@@ -36,7 +38,8 @@ export function DigestPanel() {
     saveToWatchlist(value);
   };
 
-  const handleWatchlistChange = (tickers: string[]) => {
+  const handleWatchlistChange = (name: string, tickers: string[]) => {
+    activeWatchlistRef.current = name;
     setInput(tickers.join(', '));
   };
 

--- a/web-ui/src/components/DigestPanel.tsx
+++ b/web-ui/src/components/DigestPanel.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import { runDigest } from '../api';
+import { useCallback, useRef, useState } from 'react';
+import { runDigest, updateWatchlist } from '../api';
 import type { DigestResponse } from '../types';
+import { WatchlistSelector } from './WatchlistSelector';
 
 function parseTickers(input: string): string[] {
   return input
@@ -15,6 +16,29 @@ export function DigestPanel() {
   const [result, setResult] = useState<DigestResponse | null>(null);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const activeWatchlistRef = useRef('default');
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const saveToWatchlist = useCallback((text: string) => {
+    clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      const tickers = parseTickers(text);
+      if (tickers.length > 0) {
+        updateWatchlist(activeWatchlistRef.current, tickers).catch(() => {
+          /* silent — best-effort save */
+        });
+      }
+    }, 1000);
+  }, []);
+
+  const handleInputChange = (value: string) => {
+    setInput(value);
+    saveToWatchlist(value);
+  };
+
+  const handleWatchlistChange = (tickers: string[]) => {
+    setInput(tickers.join(', '));
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -27,6 +51,7 @@ export function DigestPanel() {
     setResult(null);
     setLoading(true);
     try {
+      await updateWatchlist(activeWatchlistRef.current, tickers);
       const resp = await runDigest({ tickers, lookback_days: lookback });
       setResult(resp);
     } catch (err) {
@@ -38,13 +63,17 @@ export function DigestPanel() {
 
   return (
     <div>
+      <WatchlistSelector
+        onWatchlistChange={handleWatchlistChange}
+        activeTickers={parseTickers(input)}
+      />
       <form onSubmit={handleSubmit} style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'end' }}>
         <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', flex: 1 }}>
           <span style={{ fontSize: '0.875rem', fontWeight: 500 }}>Tickers</span>
           <input
             type="text"
             value={input}
-            onChange={(e) => setInput(e.target.value)}
+            onChange={(e) => handleInputChange(e.target.value)}
             placeholder="AAPL, MSFT, GOOGL"
             style={{ padding: '0.5rem', border: '1px solid #d1d5db', borderRadius: 6 }}
           />

--- a/web-ui/src/components/DigestPanel.tsx
+++ b/web-ui/src/components/DigestPanel.tsx
@@ -54,7 +54,9 @@ export function DigestPanel() {
     setResult(null);
     setLoading(true);
     try {
-      await updateWatchlist(activeWatchlistRef.current, tickers);
+      await updateWatchlist(activeWatchlistRef.current, tickers).catch((err) => {
+        console.warn('Failed to update watchlist before digest', err);
+      });
       const resp = await runDigest({ tickers, lookback_days: lookback });
       setResult(resp);
     } catch (err) {

--- a/web-ui/src/components/DigestPanel.tsx
+++ b/web-ui/src/components/DigestPanel.tsx
@@ -39,6 +39,7 @@ export function DigestPanel() {
   };
 
   const handleWatchlistChange = useCallback((name: string, tickers: string[]) => {
+    clearTimeout(saveTimerRef.current);
     activeWatchlistRef.current = name;
     setInput(tickers.join(', '));
   }, []);

--- a/web-ui/src/components/WatchlistSelector.tsx
+++ b/web-ui/src/components/WatchlistSelector.tsx
@@ -92,6 +92,7 @@ export function WatchlistSelector({ onWatchlistChange, activeTickers }: Watchlis
                   color: '#9ca3af', fontSize: '0.75rem', padding: 0,
                 }}
                 title={`Delete ${name}`}
+                aria-label={`Delete watchlist ${name}`}
               >
                 ✕
               </button>

--- a/web-ui/src/components/WatchlistSelector.tsx
+++ b/web-ui/src/components/WatchlistSelector.tsx
@@ -22,10 +22,13 @@ export function WatchlistSelector({ onWatchlistChange, activeTickers }: Watchlis
   const load = useCallback(async () => {
     try {
       const resp = await fetchWatchlists();
+      setError('');
       setData(resp);
       onWatchlistChange(resp.active, resp.active_watchlist.tickers);
     } catch {
+      setError('');
       setData(DEFAULT_DATA);
+      onWatchlistChange(DEFAULT_DATA.active, DEFAULT_DATA.active_watchlist.tickers);
     }
   }, [onWatchlistChange]);
 
@@ -34,6 +37,7 @@ export function WatchlistSelector({ onWatchlistChange, activeTickers }: Watchlis
   const handleSwitch = async (name: string) => {
     try {
       const resp = await activateWatchlist(name);
+      setError('');
       onWatchlistChange(name, resp.watchlist.tickers);
       await load();
     } catch (err) {
@@ -56,6 +60,7 @@ export function WatchlistSelector({ onWatchlistChange, activeTickers }: Watchlis
   };
 
   const handleDelete = async (name: string) => {
+    setError('');
     try {
       await deleteWatchlist(name);
       await load();
@@ -66,7 +71,7 @@ export function WatchlistSelector({ onWatchlistChange, activeTickers }: Watchlis
 
   if (!data) return null;
 
-  const names = Object.keys(data.watchlists);
+  const names = Object.keys(data.watchlists).sort((a, b) => a.localeCompare(b));
 
   return (
     <div style={{ marginBottom: '0.75rem' }}>

--- a/web-ui/src/components/WatchlistSelector.tsx
+++ b/web-ui/src/components/WatchlistSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { activateWatchlist, createWatchlist, deleteWatchlist, fetchWatchlists } from '../api';
 import type { WatchlistsResponse } from '../types';
 
@@ -7,23 +7,29 @@ interface WatchlistSelectorProps {
   activeTickers: string[];
 }
 
+const DEFAULT_DATA: WatchlistsResponse = {
+  active: 'default',
+  watchlists: { default: { tickers: [] } },
+  active_watchlist: { tickers: [] },
+};
+
 export function WatchlistSelector({ onWatchlistChange, activeTickers }: WatchlistSelectorProps) {
   const [data, setData] = useState<WatchlistsResponse | null>(null);
   const [newName, setNewName] = useState('');
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState('');
 
-  const load = async () => {
+  const load = useCallback(async () => {
     try {
       const resp = await fetchWatchlists();
       setData(resp);
       onWatchlistChange(resp.active, resp.active_watchlist.tickers);
     } catch {
-      /* ignore load errors — default empty state is fine */
+      setData(DEFAULT_DATA);
     }
-  };
+  }, [onWatchlistChange]);
 
-  useEffect(() => { load(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { load(); }, [load]);
 
   const handleSwitch = async (name: string) => {
     try {

--- a/web-ui/src/components/WatchlistSelector.tsx
+++ b/web-ui/src/components/WatchlistSelector.tsx
@@ -3,7 +3,7 @@ import { activateWatchlist, createWatchlist, deleteWatchlist, fetchWatchlists } 
 import type { WatchlistsResponse } from '../types';
 
 interface WatchlistSelectorProps {
-  onWatchlistChange: (tickers: string[]) => void;
+  onWatchlistChange: (name: string, tickers: string[]) => void;
   activeTickers: string[];
 }
 
@@ -17,7 +17,7 @@ export function WatchlistSelector({ onWatchlistChange, activeTickers }: Watchlis
     try {
       const resp = await fetchWatchlists();
       setData(resp);
-      onWatchlistChange(resp.active_watchlist.tickers);
+      onWatchlistChange(resp.active, resp.active_watchlist.tickers);
     } catch {
       /* ignore load errors — default empty state is fine */
     }
@@ -28,7 +28,7 @@ export function WatchlistSelector({ onWatchlistChange, activeTickers }: Watchlis
   const handleSwitch = async (name: string) => {
     try {
       const resp = await activateWatchlist(name);
-      onWatchlistChange(resp.watchlist.tickers);
+      onWatchlistChange(name, resp.watchlist.tickers);
       await load();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to switch');

--- a/web-ui/src/components/WatchlistSelector.tsx
+++ b/web-ui/src/components/WatchlistSelector.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react';
+import { activateWatchlist, createWatchlist, deleteWatchlist, fetchWatchlists } from '../api';
+import type { WatchlistsResponse } from '../types';
+
+interface WatchlistSelectorProps {
+  onWatchlistChange: (tickers: string[]) => void;
+  activeTickers: string[];
+}
+
+export function WatchlistSelector({ onWatchlistChange, activeTickers }: WatchlistSelectorProps) {
+  const [data, setData] = useState<WatchlistsResponse | null>(null);
+  const [newName, setNewName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState('');
+
+  const load = async () => {
+    try {
+      const resp = await fetchWatchlists();
+      setData(resp);
+      onWatchlistChange(resp.active_watchlist.tickers);
+    } catch {
+      /* ignore load errors — default empty state is fine */
+    }
+  };
+
+  useEffect(() => { load(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSwitch = async (name: string) => {
+    try {
+      const resp = await activateWatchlist(name);
+      onWatchlistChange(resp.watchlist.tickers);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to switch');
+    }
+  };
+
+  const handleCreate = async () => {
+    const slug = newName.trim().toLowerCase().replace(/\s+/g, '-');
+    if (!slug) return;
+    setError('');
+    try {
+      await createWatchlist(slug, activeTickers);
+      setNewName('');
+      setCreating(false);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create');
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    try {
+      await deleteWatchlist(name);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete');
+    }
+  };
+
+  if (!data) return null;
+
+  const names = Object.keys(data.watchlists);
+
+  return (
+    <div style={{ marginBottom: '0.75rem' }}>
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+        <span style={{ fontSize: '0.875rem', fontWeight: 500 }}>Watchlist:</span>
+        {names.map((name) => (
+          <span key={name} style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25rem' }}>
+            <button
+              type="button"
+              onClick={() => handleSwitch(name)}
+              style={{
+                padding: '0.25rem 0.5rem',
+                borderRadius: 4,
+                border: name === data.active ? '2px solid #2563eb' : '1px solid #d1d5db',
+                background: name === data.active ? '#eff6ff' : 'white',
+                cursor: 'pointer',
+                fontSize: '0.8rem',
+                fontWeight: name === data.active ? 600 : 400,
+              }}
+            >
+              {name}
+            </button>
+            {name !== data.active && (
+              <button
+                type="button"
+                onClick={() => handleDelete(name)}
+                style={{
+                  background: 'none', border: 'none', cursor: 'pointer',
+                  color: '#9ca3af', fontSize: '0.75rem', padding: 0,
+                }}
+                title={`Delete ${name}`}
+              >
+                ✕
+              </button>
+            )}
+          </span>
+        ))}
+        {creating ? (
+          <span style={{ display: 'inline-flex', gap: '0.25rem', alignItems: 'center' }}>
+            <input
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+              placeholder="name"
+              style={{ padding: '0.25rem', border: '1px solid #d1d5db', borderRadius: 4, width: 100, fontSize: '0.8rem' }}
+              autoFocus
+            />
+            <button type="button" onClick={handleCreate}
+              style={{ padding: '0.25rem 0.5rem', fontSize: '0.8rem', borderRadius: 4, border: '1px solid #d1d5db', cursor: 'pointer' }}>
+              ✓
+            </button>
+            <button type="button" onClick={() => { setCreating(false); setNewName(''); }}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#9ca3af', fontSize: '0.8rem' }}>
+              ✕
+            </button>
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            style={{
+              padding: '0.25rem 0.5rem', borderRadius: 4,
+              border: '1px dashed #d1d5db', background: 'white',
+              cursor: 'pointer', fontSize: '0.8rem', color: '#6b7280',
+            }}
+          >
+            + New
+          </button>
+        )}
+      </div>
+      {error && <p style={{ color: '#ef4444', fontSize: '0.8rem', margin: '0.25rem 0 0' }}>{error}</p>}
+    </div>
+  );
+}

--- a/web-ui/src/types.ts
+++ b/web-ui/src/types.ts
@@ -22,3 +22,13 @@ export interface DigestResponse {
 export interface HealthResponse {
   status: string;
 }
+
+export interface WatchlistData {
+  tickers: string[];
+}
+
+export interface WatchlistsResponse {
+  active: string;
+  watchlists: Record<string, WatchlistData>;
+  active_watchlist: WatchlistData;
+}

--- a/web-ui/tests/App.test.tsx
+++ b/web-ui/tests/App.test.tsx
@@ -243,4 +243,144 @@ describe('DigestPanel', () => {
     });
     expect(capturedLookback).toBe(30);
   });
+
+  it('continues digest when watchlist save fails', async () => {
+    server.use(
+      http.put('/api/watchlists/:name', () => HttpResponse.json({ detail: 'fail' }, { status: 500 })),
+    );
+    render(<DigestPanel />);
+    const input = screen.getByPlaceholderText('AAPL, MSFT, GOOGL');
+    fireEvent.change(input, { target: { value: 'AAPL' } });
+    fireEvent.click(screen.getByText('Run Digest'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('digest-result')).toBeInTheDocument();
+    });
+  });
+
+  it('loads active watchlist tickers on mount', async () => {
+    server.use(
+      http.get('/api/watchlists', () => HttpResponse.json({
+        active: 'default',
+        watchlists: { default: { tickers: ['TSLA', 'GOOG'] } },
+        active_watchlist: { tickers: ['TSLA', 'GOOG'] },
+      })),
+    );
+    render(<DigestPanel />);
+    await waitFor(() => {
+      const input = screen.getByPlaceholderText('AAPL, MSFT, GOOGL') as HTMLInputElement;
+      expect(input.value).toBe('TSLA, GOOG');
+    });
+  });
+
+  it('updates ticker input when switching watchlists', async () => {
+    let activated = false;
+    server.use(
+      http.get('/api/watchlists', () => {
+        if (!activated) {
+          return HttpResponse.json({
+            active: 'default',
+            watchlists: {
+              default: { tickers: ['AAPL'] },
+              tech: { tickers: ['MSFT', 'GOOG'] },
+            },
+            active_watchlist: { tickers: ['AAPL'] },
+          });
+        }
+        return HttpResponse.json({
+          active: 'tech',
+          watchlists: {
+            default: { tickers: ['AAPL'] },
+            tech: { tickers: ['MSFT', 'GOOG'] },
+          },
+          active_watchlist: { tickers: ['MSFT', 'GOOG'] },
+        });
+      }),
+      http.put('/api/watchlists/:name/activate', ({ params }) => {
+        activated = true;
+        return HttpResponse.json({
+          active: params.name as string,
+          watchlist: { tickers: ['MSFT', 'GOOG'] },
+        });
+      }),
+    );
+    render(<DigestPanel />);
+    await waitFor(() => {
+      expect(screen.getByText('tech')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('tech'));
+    await waitFor(() => {
+      const input = screen.getByPlaceholderText('AAPL, MSFT, GOOGL') as HTMLInputElement;
+      expect(input.value).toBe('MSFT, GOOG');
+    });
+  });
+
+  it('creates a new watchlist and re-renders selector', async () => {
+    let callCount = 0;
+    server.use(
+      http.get('/api/watchlists', () => {
+        callCount++;
+        if (callCount <= 1) {
+          return HttpResponse.json({
+            active: 'default',
+            watchlists: { default: { tickers: [] } },
+            active_watchlist: { tickers: [] },
+          });
+        }
+        return HttpResponse.json({
+          active: 'default',
+          watchlists: {
+            default: { tickers: [] },
+            growth: { tickers: [] },
+          },
+          active_watchlist: { tickers: [] },
+        });
+      }),
+      http.post('/api/watchlists', () => HttpResponse.json({ tickers: [] }, { status: 201 })),
+    );
+    render(<DigestPanel />);
+    await waitFor(() => {
+      expect(screen.getByText('Watchlist:')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('+ New'));
+    const nameInput = screen.getByPlaceholderText('name');
+    fireEvent.change(nameInput, { target: { value: 'growth' } });
+    fireEvent.click(screen.getByText('✓'));
+    await waitFor(() => {
+      expect(screen.getByText('growth')).toBeInTheDocument();
+    });
+  });
+
+  it('deletes a non-active watchlist', async () => {
+    let callCount = 0;
+    server.use(
+      http.get('/api/watchlists', () => {
+        callCount++;
+        if (callCount <= 1) {
+          return HttpResponse.json({
+            active: 'default',
+            watchlists: {
+              default: { tickers: [] },
+              old: { tickers: ['X'] },
+            },
+            active_watchlist: { tickers: [] },
+          });
+        }
+        return HttpResponse.json({
+          active: 'default',
+          watchlists: { default: { tickers: [] } },
+          active_watchlist: { tickers: [] },
+        });
+      }),
+      http.delete('/api/watchlists/:name', () => new HttpResponse(null, { status: 204 })),
+    );
+    render(<DigestPanel />);
+    await waitFor(() => {
+      expect(screen.getByText('old')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByLabelText('Delete watchlist old'));
+    await waitFor(() => {
+      expect(screen.queryByText('old')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/web-ui/tests/mocks/handlers.ts
+++ b/web-ui/tests/mocks/handlers.ts
@@ -28,8 +28,8 @@ export const handlers = [
   http.get('/api/watchlists', () => {
     return HttpResponse.json({
       active: 'default',
-      watchlists: { default: { tickers: ['AAPL', 'MSFT'] } },
-      active_watchlist: { tickers: ['AAPL', 'MSFT'] },
+      watchlists: { default: { tickers: [] } },
+      active_watchlist: { tickers: [] },
     });
   }),
 

--- a/web-ui/tests/mocks/handlers.ts
+++ b/web-ui/tests/mocks/handlers.ts
@@ -24,4 +24,31 @@ export const handlers = [
       content: `Digest for ${tickers.join(', ')}`,
     });
   }),
+
+  http.get('/api/watchlists', () => {
+    return HttpResponse.json({
+      active: 'default',
+      watchlists: { default: { tickers: ['AAPL', 'MSFT'] } },
+      active_watchlist: { tickers: ['AAPL', 'MSFT'] },
+    });
+  }),
+
+  http.put('/api/watchlists/:name', () => {
+    return HttpResponse.json({ tickers: ['AAPL', 'MSFT'] });
+  }),
+
+  http.post('/api/watchlists', () => {
+    return HttpResponse.json({ tickers: [] }, { status: 201 });
+  }),
+
+  http.delete('/api/watchlists/:name', () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.put('/api/watchlists/:name/activate', () => {
+    return HttpResponse.json({
+      active: 'default',
+      watchlist: { tickers: ['AAPL', 'MSFT'] },
+    });
+  }),
 ];

--- a/web-ui/tests/mocks/handlers.ts
+++ b/web-ui/tests/mocks/handlers.ts
@@ -45,9 +45,10 @@ export const handlers = [
     return new HttpResponse(null, { status: 204 });
   }),
 
-  http.put('/api/watchlists/:name/activate', () => {
+  http.put('/api/watchlists/:name/activate', ({ params }) => {
+    const name = params.name as string;
     return HttpResponse.json({
-      active: 'default',
+      active: name,
       watchlist: { tickers: ['AAPL', 'MSFT'] },
     });
   }),


### PR DESCRIPTION
## Summary

Persistent named watchlists so ticker input survives browser refreshes. Stored in `~/.config/finance-os/watchlists.json` (separate from app config).

### Backend
- **`WatchlistStore`** (`agents/src/application/watchlists.py`): Thread-safe file I/O with atomic writes (temp + rename), slug-validated names, ticker normalization (uppercase, dedup, sorted), corruption recovery, invariant enforcement (active always exists, at least one watchlist)
- **6 API endpoints**: `GET /watchlists` (includes active data), `POST /watchlists`, `GET /watchlists/{name}`, `PUT /watchlists/{name}`, `DELETE /watchlists/{name}`, `PUT /watchlists/{name}/activate`
- KeyError → 404, ValueError → 400 error handling

### Frontend
- **WatchlistSelector** component: switch active watchlist, create new (with current tickers), delete non-active
- **DigestPanel** integration: auto-loads tickers from active watchlist on mount, debounced autosave (1s) on edit, explicit save on Run Digest
- MSW handlers for test isolation

### Tests
- 24 WatchlistStore unit tests (CRUD, persistence, corruption, invariants, name validation)
- 12 web API endpoint tests (all 6 endpoints × happy + error paths)
- All 527 unit tests pass, preflight green

Closes #81