### PR TITLE
feat: Ticker-driven UI — auto-discover data from Yahoo Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ finance-os-mcp              # via console script (stdio transport)
 python -m src.mcp_server    # direct invocation
 ```
 
-Tools available: `analyze_earnings`, `classify_macro`, `research_digest`, `orchestrate`. See [docs/tools.md](docs/tools.md) for details.
+Tools available: `analyze_earnings`, `classify_macro`, `research_digest`, `orchestrate`. The `analyze_earnings` tool accepts a ticker symbol and auto-fetches the latest transcript from Yahoo Finance. See [docs/tools.md](docs/tools.md) for details.
 
 ### Web API
 
@@ -138,7 +138,6 @@ pip install -e ".[dev]"
 # Start the server
 finance-os-api                              # production (127.0.0.1:8000)
 uvicorn src.web_api:app --reload            # development with auto-reload
-uvicorn src.web_api:app --host 0.0.0.0      # expose to local network
 ```
 
 Once running, open http://127.0.0.1:8000/docs for interactive Swagger UI.
@@ -149,7 +148,9 @@ Once running, open http://127.0.0.1:8000/docs for interactive Swagger UI.
 |--------|------|-------------|
 | GET | `/health` | Health check |
 | GET | `/agents` | List available agents |
-| POST | `/agents/earnings_interpreter` | Analyze earnings transcripts |
+| GET | `/ticker/{symbol}/summary` | Fetch company summary from Yahoo Finance (cached 5 min) |
+| GET | `/ticker/{symbol}/transcript` | Fetch latest earnings transcript (cached 1 hour) |
+| POST | `/agents/earnings_interpreter` | Analyze earnings transcripts (accepts ticker or transcript) |
 | POST | `/agents/macro_regime` | Classify macro regime |
 | POST | `/agents/filing_analyst` | Search SEC filings |
 | POST | `/agents/quant_signal` | Generate quant signals |
@@ -158,12 +159,26 @@ Once running, open http://127.0.0.1:8000/docs for interactive Swagger UI.
 | POST | `/agents/adversarial` | Challenge thesis adversarially |
 | POST | `/pipeline` | Multi-agent research pipeline |
 | POST | `/digest` | Research digest for watchlist |
+| POST | `/kg/extract` | Extract entities/relationships into knowledge graph |
+| POST | `/kg/query/related` | Find entities related to a given entity |
+| POST | `/kg/query/supply-chain` | Trace supply chain from an entity |
+| POST | `/kg/query/shared-risks` | Find shared risks across entities |
+| GET | `/kg/stats` | Knowledge graph summary statistics |
+| GET | `/watchlists` | List all watchlists |
+| POST | `/watchlists` | Create a new watchlist |
+| GET | `/watchlists/{name}` | Get a specific watchlist |
+| PUT | `/watchlists/{name}` | Update tickers in a watchlist |
+| DELETE | `/watchlists/{name}` | Delete a watchlist |
+| PUT | `/watchlists/{name}/activate` | Set a watchlist as active |
 
 **Example:**
 
 ```bash
 # Health check
 curl http://127.0.0.1:8000/health
+
+# Look up a ticker
+curl http://127.0.0.1:8000/ticker/AAPL/summary
 
 # Run a research digest
 curl -X POST http://127.0.0.1:8000/digest \
@@ -195,6 +210,18 @@ The dev server proxies `/api/*` requests to the backend at `http://127.0.0.1:800
 ```bash
 cd web-ui && npm run build    # outputs to web-ui/dist/
 ```
+
+**UI Features:**
+
+| Feature | Description |
+|---------|-------------|
+| **Ticker Bar** | Enter a ticker symbol to auto-discover company data from Yahoo Finance — name, sector, price, market cap, 52W range, earnings date, and latest transcript |
+| **Agent Runner** | Run any agent with a dynamic form. Fields auto-populate from ticker context (e.g. entering AAPL fills transcript and ticker fields automatically). Dirty-field tracking preserves manual edits. |
+| **Pipeline Runner** | Define and execute multi-agent pipelines with dependency ordering. Visualizes per-task results and overall duration. Detects dependency cycles before execution. |
+| **Knowledge Graph** | Extract entities and relationships from text, then query the graph — related entities, supply chain tracing, shared risk analysis. Displays entity/relationship counts by type. |
+| **Watchlists** | Create, switch, and manage named ticker watchlists. Active watchlist auto-loads into the digest panel. |
+| **Research Digest** | Run a multi-agent digest for your watchlist tickers. Configure lookback period. View materiality alerts and signal counts. |
+| **System Health** | Live API connectivity indicator, agent catalog, and knowledge graph statistics. |
 
 ### Copilot Skills
 

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
     "networkx>=3.4",
+    "yfinance>=0.2.60",
 ]
 
 [project.optional-dependencies]

--- a/agents/src/application/contracts/agents.py
+++ b/agents/src/application/contracts/agents.py
@@ -12,10 +12,17 @@ from pydantic import BaseModel, Field
 
 
 class AnalyzeEarningsRequest(BaseModel):
-    """Request to analyze an earnings transcript."""
+    """Request to analyze an earnings transcript.
 
-    transcript: str = Field(min_length=1, description="Earnings call transcript text")
-    ticker: str = Field(default="", description="Company ticker for context")
+    Provide either ``transcript`` directly, or ``ticker`` to auto-fetch
+    the latest transcript from Yahoo Finance.
+    """
+
+    transcript: str = Field(default="", description="Earnings call transcript text")
+    ticker: str = Field(
+        default="",
+        description="Company ticker — auto-fetches transcript if transcript is empty",
+    )
 
 
 class AnalyzeEarningsResponse(BaseModel):

--- a/agents/src/application/contracts/ticker.py
+++ b/agents/src/application/contracts/ticker.py
@@ -1,0 +1,30 @@
+"""Pydantic contracts for ticker lookup endpoints."""
+
+from pydantic import BaseModel, Field
+
+
+class TickerSummary(BaseModel):
+    """Company summary from Yahoo Finance."""
+
+    symbol: str = Field(description="Ticker symbol")
+    name: str = Field(description="Company name")
+    sector: str = Field(default="", description="Company sector")
+    industry: str = Field(default="", description="Company industry")
+    market_cap: str = Field(default="", description="Market capitalization (decimal string)")
+    currency: str = Field(default="USD", description="Quote currency")
+    current_price: str = Field(default="", description="Current price (decimal string)")
+    previous_close: str = Field(default="", description="Previous close (decimal string)")
+    fifty_two_week_high: str = Field(default="", description="52-week high (decimal string)")
+    fifty_two_week_low: str = Field(default="", description="52-week low (decimal string)")
+    earnings_date: str = Field(default="", description="Next earnings date (ISO 8601)")
+    description: str = Field(default="", description="Business description")
+
+
+class TickerTranscript(BaseModel):
+    """Earnings transcript for a ticker (best-effort)."""
+
+    symbol: str = Field(description="Ticker symbol")
+    available: bool = Field(description="Whether a transcript was found")
+    transcript: str = Field(default="", description="Earnings call transcript text")
+    period: str = Field(default="", description="Fiscal period (e.g. 'Q1 2025')")
+    source: str = Field(default="yfinance", description="Data source attribution")

--- a/agents/src/application/services/ticker_service.py
+++ b/agents/src/application/services/ticker_service.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 # Per-endpoint TTL caching (seconds)
 _SUMMARY_TTL = 300  # 5 minutes
 _TRANSCRIPT_TTL = 3600  # 1 hour
+_CACHE_MAX_SIZE = 500
 
 _cache: dict[str, tuple[float, object]] = {}
 _inflight: dict[str, asyncio.Future[object]] = {}
@@ -36,7 +37,17 @@ def _cache_get(key: str, ttl: float) -> object | None:
 
 
 def _cache_set(key: str, val: object) -> None:
+    if len(_cache) >= _CACHE_MAX_SIZE:
+        _cache_evict()
     _cache[key] = (time.monotonic(), val)
+
+
+def _cache_evict() -> None:
+    """Remove oldest entries to stay under max size."""
+    entries = sorted(_cache.items(), key=lambda e: e[1][0])
+    to_remove = len(_cache) - _CACHE_MAX_SIZE + _CACHE_MAX_SIZE // 4
+    for k, _ in entries[:max(to_remove, 1)]:
+        _cache.pop(k, None)
 
 
 def _safe_decimal(val: object) -> str:
@@ -94,8 +105,8 @@ def _fetch_summary_sync(symbol: str) -> TickerSummary:
 
 def _fetch_transcript_sync(symbol: str) -> TickerTranscript:
     """Synchronous earnings transcript fetch (best-effort, runs in thread)."""
-    ticker = yf.Ticker(symbol)
     try:
+        ticker = yf.Ticker(symbol)
         transcripts = getattr(ticker, "earnings_call_transcripts", None)
         if transcripts is not None and callable(transcripts):
             transcripts = transcripts()
@@ -139,7 +150,7 @@ async def _fetch_with_dedup(key: str, ttl: float, fetcher: object) -> object:
         result = await asyncio.to_thread(fetcher)  # type: ignore[arg-type]
         _cache_set(key, result)
         fut.set_result(result)
-        return result
+        return result.model_copy(deep=True)  # type: ignore[union-attr]
     except Exception as exc:
         fut.set_exception(exc)
         raise

--- a/agents/src/application/services/ticker_service.py
+++ b/agents/src/application/services/ticker_service.py
@@ -117,8 +117,15 @@ def _fetch_transcript_sync(symbol: str) -> TickerTranscript:
         # yfinance returns list of transcript dicts — take the latest
         if isinstance(transcripts, list) and transcripts:
             latest = transcripts[0]
-            text = latest if isinstance(latest, str) else str(latest.get("content", latest))
-            period = latest.get("period", "") if isinstance(latest, dict) else ""
+            if isinstance(latest, str):
+                text = latest
+                period = ""
+            elif isinstance(latest, dict):
+                text = str(latest.get("content", latest))
+                period = latest.get("period", "")
+            else:
+                text = str(latest)
+                period = ""
             return TickerTranscript(
                 symbol=symbol.upper(),
                 available=True,

--- a/agents/src/application/services/ticker_service.py
+++ b/agents/src/application/services/ticker_service.py
@@ -20,6 +20,7 @@ _SUMMARY_TTL = 300  # 5 minutes
 _TRANSCRIPT_TTL = 3600  # 1 hour
 
 _cache: dict[str, tuple[float, object]] = {}
+_inflight: dict[str, asyncio.Future[object]] = {}
 
 
 def _cache_get(key: str, ttl: float) -> object | None:
@@ -110,25 +111,44 @@ def _fetch_transcript_sync(symbol: str) -> TickerTranscript:
         return TickerTranscript(symbol=symbol.upper(), available=False)
 
 
+async def _fetch_with_dedup(key: str, ttl: float, fetcher: object) -> object:
+    """Fetch with cache and in-flight request deduplication."""
+    cached = _cache_get(key, ttl)
+    if cached is not None:
+        return cached
+
+    # Deduplicate concurrent requests for the same key
+    if key in _inflight:
+        return await _inflight[key]
+
+    loop = asyncio.get_running_loop()
+    fut: asyncio.Future[object] = loop.create_future()
+    _inflight[key] = fut
+    try:
+        result = await asyncio.to_thread(fetcher)  # type: ignore[arg-type]
+        _cache_set(key, result)
+        fut.set_result(result)
+        return result
+    except Exception as exc:
+        fut.set_exception(exc)
+        raise
+    finally:
+        _inflight.pop(key, None)
+
+
 async def get_ticker_summary(symbol: str) -> TickerSummary:
     """Fetch company summary. Cached for 5 minutes."""
     key = f"summary:{symbol.upper()}"
-    cached = _cache_get(key, _SUMMARY_TTL)
-    if cached is not None:
-        return cached  # type: ignore[return-value]
-
-    result = await asyncio.to_thread(_fetch_summary_sync, symbol)
-    _cache_set(key, result)
-    return result
+    result = await _fetch_with_dedup(
+        key, _SUMMARY_TTL, lambda: _fetch_summary_sync(symbol)
+    )
+    return result  # type: ignore[return-value]
 
 
 async def get_ticker_transcript(symbol: str) -> TickerTranscript:
     """Fetch latest earnings transcript (best-effort). Cached for 1 hour."""
     key = f"transcript:{symbol.upper()}"
-    cached = _cache_get(key, _TRANSCRIPT_TTL)
-    if cached is not None:
-        return cached  # type: ignore[return-value]
-
-    result = await asyncio.to_thread(_fetch_transcript_sync, symbol)
-    _cache_set(key, result)
-    return result
+    result = await _fetch_with_dedup(
+        key, _TRANSCRIPT_TTL, lambda: _fetch_transcript_sync(symbol)
+    )
+    return result  # type: ignore[return-value]

--- a/agents/src/application/services/ticker_service.py
+++ b/agents/src/application/services/ticker_service.py
@@ -151,8 +151,9 @@ async def _fetch_with_dedup(key: str, ttl: float, fetcher: object) -> object:
         _cache_set(key, result)
         fut.set_result(result)
         return result.model_copy(deep=True)  # type: ignore[union-attr]
-    except Exception as exc:
-        fut.set_exception(exc)
+    except BaseException as exc:
+        if not fut.done():
+            fut.set_exception(exc)
         raise
     finally:
         _inflight.pop(key, None)

--- a/agents/src/application/services/ticker_service.py
+++ b/agents/src/application/services/ticker_service.py
@@ -1,0 +1,134 @@
+"""Ticker lookup service — auto-discover company data from Yahoo Finance.
+
+Wraps yfinance with caching and graceful degradation. All yfinance calls
+are dispatched to a thread to avoid blocking the async event loop.
+"""
+
+import asyncio
+import logging
+import time
+from decimal import Decimal, InvalidOperation
+
+import yfinance as yf
+
+from src.application.contracts.ticker import TickerSummary, TickerTranscript
+
+logger = logging.getLogger(__name__)
+
+# Per-endpoint TTL caching (seconds)
+_SUMMARY_TTL = 300  # 5 minutes
+_TRANSCRIPT_TTL = 3600  # 1 hour
+
+_cache: dict[str, tuple[float, object]] = {}
+
+
+def _cache_get(key: str, ttl: float) -> object | None:
+    """Return cached value if within TTL, else None."""
+    entry = _cache.get(key)
+    if entry is None:
+        return None
+    ts, val = entry
+    if time.monotonic() - ts > ttl:
+        del _cache[key]
+        return None
+    return val
+
+
+def _cache_set(key: str, val: object) -> None:
+    _cache[key] = (time.monotonic(), val)
+
+
+def _safe_decimal(val: object) -> str:
+    """Convert a numeric value to decimal string, or empty string on failure."""
+    if val is None:
+        return ""
+    try:
+        return str(Decimal(str(val)))
+    except (InvalidOperation, ValueError):
+        return ""
+
+
+def _fetch_summary_sync(symbol: str) -> TickerSummary:
+    """Synchronous Yahoo Finance summary fetch (runs in thread)."""
+    ticker = yf.Ticker(symbol)
+    info = ticker.info or {}
+
+    name = info.get("longName") or info.get("shortName") or symbol
+    earnings_date = ""
+    cal = getattr(ticker, "calendar", None)
+    if isinstance(cal, dict) and "Earnings Date" in cal:
+        dates = cal["Earnings Date"]
+        if isinstance(dates, list) and dates:
+            earnings_date = str(dates[0])
+        elif dates:
+            earnings_date = str(dates)
+
+    return TickerSummary(
+        symbol=symbol.upper(),
+        name=name,
+        sector=info.get("sector", ""),
+        industry=info.get("industry", ""),
+        market_cap=_safe_decimal(info.get("marketCap")),
+        currency=info.get("currency", "USD"),
+        current_price=_safe_decimal(
+            info.get("currentPrice") or info.get("regularMarketPrice")
+        ),
+        previous_close=_safe_decimal(info.get("previousClose")),
+        fifty_two_week_high=_safe_decimal(info.get("fiftyTwoWeekHigh")),
+        fifty_two_week_low=_safe_decimal(info.get("fiftyTwoWeekLow")),
+        earnings_date=earnings_date,
+        description=info.get("longBusinessSummary", ""),
+    )
+
+
+def _fetch_transcript_sync(symbol: str) -> TickerTranscript:
+    """Synchronous earnings transcript fetch (best-effort, runs in thread)."""
+    ticker = yf.Ticker(symbol)
+    try:
+        transcripts = getattr(ticker, "earnings_call_transcripts", None)
+        if transcripts is not None and callable(transcripts):
+            transcripts = transcripts()
+
+        if not transcripts:
+            return TickerTranscript(symbol=symbol.upper(), available=False)
+
+        # yfinance returns list of transcript dicts — take the latest
+        if isinstance(transcripts, list) and transcripts:
+            latest = transcripts[0]
+            text = latest if isinstance(latest, str) else str(latest.get("content", latest))
+            period = latest.get("period", "") if isinstance(latest, dict) else ""
+            return TickerTranscript(
+                symbol=symbol.upper(),
+                available=True,
+                transcript=text,
+                period=period,
+            )
+
+        return TickerTranscript(symbol=symbol.upper(), available=False)
+    except Exception:
+        logger.warning("Transcript fetch failed for %s", symbol, exc_info=True)
+        return TickerTranscript(symbol=symbol.upper(), available=False)
+
+
+async def get_ticker_summary(symbol: str) -> TickerSummary:
+    """Fetch company summary. Cached for 5 minutes."""
+    key = f"summary:{symbol.upper()}"
+    cached = _cache_get(key, _SUMMARY_TTL)
+    if cached is not None:
+        return cached  # type: ignore[return-value]
+
+    result = await asyncio.to_thread(_fetch_summary_sync, symbol)
+    _cache_set(key, result)
+    return result
+
+
+async def get_ticker_transcript(symbol: str) -> TickerTranscript:
+    """Fetch latest earnings transcript (best-effort). Cached for 1 hour."""
+    key = f"transcript:{symbol.upper()}"
+    cached = _cache_get(key, _TRANSCRIPT_TTL)
+    if cached is not None:
+        return cached  # type: ignore[return-value]
+
+    result = await asyncio.to_thread(_fetch_transcript_sync, symbol)
+    _cache_set(key, result)
+    return result

--- a/agents/src/application/services/ticker_service.py
+++ b/agents/src/application/services/ticker_service.py
@@ -145,6 +145,8 @@ async def _fetch_with_dedup(key: str, ttl: float, fetcher: object) -> object:
 
     loop = asyncio.get_running_loop()
     fut: asyncio.Future[object] = loop.create_future()
+    # Suppress "Future exception was never retrieved" when no concurrent waiters
+    fut.add_done_callback(lambda f: f.exception() if not f.cancelled() else None)
     _inflight[key] = fut
     try:
         result = await asyncio.to_thread(fetcher)  # type: ignore[arg-type]

--- a/agents/src/application/services/ticker_service.py
+++ b/agents/src/application/services/ticker_service.py
@@ -51,35 +51,45 @@ def _safe_decimal(val: object) -> str:
 
 def _fetch_summary_sync(symbol: str) -> TickerSummary:
     """Synchronous Yahoo Finance summary fetch (runs in thread)."""
-    ticker = yf.Ticker(symbol)
-    info = ticker.info or {}
+    normalized = symbol.upper()
+    try:
+        ticker = yf.Ticker(symbol)
+        info = ticker.info or {}
 
-    name = info.get("longName") or info.get("shortName") or symbol
-    earnings_date = ""
-    cal = getattr(ticker, "calendar", None)
-    if isinstance(cal, dict) and "Earnings Date" in cal:
-        dates = cal["Earnings Date"]
-        if isinstance(dates, list) and dates:
-            earnings_date = str(dates[0])
-        elif dates:
-            earnings_date = str(dates)
+        name = info.get("longName") or info.get("shortName") or normalized
+        earnings_date = ""
+        cal = getattr(ticker, "calendar", None)
+        if isinstance(cal, dict) and "Earnings Date" in cal:
+            dates = cal["Earnings Date"]
+            if isinstance(dates, list) and dates:
+                earnings_date = str(dates[0])
+            elif dates:
+                earnings_date = str(dates)
 
-    return TickerSummary(
-        symbol=symbol.upper(),
-        name=name,
-        sector=info.get("sector", ""),
-        industry=info.get("industry", ""),
-        market_cap=_safe_decimal(info.get("marketCap")),
-        currency=info.get("currency", "USD"),
-        current_price=_safe_decimal(
-            info.get("currentPrice") or info.get("regularMarketPrice")
-        ),
-        previous_close=_safe_decimal(info.get("previousClose")),
-        fifty_two_week_high=_safe_decimal(info.get("fiftyTwoWeekHigh")),
-        fifty_two_week_low=_safe_decimal(info.get("fiftyTwoWeekLow")),
-        earnings_date=earnings_date,
-        description=info.get("longBusinessSummary", ""),
-    )
+        return TickerSummary(
+            symbol=normalized,
+            name=name,
+            sector=info.get("sector", ""),
+            industry=info.get("industry", ""),
+            market_cap=_safe_decimal(info.get("marketCap")),
+            currency=info.get("currency", "USD"),
+            current_price=_safe_decimal(
+                info.get("currentPrice") or info.get("regularMarketPrice")
+            ),
+            previous_close=_safe_decimal(info.get("previousClose")),
+            fifty_two_week_high=_safe_decimal(info.get("fiftyTwoWeekHigh")),
+            fifty_two_week_low=_safe_decimal(info.get("fiftyTwoWeekLow")),
+            earnings_date=earnings_date,
+            description=info.get("longBusinessSummary", ""),
+        )
+    except Exception:
+        logger.warning("Summary fetch failed for %s", symbol, exc_info=True)
+        return TickerSummary(
+            symbol=normalized, name=normalized, sector="", industry="",
+            market_cap="", currency="USD", current_price="",
+            previous_close="", fifty_two_week_high="", fifty_two_week_low="",
+            earnings_date="", description="",
+        )
 
 
 def _fetch_transcript_sync(symbol: str) -> TickerTranscript:
@@ -115,11 +125,12 @@ async def _fetch_with_dedup(key: str, ttl: float, fetcher: object) -> object:
     """Fetch with cache and in-flight request deduplication."""
     cached = _cache_get(key, ttl)
     if cached is not None:
-        return cached
+        return cached.model_copy(deep=True)  # type: ignore[union-attr]
 
     # Deduplicate concurrent requests for the same key
     if key in _inflight:
-        return await _inflight[key]
+        result = await _inflight[key]
+        return result.model_copy(deep=True)  # type: ignore[union-attr]
 
     loop = asyncio.get_running_loop()
     fut: asyncio.Future[object] = loop.create_future()

--- a/agents/src/mcp_server.py
+++ b/agents/src/mcp_server.py
@@ -7,6 +7,7 @@ LLM gateway is skipped by default — the host LLM (Copilot, Claude Desktop)
 handles reasoning. Agents return structured data for the host to synthesize.
 """
 
+import re
 import sys
 from decimal import Decimal
 from typing import Any
@@ -24,6 +25,8 @@ from src.application.contracts.agents import (
 from src.application.registry import AGENT_CATALOG, create_pipeline_service
 from src.application.services.agent_service import AgentService
 from src.application.services.digest_service import DigestService
+
+_TICKER_RE = re.compile(r"^[A-Za-z0-9.\-]{1,10}$")
 
 mcp = FastMCP(
     "finance-os-agents",
@@ -57,6 +60,9 @@ async def analyze_earnings(transcript: str = "", ticker: str = "") -> dict[str, 
         from src.application.services.ticker_service import get_ticker_transcript
 
         ticker = ticker.strip().upper()
+        if not _TICKER_RE.match(ticker):
+            msg = f"Invalid ticker symbol: {ticker!r}"
+            raise ValueError(msg)
         result = await get_ticker_transcript(ticker)
         if result.available:
             transcript = result.transcript

--- a/agents/src/mcp_server.py
+++ b/agents/src/mcp_server.py
@@ -59,6 +59,9 @@ async def analyze_earnings(transcript: str = "", ticker: str = "") -> dict[str, 
         result = await get_ticker_transcript(ticker)
         if result.available:
             transcript = result.transcript
+        else:
+            msg = f"No earnings transcript found for ticker '{ticker}'."
+            raise ValueError(msg)
     if not transcript:
         msg = "Provide either a transcript or a ticker symbol."
         raise ValueError(msg)

--- a/agents/src/mcp_server.py
+++ b/agents/src/mcp_server.py
@@ -39,17 +39,29 @@ VALID_AGENT_NAMES = frozenset(info["name"] for info in AGENT_CATALOG)
 
 
 @mcp.tool()
-async def analyze_earnings(transcript: str, ticker: str = "") -> dict[str, Any]:
+async def analyze_earnings(transcript: str = "", ticker: str = "") -> dict[str, Any]:
     """Analyze an earnings call transcript for tone, sentiment, and guidance.
+
+    Provide either transcript text directly, or a ticker to auto-fetch
+    the latest earnings transcript from Yahoo Finance.
 
     Args:
         transcript: Full earnings call transcript text.
-        ticker: Company ticker symbol for context (e.g. AAPL).
+        ticker: Company ticker symbol — auto-fetches transcript if transcript is empty.
 
     Returns:
         Analysis with tone, net_sentiment, confidence, guidance_direction,
         guidance_count, key_phrase_count, and human-readable content.
     """
+    if not transcript and ticker:
+        from src.application.services.ticker_service import get_ticker_transcript
+
+        result = await get_ticker_transcript(ticker)
+        if result.available:
+            transcript = result.transcript
+    if not transcript:
+        msg = "Provide either a transcript or a ticker symbol."
+        raise ValueError(msg)
     request = AnalyzeEarningsRequest(transcript=transcript, ticker=ticker)
     service = AgentService()
     response = await service.analyze_earnings(request)

--- a/agents/src/mcp_server.py
+++ b/agents/src/mcp_server.py
@@ -56,6 +56,7 @@ async def analyze_earnings(transcript: str = "", ticker: str = "") -> dict[str, 
     if not transcript and ticker:
         from src.application.services.ticker_service import get_ticker_transcript
 
+        ticker = ticker.strip().upper()
         result = await get_ticker_transcript(ticker)
         if result.available:
             transcript = result.transcript

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -177,13 +177,16 @@ async def analyze_earnings(request: AnalyzeEarningsRequest) -> Any:
     if not request.transcript and request.ticker:
         from src.application.services.ticker_service import get_ticker_transcript
 
-        result = await get_ticker_transcript(request.ticker)
+        normalized_ticker = request.ticker.strip().upper()
+        result = await get_ticker_transcript(normalized_ticker)
         if not result.available:
             raise ValueError(
-                f"No transcript available for {request.ticker}. "
+                f"No transcript available for {normalized_ticker}. "
                 "Provide transcript text directly."
             )
-        request = request.model_copy(update={"transcript": result.transcript})
+        request = request.model_copy(
+            update={"transcript": result.transcript, "ticker": normalized_ticker},
+        )
     if not request.transcript:
         raise ValueError("Provide either a transcript or a ticker symbol.")
     service = AgentService()

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -22,7 +22,7 @@ from functools import lru_cache
 from typing import Any
 
 import uvicorn
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Path, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -145,7 +145,9 @@ async def list_agents() -> list[dict[str, str]]:
 
 
 @app.get("/ticker/{symbol}/summary", response_model=TickerSummary)
-async def ticker_summary(symbol: str) -> Any:
+async def ticker_summary(
+    symbol: str = Path(..., pattern=r"^[A-Z0-9.\-]{1,10}$"),
+) -> Any:
     """Fetch company summary from Yahoo Finance."""
     from src.application.services.ticker_service import get_ticker_summary
 
@@ -153,7 +155,9 @@ async def ticker_summary(symbol: str) -> Any:
 
 
 @app.get("/ticker/{symbol}/transcript", response_model=TickerTranscript)
-async def ticker_transcript(symbol: str) -> Any:
+async def ticker_transcript(
+    symbol: str = Path(..., pattern=r"^[A-Z0-9.\-]{1,10}$"),
+) -> Any:
     """Fetch latest earnings transcript (best-effort)."""
     from src.application.services.ticker_service import get_ticker_transcript
 

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -59,6 +59,7 @@ from src.application.contracts.knowledge_graph import (
     QuerySupplyChainRequest,
     QuerySupplyChainResponse,
 )
+from src.application.contracts.ticker import TickerSummary, TickerTranscript
 from src.application.registry import AGENT_CATALOG, create_pipeline_service
 from src.application.services.agent_service import AgentService
 from src.application.services.digest_service import DigestService
@@ -140,12 +141,47 @@ async def list_agents() -> list[dict[str, str]]:
     return list(AGENT_CATALOG)
 
 
+# --- Ticker Lookup Endpoints ---
+
+
+@app.get("/ticker/{symbol}/summary", response_model=TickerSummary)
+async def ticker_summary(symbol: str) -> Any:
+    """Fetch company summary from Yahoo Finance."""
+    from src.application.services.ticker_service import get_ticker_summary
+
+    return await get_ticker_summary(symbol)
+
+
+@app.get("/ticker/{symbol}/transcript", response_model=TickerTranscript)
+async def ticker_transcript(symbol: str) -> Any:
+    """Fetch latest earnings transcript (best-effort)."""
+    from src.application.services.ticker_service import get_ticker_transcript
+
+    return await get_ticker_transcript(symbol)
+
+
 # --- Agent Endpoints ---
 
 
 @app.post("/agents/earnings_interpreter", response_model=AnalyzeEarningsResponse)
 async def analyze_earnings(request: AnalyzeEarningsRequest) -> Any:
-    """Analyze an earnings call transcript for tone, sentiment, and guidance."""
+    """Analyze an earnings call transcript for tone, sentiment, and guidance.
+
+    If ``transcript`` is empty but ``ticker`` is provided, auto-fetches
+    the latest transcript from Yahoo Finance.
+    """
+    if not request.transcript and request.ticker:
+        from src.application.services.ticker_service import get_ticker_transcript
+
+        result = await get_ticker_transcript(request.ticker)
+        if not result.available:
+            raise ValueError(
+                f"No transcript available for {request.ticker}. "
+                "Provide transcript text directly."
+            )
+        request = request.model_copy(update={"transcript": result.transcript})
+    if not request.transcript:
+        raise ValueError("Provide either a transcript or a ticker symbol.")
     service = AgentService()
     response = await service.analyze_earnings(request)
     return response.model_dump(mode="json")

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -18,6 +18,7 @@ Run locally:
 
 import asyncio
 import logging
+import re
 from functools import lru_cache
 from typing import Any
 
@@ -68,6 +69,8 @@ from src.application.watchlists import WatchlistNotFoundError, WatchlistStore
 from src.core.knowledge_graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
+
+_TICKER_RE = re.compile(r"^[A-Za-z0-9.\-]{1,10}$")
 
 
 class CreateWatchlistRequest(BaseModel):
@@ -178,6 +181,10 @@ async def analyze_earnings(request: AnalyzeEarningsRequest) -> Any:
         from src.application.services.ticker_service import get_ticker_transcript
 
         normalized_ticker = request.ticker.strip().upper()
+        if not _TICKER_RE.match(normalized_ticker):
+            raise ValueError(
+                f"Invalid ticker symbol: {request.ticker!r}"
+            )
         result = await get_ticker_transcript(normalized_ticker)
         if not result.available:
             raise ValueError(

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -146,22 +146,22 @@ async def list_agents() -> list[dict[str, str]]:
 
 @app.get("/ticker/{symbol}/summary", response_model=TickerSummary)
 async def ticker_summary(
-    symbol: str = Path(..., pattern=r"^[A-Z0-9.\-]{1,10}$"),
+    symbol: str = Path(..., pattern=r"^[A-Za-z0-9.\-]{1,10}$"),
 ) -> Any:
     """Fetch company summary from Yahoo Finance."""
     from src.application.services.ticker_service import get_ticker_summary
 
-    return await get_ticker_summary(symbol)
+    return await get_ticker_summary(symbol.upper())
 
 
 @app.get("/ticker/{symbol}/transcript", response_model=TickerTranscript)
 async def ticker_transcript(
-    symbol: str = Path(..., pattern=r"^[A-Z0-9.\-]{1,10}$"),
+    symbol: str = Path(..., pattern=r"^[A-Za-z0-9.\-]{1,10}$"),
 ) -> Any:
     """Fetch latest earnings transcript (best-effort)."""
     from src.application.services.ticker_service import get_ticker_transcript
 
-    return await get_ticker_transcript(symbol)
+    return await get_ticker_transcript(symbol.upper())
 
 
 # --- Agent Endpoints ---

--- a/agents/tests/test_contracts.py
+++ b/agents/tests/test_contracts.py
@@ -2,9 +2,6 @@
 
 from decimal import Decimal
 
-import pytest
-from pydantic import ValidationError
-
 from src.application.contracts.agents import (
     AnalyzeEarningsRequest,
     AssessRiskRequest,
@@ -19,9 +16,14 @@ from src.application.contracts.agents import (
 
 
 class TestAnalyzeEarningsContract:
-    def test_empty_transcript_rejected(self):
-        with pytest.raises(ValidationError):
-            AnalyzeEarningsRequest(transcript="")
+    def test_accepts_empty_transcript_with_ticker(self):
+        req = AnalyzeEarningsRequest(transcript="", ticker="AAPL")
+        assert req.ticker == "AAPL"
+        assert req.transcript == ""
+
+    def test_accepts_transcript_without_ticker(self):
+        req = AnalyzeEarningsRequest(transcript="Some earnings text")
+        assert req.transcript == "Some earnings text"
 
 
 class TestClassifyMacroContract:

--- a/agents/tests/test_mcp_server.py
+++ b/agents/tests/test_mcp_server.py
@@ -23,7 +23,7 @@ class TestToolRegistration:
         props = tool.inputSchema["properties"]
         assert "transcript" in props
         assert "ticker" in props
-        assert "transcript" in tool.inputSchema.get("required", [])
+        # Both are optional (provide either one)
 
     async def test_classify_macro_schema(self) -> None:
         tools = await mcp.list_tools()
@@ -77,7 +77,7 @@ class TestAnalyzeEarnings:
         parsed = json.loads(content_list[0].text)
         assert "content" in parsed
 
-    async def test_empty_transcript_rejected(self) -> None:
+    async def test_empty_transcript_no_ticker_rejected(self) -> None:
         with pytest.raises(ToolError):
             await mcp.call_tool("analyze_earnings", {"transcript": ""})
 

--- a/agents/tests/test_ticker_service.py
+++ b/agents/tests/test_ticker_service.py
@@ -77,7 +77,8 @@ class TestGetTickerSummary:
         result1 = await get_ticker_summary("AAPL")
         result2 = await get_ticker_summary("AAPL")
 
-        assert result1 is result2
+        assert result1 is not result2  # defensive copy
+        assert result1 == result2
         assert mock_yf_ticker.call_count == 1
 
     @patch("src.application.services.ticker_service.yf.Ticker")
@@ -145,5 +146,6 @@ class TestGetTickerTranscript:
         result1 = await get_ticker_transcript("AAPL")
         result2 = await get_ticker_transcript("AAPL")
 
-        assert result1 is result2
+        assert result1 is not result2  # defensive copy
+        assert result1 == result2
         assert mock_yf_ticker.call_count == 1

--- a/agents/tests/test_ticker_service.py
+++ b/agents/tests/test_ticker_service.py
@@ -1,0 +1,149 @@
+"""Tests for the ticker lookup service."""
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.application.contracts.ticker import TickerSummary, TickerTranscript
+from src.application.services.ticker_service import (
+    _cache,
+    _safe_decimal,
+    get_ticker_summary,
+    get_ticker_transcript,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Clear ticker cache before each test."""
+    _cache.clear()
+    yield
+    _cache.clear()
+
+
+def _mock_ticker(info: dict | None = None, calendar: dict | None = None):
+    """Create a mock yfinance Ticker."""
+    mock = MagicMock()
+    mock.info = info if info is not None else {
+        "longName": "Apple Inc.",
+        "sector": "Technology",
+        "industry": "Consumer Electronics",
+        "marketCap": 3000000000000,
+        "currency": "USD",
+        "currentPrice": 198.50,
+        "previousClose": 197.25,
+        "fiftyTwoWeekHigh": 220.00,
+        "fiftyTwoWeekLow": 155.00,
+        "longBusinessSummary": "Apple designs consumer electronics.",
+    }
+    mock.calendar = calendar or {}
+    mock.earnings_call_transcripts = MagicMock(return_value=None)
+    return mock
+
+
+class TestSafeDecimal:
+    def test_converts_number(self):
+        assert _safe_decimal(198.50) == str(Decimal("198.5"))
+
+    def test_converts_int(self):
+        assert _safe_decimal(3000000000000) == "3000000000000"
+
+    def test_returns_empty_on_none(self):
+        assert _safe_decimal(None) == ""
+
+    def test_returns_empty_on_invalid(self):
+        assert _safe_decimal("not-a-number") == ""
+
+
+class TestGetTickerSummary:
+    @patch("src.application.services.ticker_service.yf.Ticker")
+    async def test_returns_summary(self, mock_yf_ticker):
+        mock_yf_ticker.return_value = _mock_ticker()
+
+        result = await get_ticker_summary("AAPL")
+
+        assert isinstance(result, TickerSummary)
+        assert result.symbol == "AAPL"
+        assert result.name == "Apple Inc."
+        assert result.sector == "Technology"
+        assert result.market_cap != ""
+        assert result.current_price != ""
+
+    @patch("src.application.services.ticker_service.yf.Ticker")
+    async def test_caches_result(self, mock_yf_ticker):
+        mock_yf_ticker.return_value = _mock_ticker()
+
+        result1 = await get_ticker_summary("AAPL")
+        result2 = await get_ticker_summary("AAPL")
+
+        assert result1 is result2
+        assert mock_yf_ticker.call_count == 1
+
+    @patch("src.application.services.ticker_service.yf.Ticker")
+    async def test_handles_minimal_info(self, mock_yf_ticker):
+        mock_yf_ticker.return_value = _mock_ticker(info={})
+
+        result = await get_ticker_summary("XYZ")
+
+        assert result.symbol == "XYZ"
+        assert result.name == "XYZ"
+        assert result.sector == ""
+        assert result.current_price == ""
+
+    @patch("src.application.services.ticker_service.yf.Ticker")
+    async def test_handles_earnings_date(self, mock_yf_ticker):
+        mock_yf_ticker.return_value = _mock_ticker(
+            calendar={"Earnings Date": ["2025-07-30"]}
+        )
+
+        result = await get_ticker_summary("AAPL")
+
+        assert result.earnings_date == "2025-07-30"
+
+
+class TestGetTickerTranscript:
+    @patch("src.application.services.ticker_service.yf.Ticker")
+    async def test_returns_unavailable_when_no_transcripts(self, mock_yf_ticker):
+        mock_yf_ticker.return_value = _mock_ticker()
+
+        result = await get_ticker_transcript("AAPL")
+
+        assert isinstance(result, TickerTranscript)
+        assert result.symbol == "AAPL"
+        assert not result.available
+        assert result.transcript == ""
+
+    @patch("src.application.services.ticker_service.yf.Ticker")
+    async def test_returns_transcript_when_available(self, mock_yf_ticker):
+        mock = _mock_ticker()
+        mock.earnings_call_transcripts = MagicMock(
+            return_value=[{"content": "Q1 was great...", "period": "Q1 2025"}]
+        )
+        mock_yf_ticker.return_value = mock
+
+        result = await get_ticker_transcript("AAPL")
+
+        assert result.available
+        assert "Q1 was great" in result.transcript
+        assert result.period == "Q1 2025"
+
+    @patch("src.application.services.ticker_service.yf.Ticker")
+    async def test_handles_exception_gracefully(self, mock_yf_ticker):
+        mock = _mock_ticker()
+        mock.earnings_call_transcripts = MagicMock(side_effect=RuntimeError("network"))
+        mock_yf_ticker.return_value = mock
+
+        result = await get_ticker_transcript("AAPL")
+
+        assert not result.available
+
+    @patch("src.application.services.ticker_service.yf.Ticker")
+    async def test_caches_transcript(self, mock_yf_ticker):
+        mock_yf_ticker.return_value = _mock_ticker()
+
+        result1 = await get_ticker_transcript("AAPL")
+        result2 = await get_ticker_transcript("AAPL")
+
+        assert result1 is result2
+        assert mock_yf_ticker.call_count == 1

--- a/agents/tests/test_web_api.py
+++ b/agents/tests/test_web_api.py
@@ -108,6 +108,25 @@ class TestEarningsEndpoint:
         resp = client.post("/agents/earnings_interpreter", json={})
         assert resp.status_code == 400
 
+    @patch("src.application.services.ticker_service.get_ticker_transcript", new_callable=AsyncMock)
+    @patch("src.web_api.AgentService")
+    def test_analyze_earnings_ticker_only_auto_fetches(self, mock_cls, mock_tx, client):
+        mock_tx.return_value = MagicMock(available=True, transcript="Auto-fetched transcript")
+        mock_svc = mock_cls.return_value
+        mock_svc.analyze_earnings = AsyncMock(return_value=_mock_response(
+            AnalyzeEarningsResponse,
+            tone="positive", net_sentiment=0.7, confidence="high",
+            guidance_direction="raised", guidance_count=2, key_phrase_count=5,
+        ))
+        resp = client.post("/agents/earnings_interpreter", json={"ticker": "AAPL"})
+        assert resp.status_code == 200
+
+    @patch("src.application.services.ticker_service.get_ticker_transcript", new_callable=AsyncMock)
+    def test_analyze_earnings_ticker_no_transcript_available_400(self, mock_tx, client):
+        mock_tx.return_value = MagicMock(available=False, transcript="")
+        resp = client.post("/agents/earnings_interpreter", json={"ticker": "AAPL"})
+        assert resp.status_code == 400
+
 
 class TestMacroEndpoint:
     @patch("src.web_api.AgentService")

--- a/agents/tests/test_web_api.py
+++ b/agents/tests/test_web_api.py
@@ -98,15 +98,15 @@ class TestEarningsEndpoint:
         assert data["tone"] == "positive"
         assert data["guidance_count"] == 3
 
-    def test_analyze_earnings_empty_transcript_422(self, client):
+    def test_analyze_earnings_empty_transcript_no_ticker_400(self, client):
         resp = client.post("/agents/earnings_interpreter", json={
             "transcript": "",
         })
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
-    def test_analyze_earnings_missing_transcript_422(self, client):
+    def test_analyze_earnings_missing_both_400(self, client):
         resp = client.post("/agents/earnings_interpreter", json={})
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
 
 class TestMacroEndpoint:

--- a/agents/tests/test_web_api.py
+++ b/agents/tests/test_web_api.py
@@ -22,6 +22,7 @@ from src.application.contracts.agents import (
     RunPipelineResponse,
     SearchFilingsResponse,
 )
+from src.application.contracts.ticker import TickerSummary, TickerTranscript
 from src.application.registry import AGENT_CATALOG
 from src.core.knowledge_graph import KnowledgeGraph
 from src.web_api import app, get_config
@@ -707,3 +708,86 @@ class TestWatchlistActivate:
     def test_activate_nonexistent_404(self, client):
         resp = client.put("/watchlists/nope/activate")
         assert resp.status_code == 404
+
+
+# --- Ticker Lookup Endpoints ---
+
+
+class TestTickerSummary:
+    @patch(
+        "src.application.services.ticker_service.get_ticker_summary",
+        new_callable=AsyncMock,
+    )
+    def test_success(self, mock_summary, client):
+        mock_summary.return_value = TickerSummary(
+            symbol="AAPL",
+            name="Apple Inc.",
+            sector="Technology",
+            industry="Consumer Electronics",
+            market_cap="3000000000000",
+            currency="USD",
+            current_price="190.50",
+            previous_close="189.00",
+            fifty_two_week_high="199.62",
+            fifty_two_week_low="155.98",
+            earnings_date="2025-07-24",
+            description="Apple designs consumer electronics.",
+        )
+        resp = client.get("/ticker/AAPL/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["symbol"] == "AAPL"
+        assert data["name"] == "Apple Inc."
+        mock_summary.assert_awaited_once_with("AAPL")
+
+    @patch(
+        "src.application.services.ticker_service.get_ticker_summary",
+        new_callable=AsyncMock,
+    )
+    def test_lowercase_normalized(self, mock_summary, client):
+        mock_summary.return_value = TickerSummary(
+            symbol="AAPL", name="Apple Inc.",
+        )
+        resp = client.get("/ticker/aapl/summary")
+        assert resp.status_code == 200
+        mock_summary.assert_awaited_once_with("AAPL")
+
+    def test_invalid_symbol_422(self, client):
+        resp = client.get("/ticker/INVALID!!!/summary")
+        assert resp.status_code == 422
+
+
+class TestTickerTranscript:
+    @patch(
+        "src.application.services.ticker_service.get_ticker_transcript",
+        new_callable=AsyncMock,
+    )
+    def test_success(self, mock_transcript, client):
+        mock_transcript.return_value = TickerTranscript(
+            symbol="MSFT",
+            available=True,
+            transcript="Q2 earnings call...",
+            period="Q2 2025",
+        )
+        resp = client.get("/ticker/MSFT/transcript")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["available"] is True
+        mock_transcript.assert_awaited_once_with("MSFT")
+
+    @patch(
+        "src.application.services.ticker_service.get_ticker_transcript",
+        new_callable=AsyncMock,
+    )
+    def test_unavailable(self, mock_transcript, client):
+        mock_transcript.return_value = TickerTranscript(
+            symbol="XYZ",
+            available=False,
+        )
+        resp = client.get("/ticker/XYZ/transcript")
+        assert resp.status_code == 200
+        assert resp.json()["available"] is False
+
+    def test_invalid_symbol_422(self, client):
+        resp = client.get("/ticker/@bad/transcript")
+        assert resp.status_code == 422

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from 'react';
 import { HealthStatus } from './components/HealthStatus';
 import { AgentList } from './components/AgentList';
 import { AgentRunner } from './components/AgentRunner';
@@ -5,14 +6,24 @@ import { DigestPanel } from './components/DigestPanel';
 import { KnowledgeGraphPanel } from './components/KnowledgeGraphPanel';
 import { PipelineRunner } from './components/PipelineRunner';
 import { StatsDashboard } from './components/StatsDashboard';
+import { TickerBar } from './components/TickerBar';
+import type { TickerContext } from './components/TickerBar';
 
 export function App() {
+  const [ticker, setTicker] = useState<TickerContext | null>(null);
+
+  const handleTickerChange = useCallback((ctx: TickerContext) => {
+    setTicker(ctx);
+  }, []);
+
   return (
     <div style={{ maxWidth: 960, margin: '0 auto', padding: '2rem 1rem', fontFamily: 'system-ui, sans-serif' }}>
       <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem' }}>
         <h1 style={{ margin: 0, fontSize: '1.5rem' }}>finance-os</h1>
         <HealthStatus />
       </header>
+
+      <TickerBar onTickerChange={handleTickerChange} />
 
       <section style={{ marginBottom: '2rem' }}>
         <h2 style={{ fontSize: '1.125rem', marginBottom: '0.75rem' }}>Research Digest</h2>
@@ -26,7 +37,7 @@ export function App() {
 
       <section style={{ marginBottom: '2rem' }}>
         <h2 style={{ fontSize: '1.125rem', marginBottom: '0.75rem' }}>Agent Runner</h2>
-        <AgentRunner />
+        <AgentRunner ticker={ticker} />
       </section>
 
       <section style={{ marginBottom: '2rem' }}>

--- a/web-ui/src/agentSpecs.ts
+++ b/web-ui/src/agentSpecs.ts
@@ -26,7 +26,7 @@ export const agentSpecs: AgentSpec[] = [
     description: 'Analyze earnings call transcripts for tone, sentiment, and guidance.',
     endpoint: '/agents/earnings_interpreter',
     fields: [
-      { name: 'transcript', label: 'Transcript', type: 'textarea', required: true, placeholder: 'Paste earnings call transcript...' },
+      { name: 'transcript', label: 'Transcript', type: 'textarea', placeholder: 'Paste earnings call transcript… or enter a ticker above to auto-fetch' },
       { name: 'ticker', label: 'Ticker', type: 'text', placeholder: 'AAPL' },
     ],
     responseFields: ['tone', 'net_sentiment', 'confidence', 'guidance_direction', 'guidance_count', 'key_phrase_count'],

--- a/web-ui/src/api.ts
+++ b/web-ui/src/api.ts
@@ -10,7 +10,8 @@ import type {
   QueryRelatedRequest, QueryRelatedResponse, QuerySharedRisksRequest,
   QuerySharedRisksResponse, QuerySupplyChainRequest, QuerySupplyChainResponse,
   RunPipelineRequest, RunPipelineResponse, SearchFilingsRequest,
-  SearchFilingsResponse, WatchlistData, WatchlistsResponse,
+  SearchFilingsResponse, TickerSummary, TickerTranscript, WatchlistData,
+  WatchlistsResponse,
 } from './types';
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? '/api';
@@ -209,4 +210,14 @@ export function querySharedRisks(req: QuerySharedRisksRequest): Promise<QuerySha
 
 export function fetchKGStats(): Promise<KGStatsResponse> {
   return request('/kg/stats');
+}
+
+// --- Ticker Lookup ---
+
+export function fetchTickerSummary(symbol: string): Promise<TickerSummary> {
+  return request(`/ticker/${encodeURIComponent(symbol)}/summary`);
+}
+
+export function fetchTickerTranscript(symbol: string): Promise<TickerTranscript> {
+  return request(`/ticker/${encodeURIComponent(symbol)}/transcript`);
 }

--- a/web-ui/src/components/AgentRunner.tsx
+++ b/web-ui/src/components/AgentRunner.tsx
@@ -1,9 +1,14 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchAgents, postJson } from '../api';
 import { agentSpecs, type AgentSpec, type FieldSpec } from '../agentSpecs';
 import type { AgentInfo } from '../types';
+import type { TickerContext } from './TickerBar';
 
-export function AgentRunner() {
+interface AgentRunnerProps {
+  ticker?: TickerContext | null;
+}
+
+export function AgentRunner({ ticker }: AgentRunnerProps) {
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedAgent, setSelectedAgent] = useState('');
@@ -11,6 +16,7 @@ export function AgentRunner() {
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<Record<string, unknown> | null>(null);
   const [error, setError] = useState('');
+  const userEdited = useRef<Set<string>>(new Set());
 
   const initForm = useCallback((agentName: string) => {
     const spec = agentSpecs.find((s) => s.name === agentName);
@@ -20,6 +26,7 @@ export function AgentRunner() {
       defaults[field.name] = field.defaultValue ?? '';
     }
     setFormValues(defaults);
+    userEdited.current.clear();
   }, []);
 
   useEffect(() => {
@@ -40,6 +47,28 @@ export function AgentRunner() {
     setError('');
     initForm(name);
   };
+
+  // Auto-populate fields from ticker context (only untouched fields)
+  useEffect(() => {
+    if (!ticker?.summary || ticker.loading || !selectedAgent) return;
+    const sym = ticker.symbol;
+    const prefills: Record<string, Record<string, string>> = {
+      earnings_interpreter: { ticker: sym, ...(ticker.transcript?.available ? { transcript: ticker.transcript.transcript } : {}) },
+      filing_analyst: { ticker: sym },
+      thesis_guardian: { ticker: sym },
+      risk_analyst: {},
+      adversarial: { ticker: sym },
+    };
+    const fills = prefills[selectedAgent];
+    if (!fills) return;
+    setFormValues((prev) => {
+      const next = { ...prev };
+      for (const [k, v] of Object.entries(fills)) {
+        if (!userEdited.current.has(k)) next[k] = v;
+      }
+      return next;
+    });
+  }, [ticker, selectedAgent]);
 
   const currentSpec: AgentSpec | undefined = agentSpecs.find((s) => s.name === selectedAgent);
 
@@ -123,7 +152,7 @@ export function AgentRunner() {
               key={field.name}
               field={field}
               value={formValues[field.name] ?? ''}
-              onChange={(val) => setFormValues((prev) => ({ ...prev, [field.name]: val }))}
+              onChange={(val) => { userEdited.current.add(field.name); setFormValues((prev) => ({ ...prev, [field.name]: val })); }}
             />
           ))}
           <button

--- a/web-ui/src/components/AgentRunner.tsx
+++ b/web-ui/src/components/AgentRunner.tsx
@@ -52,15 +52,18 @@ export function AgentRunner({ ticker }: AgentRunnerProps) {
   useEffect(() => {
     if (!ticker?.summary || ticker.loading || !selectedAgent) return;
     const sym = ticker.symbol;
-    const prefills: Record<string, Record<string, string>> = {
-      earnings_interpreter: { ticker: sym, ...(ticker.transcript?.available ? { transcript: ticker.transcript.transcript } : {}) },
-      filing_analyst: { ticker: sym },
-      thesis_guardian: { ticker: sym },
-      risk_analyst: {},
-      adversarial: { ticker: sym },
+    const spec = agentSpecs.find((s) => s.name === selectedAgent);
+    if (!spec) return;
+    const fieldNames = new Set(spec.fields.map((f) => f.name));
+    const candidates: Record<string, string> = {
+      ticker: sym,
+      ...(ticker.transcript?.available ? { transcript: ticker.transcript.transcript } : {}),
     };
-    const fills = prefills[selectedAgent];
-    if (!fills) return;
+    const fills: Record<string, string> = {};
+    for (const [k, v] of Object.entries(candidates)) {
+      if (fieldNames.has(k)) fills[k] = v;
+    }
+    if (Object.keys(fills).length === 0) return;
     setFormValues((prev) => {
       const next = { ...prev };
       for (const [k, v] of Object.entries(fills)) {

--- a/web-ui/src/components/TickerBar.tsx
+++ b/web-ui/src/components/TickerBar.tsx
@@ -22,7 +22,7 @@ export function TickerBar({ onTickerChange }: TickerBarProps) {
 
   const lookup = useCallback(async () => {
     const symbol = input.trim().toUpperCase();
-    if (!symbol) return;
+    if (!symbol || loading) return;
 
     const thisRequest = ++requestId.current;
 
@@ -63,7 +63,7 @@ export function TickerBar({ onTickerChange }: TickerBarProps) {
         setLoading(false);
       }
     }
-  }, [input, onTickerChange]);
+  }, [input, loading, onTickerChange]);
 
   return (
     <div data-testid="ticker-bar" style={{ padding: '1rem', background: '#f0f4ff', borderRadius: 8, marginBottom: '1rem' }}>

--- a/web-ui/src/components/TickerBar.tsx
+++ b/web-ui/src/components/TickerBar.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useState } from 'react';
+import { fetchTickerSummary, fetchTickerTranscript } from '../api';
+import type { TickerSummary, TickerTranscript } from '../types';
+
+export interface TickerContext {
+  symbol: string;
+  summary: TickerSummary | null;
+  transcript: TickerTranscript | null;
+  loading: boolean;
+}
+
+interface TickerBarProps {
+  onTickerChange: (ctx: TickerContext) => void;
+}
+
+export function TickerBar({ onTickerChange }: TickerBarProps) {
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [summary, setSummary] = useState<TickerSummary | null>(null);
+
+  const lookup = useCallback(async () => {
+    const symbol = input.trim().toUpperCase();
+    if (!symbol) return;
+
+    setLoading(true);
+    setError('');
+    setSummary(null);
+    onTickerChange({ symbol, summary: null, transcript: null, loading: true });
+
+    try {
+      const [sum, tx] = await Promise.all([
+        fetchTickerSummary(symbol),
+        fetchTickerTranscript(symbol),
+      ]);
+      setSummary(sum);
+      onTickerChange({ symbol, summary: sum, transcript: tx, loading: false });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Lookup failed';
+      setError(msg);
+      onTickerChange({ symbol, summary: null, transcript: null, loading: false });
+    } finally {
+      setLoading(false);
+    }
+  }, [input, onTickerChange]);
+
+  return (
+    <div data-testid="ticker-bar" style={{ padding: '1rem', background: '#f0f4ff', borderRadius: 8, marginBottom: '1rem' }}>
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <input
+          data-testid="ticker-input"
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value.toUpperCase())}
+          onKeyDown={(e) => { if (e.key === 'Enter') lookup(); }}
+          placeholder="Enter ticker (e.g. AAPL)"
+          style={{ padding: '0.5rem 0.75rem', border: '1px solid #d1d5db', borderRadius: 6, fontSize: '1rem', fontWeight: 600, width: 140 }}
+        />
+        <button
+          data-testid="ticker-lookup"
+          type="button"
+          onClick={lookup}
+          disabled={loading || !input.trim()}
+          style={{ padding: '0.5rem 1rem', background: '#2563eb', color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: '0.9rem' }}
+        >
+          {loading ? 'Looking up…' : 'Look Up'}
+        </button>
+      </div>
+
+      {error && <p data-testid="ticker-error" style={{ color: '#ef4444', marginTop: '0.5rem', fontSize: '0.85rem' }}>{error}</p>}
+
+      {summary && (
+        <div data-testid="ticker-summary" style={{ marginTop: '0.75rem', display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '0.5rem', fontSize: '0.85rem' }}>
+          <div><strong>{summary.name}</strong> ({summary.symbol})</div>
+          <div>Sector: {summary.sector || '—'}</div>
+          <div>Industry: {summary.industry || '—'}</div>
+          <div>Price: {summary.current_price ? `${summary.currency} ${summary.current_price}` : '—'}</div>
+          <div>Market Cap: {summary.market_cap ? formatMarketCap(summary.market_cap) : '—'}</div>
+          <div>52W Range: {summary.fifty_two_week_low && summary.fifty_two_week_high ? `${summary.fifty_two_week_low} – ${summary.fifty_two_week_high}` : '—'}</div>
+          {summary.earnings_date && <div>Next Earnings: {summary.earnings_date}</div>}
+        </div>
+      )}
+
+      {summary?.description && (
+        <p style={{ marginTop: '0.5rem', fontSize: '0.8rem', color: '#4b5563', lineHeight: 1.4 }}>
+          {summary.description.length > 300 ? summary.description.slice(0, 300) + '…' : summary.description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function formatMarketCap(val: string): string {
+  const num = Number(val);
+  if (!Number.isFinite(num)) return val;
+  if (num >= 1e12) return `$${(num / 1e12).toFixed(1)}T`;
+  if (num >= 1e9) return `$${(num / 1e9).toFixed(1)}B`;
+  if (num >= 1e6) return `$${(num / 1e6).toFixed(0)}M`;
+  return `$${num.toLocaleString()}`;
+}

--- a/web-ui/src/components/TickerBar.tsx
+++ b/web-ui/src/components/TickerBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { fetchTickerSummary, fetchTickerTranscript } from '../api';
 import type { TickerSummary, TickerTranscript } from '../types';
 
@@ -18,10 +18,13 @@ export function TickerBar({ onTickerChange }: TickerBarProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [summary, setSummary] = useState<TickerSummary | null>(null);
+  const requestId = useRef(0);
 
   const lookup = useCallback(async () => {
     const symbol = input.trim().toUpperCase();
     if (!symbol) return;
+
+    const thisRequest = ++requestId.current;
 
     setLoading(true);
     setError('');
@@ -33,14 +36,19 @@ export function TickerBar({ onTickerChange }: TickerBarProps) {
         fetchTickerSummary(symbol),
         fetchTickerTranscript(symbol),
       ]);
+      // Ignore stale responses from superseded requests
+      if (thisRequest !== requestId.current) return;
       setSummary(sum);
       onTickerChange({ symbol, summary: sum, transcript: tx, loading: false });
     } catch (err) {
+      if (thisRequest !== requestId.current) return;
       const msg = err instanceof Error ? err.message : 'Lookup failed';
       setError(msg);
       onTickerChange({ symbol, summary: null, transcript: null, loading: false });
     } finally {
-      setLoading(false);
+      if (thisRequest === requestId.current) {
+        setLoading(false);
+      }
     }
   }, [input, onTickerChange]);
 

--- a/web-ui/src/components/TickerBar.tsx
+++ b/web-ui/src/components/TickerBar.tsx
@@ -71,6 +71,7 @@ export function TickerBar({ onTickerChange }: TickerBarProps) {
         <input
           data-testid="ticker-input"
           type="text"
+          aria-label="Ticker symbol"
           value={input}
           onChange={(e) => setInput(e.target.value.toUpperCase())}
           onKeyDown={(e) => { if (e.key === 'Enter') lookup(); }}
@@ -88,7 +89,7 @@ export function TickerBar({ onTickerChange }: TickerBarProps) {
         </button>
       </div>
 
-      {error && <p data-testid="ticker-error" style={{ color: '#ef4444', marginTop: '0.5rem', fontSize: '0.85rem' }}>{error}</p>}
+      {error && <p data-testid="ticker-error" role="alert" style={{ color: '#ef4444', marginTop: '0.5rem', fontSize: '0.85rem' }}>{error}</p>}
 
       {summary && (
         <div data-testid="ticker-summary" style={{ marginTop: '0.75rem', display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '0.5rem', fontSize: '0.85rem' }}>

--- a/web-ui/src/components/TickerBar.tsx
+++ b/web-ui/src/components/TickerBar.tsx
@@ -32,13 +32,26 @@ export function TickerBar({ onTickerChange }: TickerBarProps) {
     onTickerChange({ symbol, summary: null, transcript: null, loading: true });
 
     try {
-      const [sum, tx] = await Promise.all([
+      const [summaryResult, transcriptResult] = await Promise.allSettled([
         fetchTickerSummary(symbol),
         fetchTickerTranscript(symbol),
       ]);
-      // Ignore stale responses from superseded requests
       if (thisRequest !== requestId.current) return;
+
+      if (summaryResult.status === 'rejected') {
+        const msg = summaryResult.reason instanceof Error ? summaryResult.reason.message : 'Lookup failed';
+        setError(msg);
+        onTickerChange({ symbol, summary: null, transcript: null, loading: false });
+        return;
+      }
+
+      const sum = summaryResult.value;
+      const tx = transcriptResult.status === 'fulfilled' ? transcriptResult.value : null;
+
       setSummary(sum);
+      if (transcriptResult.status === 'rejected') {
+        setError(transcriptResult.reason instanceof Error ? transcriptResult.reason.message : 'Transcript unavailable');
+      }
       onTickerChange({ symbol, summary: sum, transcript: tx, loading: false });
     } catch (err) {
       if (thisRequest !== requestId.current) return;
@@ -83,7 +96,7 @@ export function TickerBar({ onTickerChange }: TickerBarProps) {
           <div>Sector: {summary.sector || '—'}</div>
           <div>Industry: {summary.industry || '—'}</div>
           <div>Price: {summary.current_price ? `${summary.currency} ${summary.current_price}` : '—'}</div>
-          <div>Market Cap: {summary.market_cap ? formatMarketCap(summary.market_cap) : '—'}</div>
+          <div>Market Cap: {summary.market_cap ? formatMarketCap(summary.market_cap, summary.currency) : '—'}</div>
           <div>52W Range: {summary.fifty_two_week_low && summary.fifty_two_week_high ? `${summary.fifty_two_week_low} – ${summary.fifty_two_week_high}` : '—'}</div>
           {summary.earnings_date && <div>Next Earnings: {summary.earnings_date}</div>}
         </div>
@@ -98,11 +111,12 @@ export function TickerBar({ onTickerChange }: TickerBarProps) {
   );
 }
 
-function formatMarketCap(val: string): string {
+function formatMarketCap(val: string, currency?: string): string {
   const num = Number(val);
   if (!Number.isFinite(num)) return val;
-  if (num >= 1e12) return `$${(num / 1e12).toFixed(1)}T`;
-  if (num >= 1e9) return `$${(num / 1e9).toFixed(1)}B`;
-  if (num >= 1e6) return `$${(num / 1e6).toFixed(0)}M`;
-  return `$${num.toLocaleString()}`;
+  const prefix = currency || '$';
+  if (num >= 1e12) return `${prefix} ${(num / 1e12).toFixed(1)}T`;
+  if (num >= 1e9) return `${prefix} ${(num / 1e9).toFixed(1)}B`;
+  if (num >= 1e6) return `${prefix} ${(num / 1e6).toFixed(0)}M`;
+  return `${prefix} ${num.toLocaleString()}`;
 }

--- a/web-ui/src/components/TickerBar.tsx
+++ b/web-ui/src/components/TickerBar.tsx
@@ -82,7 +82,7 @@ export function TickerBar({ onTickerChange }: TickerBarProps) {
           type="button"
           onClick={lookup}
           disabled={loading || !input.trim()}
-          style={{ padding: '0.5rem 1rem', background: '#2563eb', color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: '0.9rem' }}
+          style={{ padding: '0.5rem 1rem', background: '#2563eb', color: '#fff', border: 'none', borderRadius: 6, cursor: loading || !input.trim() ? 'not-allowed' : 'pointer', fontSize: '0.9rem' }}
         >
           {loading ? 'Looking up…' : 'Look Up'}
         </button>

--- a/web-ui/src/types.ts
+++ b/web-ui/src/types.ts
@@ -231,3 +231,28 @@ export interface KGStatsResponse {
   entities_by_type: Record<string, number>;
   relationships_by_type: Record<string, number>;
 }
+
+// --- Ticker Lookup ---
+
+export interface TickerSummary {
+  symbol: string;
+  name: string;
+  sector: string;
+  industry: string;
+  market_cap: string;
+  currency: string;
+  current_price: string;
+  previous_close: string;
+  fifty_two_week_high: string;
+  fifty_two_week_low: string;
+  earnings_date: string;
+  description: string;
+}
+
+export interface TickerTranscript {
+  symbol: string;
+  available: boolean;
+  transcript: string;
+  period: string;
+  source: string;
+}

--- a/web-ui/tests/agent-runner.test.tsx
+++ b/web-ui/tests/agent-runner.test.tsx
@@ -37,7 +37,7 @@ describe('AgentRunner', () => {
     });
 
     // earnings_interpreter is the first agent in mock — its spec has transcript and ticker fields
-    expect(screen.getByText('Transcript *')).toBeInTheDocument();
+    expect(screen.getByText('Transcript')).toBeInTheDocument();
   });
 
   it('switches form when selecting different agent', async () => {
@@ -127,7 +127,7 @@ describe('AgentRunner', () => {
     await waitFor(() => {
       expect(screen.getByTestId('agent-select')).toBeInTheDocument();
     });
-    const transcriptInput = screen.getByPlaceholderText('Paste earnings call transcript...');
+    const transcriptInput = screen.getByPlaceholderText(/Paste earnings call transcript/);
     fireEvent.change(transcriptInput, { target: { value: 'Some transcript' } });
     fireEvent.click(screen.getByText('Run Agent'));
 
@@ -145,8 +145,8 @@ describe('AgentRunner', () => {
       expect(screen.getByTestId('agent-select')).toBeInTheDocument();
     });
 
-    // Fill required transcript field before running
-    const transcriptInput = screen.getByPlaceholderText('Paste earnings call transcript...');
+    // Fill transcript field before running
+    const transcriptInput = screen.getByPlaceholderText(/Paste earnings call transcript/);
     fireEvent.change(transcriptInput, { target: { value: 'Q1 results strong' } });
     fireEvent.click(screen.getByText('Run Agent'));
     await waitFor(() => {

--- a/web-ui/tests/mocks/handlers.ts
+++ b/web-ui/tests/mocks/handlers.ts
@@ -191,4 +191,35 @@ export const handlers = [
       relationships_by_type: { supplies_to: 12, competes_with: 6, exposed_to: 4 },
     });
   }),
+
+  // --- Ticker Lookup ---
+
+  http.get('/api/ticker/:symbol/summary', ({ params }) => {
+    const symbol = String(params.symbol).toUpperCase();
+    return HttpResponse.json({
+      symbol,
+      name: `${symbol} Inc.`,
+      sector: 'Technology',
+      industry: 'Consumer Electronics',
+      market_cap: '3000000000000',
+      currency: 'USD',
+      current_price: '198.50',
+      previous_close: '197.25',
+      fifty_two_week_high: '220.00',
+      fifty_two_week_low: '155.00',
+      earnings_date: '2025-07-30',
+      description: `${symbol} designs and manufactures consumer electronics.`,
+    });
+  }),
+
+  http.get('/api/ticker/:symbol/transcript', ({ params }) => {
+    const symbol = String(params.symbol).toUpperCase();
+    return HttpResponse.json({
+      symbol,
+      available: true,
+      transcript: `This is the latest earnings call transcript for ${symbol}. Revenue grew 15% year over year.`,
+      period: 'Q1 2025',
+      source: 'yfinance',
+    });
+  }),
 ];

--- a/web-ui/tests/ticker.test.tsx
+++ b/web-ui/tests/ticker.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { App } from '../src/App';
+import { server } from './mocks/server';
+
+describe('TickerBar', () => {
+  it('renders ticker input and lookup button', () => {
+    render(<App />);
+    expect(screen.getByTestId('ticker-input')).toBeInTheDocument();
+    expect(screen.getByTestId('ticker-lookup')).toBeInTheDocument();
+  });
+
+  it('fetches and displays ticker summary on lookup', async () => {
+    render(<App />);
+    fireEvent.change(screen.getByTestId('ticker-input'), { target: { value: 'AAPL' } });
+    fireEvent.click(screen.getByTestId('ticker-lookup'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ticker-summary')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/AAPL Inc\./)).toBeInTheDocument();
+    expect(screen.getByText(/Technology/)).toBeInTheDocument();
+  });
+
+  it('shows error when lookup fails', async () => {
+    server.use(
+      http.get('/api/ticker/:symbol/summary', () => HttpResponse.json({}, { status: 500 })),
+    );
+    render(<App />);
+    fireEvent.change(screen.getByTestId('ticker-input'), { target: { value: 'BAD' } });
+    fireEvent.click(screen.getByTestId('ticker-lookup'));
+
+    await waitFor(() => {
+      const el = screen.getByTestId('ticker-error');
+      expect(el).toBeInTheDocument();
+      expect(el.textContent).not.toBe('');
+    });
+  });
+
+  it('auto-populates agent runner fields with ticker data', async () => {
+    render(<App />);
+
+    // Wait for agents to load
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-select')).toBeInTheDocument();
+    });
+
+    // Look up AAPL
+    fireEvent.change(screen.getByTestId('ticker-input'), { target: { value: 'AAPL' } });
+    fireEvent.click(screen.getByTestId('ticker-lookup'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ticker-summary')).toBeInTheDocument();
+    });
+
+    // The earnings_interpreter form should have ticker pre-filled
+    // (earnings_interpreter is the default agent)
+    const transcriptField = screen.getByPlaceholderText('Paste earnings call transcript...');
+    await waitFor(() => {
+      expect((transcriptField as HTMLTextAreaElement).value).toContain('earnings call transcript for AAPL');
+    });
+  });
+
+  it('submits lookup on Enter key', async () => {
+    render(<App />);
+    const input = screen.getByTestId('ticker-input');
+    fireEvent.change(input, { target: { value: 'MSFT' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ticker-summary')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/MSFT Inc\./)).toBeInTheDocument();
+  });
+
+  it('disables lookup button when input is empty', () => {
+    render(<App />);
+    expect(screen.getByTestId('ticker-lookup')).toBeDisabled();
+  });
+});

--- a/web-ui/tests/ticker.test.tsx
+++ b/web-ui/tests/ticker.test.tsx
@@ -56,7 +56,7 @@ describe('TickerBar', () => {
 
     // The earnings_interpreter form should have ticker pre-filled
     // (earnings_interpreter is the default agent)
-    const transcriptField = screen.getByPlaceholderText('Paste earnings call transcript...');
+    const transcriptField = screen.getByPlaceholderText(/Paste earnings call transcript/);
     await waitFor(() => {
       expect((transcriptField as HTMLTextAreaElement).value).toContain('earnings call transcript for AAPL');
     });


### PR DESCRIPTION
Closes #84

## Changes

### Backend
- Added `yfinance` dependency to `agents/pyproject.toml`
- Created `TickerService` with `get_summary` and `get_transcript` (async, cached with per-endpoint TTLs)
- Added `TickerSummary` and `TickerTranscript` Pydantic contracts
- Added `GET /ticker/{symbol}/summary` and `GET /ticker/{symbol}/transcript` endpoints
- Updated `AnalyzeEarningsRequest`: accepts `ticker` OR `transcript` (auto-fetches transcript when ticker given)
- MCP server `analyze_earnings` also supports ticker-only invocation
- All yfinance calls wrapped in `asyncio.to_thread` to avoid blocking the event loop

### Frontend
- New `TickerBar` component with search input, Enter-key support, and company summary display
- App-level ticker context passed to `AgentRunner`
- Auto-populates agent form fields (ticker, transcript) from Yahoo Finance data
- Dirty field tracking prevents overwriting user edits
- Market cap formatting (T/B/M)
- MSW handlers for ticker endpoints

### Tests
- 12 new Python tests for ticker service (summary, transcript, caching, graceful degradation)
- 6 new web-ui tests for ticker bar (lookup, error, auto-populate, Enter key, disabled state)
- Updated existing tests for new optional transcript contract
- 540 Python unit tests passing, 76 web-ui tests passing