### PR TITLE
docs: rewrite project documentation for macro ETF pivot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,9 @@
 
 ## Project Context
 
-**finance-os** is a modular, LLM-powered personal investing AI stack — agent orchestration, domain-tuned prompting, custom MCP tools, and deep integration with quant + NLP pipelines. It is a monorepo with a TypeScript MCP server and Python agent framework.
+**finance-os** is a macro ETF portfolio intelligence system — macroeconomic outlook-driven investment evaluation and goal-driven portfolio rebalancing for a wealthy family ($2M–$10M investable). Monorepo with a TypeScript MCP server, Python agent framework, FastAPI web API, and React frontend.
+
+**Target persona**: Wealthy family that can retire anytime keeping their lifestyle comfortably. Capital preservation + moderate growth. Tax-efficient ETF portfolios. Not average, not ultra-rich.
 
 ## Architecture
 
@@ -11,24 +13,30 @@
 - **Protocol**: Model Context Protocol via `@modelcontextprotocol/sdk`
 - **Build**: `tsc` to `dist/`, ES Modules (`"type": "module"`)
 - **Tools**: Each tool in `src/tools/` exports a registration function. Tools are stateless data request handlers.
-- **Resources**: `src/resources/` for MCP resource providers
-- **Prompts**: `src/prompts/` for MCP prompt templates
 - **Tests**: Vitest in `tests/`
 
 ### Agents (`agents/`) — Python
 - **Framework**: Custom agent base classes in `src/core/`
-- **LLM Gateway**: Pluggable inference client in the application layer — supports OpenAI, Anthropic, ollama, or skip when host LLM reasons (MCP path)
-- **Domain Agents**: `src/agents/` — filing analyst, earnings interpreter, macro regime, quant signal, thesis guardian, risk, adversarial
-- **Application Layer**: `src/application/` — shared contracts (Pydantic), LLM gateway, services. CLI, MCP server, and Web API are thin wrappers over this.
+- **LLM Gateway**: Pluggable inference client — supports Azure OpenAI, or skip when host LLM reasons (MCP path)
+- **Active Agents**: Macro regime, risk analyst, quant signal (kept from v1). Macro outlook, portfolio evaluator, rebalancer (new, in development).
+- **Retiring Agents**: Filing analyst, earnings interpreter, thesis guardian, adversarial (stock-picking focused — being removed after new UI is ready)
+- **Application Layer**: `src/application/` — shared contracts (Pydantic), LLM gateway, services. CLI, MCP server, and Web API are thin wrappers.
 - **Quant Tools**: `src/tools/` — regression, factor analysis, Monte Carlo, Bayesian updates
-- **Data Pipelines**: `src/pipelines/` — EDGAR, FRED, market data, research digest
+- **Data Pipelines**: `src/pipelines/` — FRED, market data, research digest
 - **Tests**: pytest in `tests/`
 
-### Prompt Library (`prompts/`) — Shared
-- `roles/` — role-stacking persona prompts
-- `analysis/` — analytical prompt templates
-- `adversarial/` — thesis-challenging prompts
-- `synthesis/` — multi-document synthesis
+### Data Sources (credible, no social networks)
+
+| Source | Data | Auth |
+|--------|------|------|
+| FRED (Federal Reserve) | GDP, employment, inflation, rates, spreads, sentiment, production | API key |
+| Yahoo Finance (yfinance) | ETF prices, holdings (best-effort), expense ratios, categories | None |
+| BLS (Bureau of Labor Statistics) | Detailed CPI components, employment by sector, productivity | API key |
+| Treasury.gov | Yield curves, real yields, fiscal data, auction results | None |
+| IMF (Data API) | Global GDP forecasts, trade balances, exchange rates | None |
+| World Bank (Data API) | Development indicators, global growth | None |
+
+**No social network data. No SEC EDGAR (retiring).**
 
 ## LLM Inference Model
 
@@ -43,17 +51,15 @@ Agents perform deterministic data processing and construct prompts but **do not 
 ## Data Flow
 
 ```
-External APIs (EDGAR, FRED, Yahoo Finance)
+External APIs (FRED, BLS, Treasury, IMF, World Bank, Yahoo Finance)
         ↓
-Data Pipelines (Python) → Local Data Store
-        ↓
-MCP Tools (TypeScript) ← LLM requests via MCP protocol
+Data Services (Python) → Provider Abstraction (freshness tracking)
         ↓
 Application Layer (contracts + LLM gateway)
         ↓
-Agents (Python) — orchestrated multi-agent reasoning
+Agents (Python) — macro outlook, portfolio evaluation, rebalancing
         ↓
-Research Output (memos, alerts, signals)
+Portfolio Intelligence (evaluation, recommendations, stress tests)
 ```
 
 ## Tech Stack
@@ -63,10 +69,9 @@ Research Output (memos, alerts, signals)
 | MCP Server (data tools) | TypeScript, Node.js, `@modelcontextprotocol/sdk` |
 | MCP Server (agents) | Python, `mcp` SDK |
 | Application Layer | Python, Pydantic 2.11+, pydantic-settings, azure-identity |
-| Agents | Python 3.12+, NumPy, pandas, scipy |
-| Vector DB | ChromaDB (local) |
-| LLM Gateway | Pluggable — OpenAI, Anthropic, ollama, or host LLM via MCP |
-| Data Sources | SEC EDGAR (free), FRED (free), Yahoo Finance (yfinance), QIF files |
+| Agents | Python 3.12+ |
+| LLM Gateway | Pluggable — Azure OpenAI, or host LLM via MCP |
+| Data Sources | FRED, BLS, Treasury.gov, IMF, World Bank, Yahoo Finance |
 | CLI | Python (`finance-os` console script) |
 | Web API | Python (`finance-os-api` console script, FastAPI + uvicorn) |
 | Web UI | React 19, TypeScript, Vite |
@@ -75,12 +80,31 @@ Research Output (memos, alerts, signals)
 | Testing | Vitest (TS), pytest (Python) |
 | CI/CD | GitHub Actions |
 
+## Asset Class Taxonomy
+
+Two-layer taxonomy for ETF classification:
+
+**Canonical** (for allocation decisions): US Equity, International Developed, Emerging Markets, US Treasuries, IG Corporate Bonds, High Yield, TIPS/Inflation-Linked, Real Assets (REITs/Commodities), Cash/Money Market
+
+**Diagnostic** (for deeper analysis): Large/Small cap, Value/Growth, Sector, Duration buckets, Credit quality, Currency exposure
+
+## Key Design Decisions
+
+1. **Policy-first**: Macro outlook applies bounded tilts around strategic allocation (IPS), never overrides it
+2. **Dimensioned evaluation**: No single "health score" — policy drift, concentration, macro alignment, liquidity, tax drag, scenario exposure
+3. **Phased rebalancing**: Directional → account-aware → tax-lot (increasing complexity)
+4. **Provider abstraction**: All data behind interfaces for future source upgrades; track freshness/confidence
+5. **Wealthy family persona**: 3–4% SWR, capital preservation priority, tax-efficiency, multi-generational
+6. **No social network data**: Only government, institutional, and market data sources
+7. **ETF-level, not stock-level**: All analysis at macro/asset-class/ETF granularity
+8. **Decimal precision**: All monetary/financial arithmetic uses `decimal.Decimal`, never `float`
+
 ## Code Guidelines
 
 ### General
 - **ES Modules**: All TypeScript and JavaScript uses ESM (`"type": "module"`)
 - **Dependencies**: Minimize. Justify every new dependency.
-- **Dependency versions**: Always use the latest stable version. No legacy compatibility — legacy systems must fail. When a dependency ships a breaking change, update all consuming code to work with the new version. Never pin to old versions to avoid migration work. **Legacy compatibility is an anti-pattern** — do not use compatibility shims, polyfills, or `__future__` imports that exist only to support older versions.
+- **Dependency versions**: Always use the latest stable version. No legacy compatibility — legacy systems must fail. When a dependency ships a breaking change, update all consuming code to work with the new version. Never pin to old versions to avoid migration work. **Legacy compatibility is an anti-pattern.**
 - **No secrets**: See [Security](#security) section below.
 - **Error handling**: Graceful degradation. Never crash on malformed input — log warnings and continue.
 - **Privacy**: All portfolio/personal data stays local. No PII sent to external APIs unless explicitly configured.
@@ -109,6 +133,7 @@ These rules exist because this is financial software. Violations produce incorre
 3. **Data source attribution**: Every data point must trace to its source (API, filing, calculation).
 4. **Timestamp everything**: All market data, signals, and analysis must carry timestamps.
 5. **No stale data assumptions**: Always check data freshness before analysis.
+6. **Tax-lot integrity**: When multiple lots exist per position, never merge or average cost basis. Each lot retains its purchase date and per-share cost.
 
 ## Security
 
@@ -117,57 +142,35 @@ Security is not optional. This is financial software handling sensitive portfoli
 ### No Portable Credentials
 
 - **No passwords, secrets, API keys, tokens, or credentials anywhere in the codebase** — not in source files, config files, environment files, comments, tests, documentation, or commit messages.
-- **No `.env` files committed to the repository.** Use `.env.example` with placeholder keys only (e.g., `FRED_API_KEY=your-key-here`). Actual `.env` files must be in `.gitignore`.
-- **No GitHub Secrets for PATs or service credentials.** Use only the built-in `GITHUB_TOKEN` and native GitHub features (e.g., OIDC federation for cloud access).
-- **No plaintext credential storage** — not in config files, databases, local files, or environment variable dumps.
+- **No `.env` files committed to the repository.** Use `.env.example` with placeholder keys only. Actual `.env` files must be in `.gitignore`.
+- **No GitHub Secrets for PATs or service credentials.** Use only the built-in `GITHUB_TOKEN` and native GitHub features.
+- **No plaintext credential storage.**
 
 ### Authentication Standards
 
 - **Prefer credential-free authentication**: OIDC federation, managed identities, workload identity, certificate-based auth.
-- **When credentials are unavoidable** (e.g., third-party API keys like FRED): load from environment variables at runtime via `pydantic-settings` (`AppConfig`). Never hardcode, never log, never serialize.
-- **Reject systems that only support username/password auth** unless they also offer SSO, OIDC, or certificate-based alternatives. Portable credentials are a liability.
+- **When credentials are unavoidable** (e.g., FRED, BLS API keys): load from environment variables at runtime via `pydantic-settings` (`AppConfig`). Never hardcode, never log, never serialize.
 
 ### Defense in Depth
 
 - **All portfolio and personal data stays local.** No PII sent to external APIs unless the user explicitly configures it.
 - **Validate all external input** — API responses, file contents, user input. Never trust external data.
-- **Log security-relevant events** (auth failures, config errors) but **never log credentials or sensitive data**.
-- **Fail closed**: if a security check cannot be performed (missing credentials, unreachable auth provider), deny access rather than falling back to insecure defaults.
+- **Log security-relevant events** but **never log credentials or sensitive data**.
+- **Fail closed**: if a security check cannot be performed, deny access.
 
 ## Testing
 
 ### Running Tests
 
 - **MCP Server (unit)**: `cd mcp-server && npm test`
-- **MCP Server (integration)**: `cd mcp-server && npm run test:integration`
 - **Agents (unit)**: `cd agents && source .venv/bin/activate && pytest -m "not integration"`
 - **Agents (integration)**: `cd agents && source .venv/bin/activate && pytest -m integration`
-- **Full suite (unit)**: `npm test` (from root, runs workspace tests)
-- **Python type checking**: `cd agents && source .venv/bin/activate && mypy src/`
-- **Linting**: `npm run lint` (root), `cd agents && source .venv/bin/activate && ruff check src/ tests/`
-
-> **Note**: Python requires a virtual environment. Set up once: `cd agents && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"`
-
-### Unit vs Integration Tests
-
-Tests are split into **unit** (fast, no external deps) and **integration** (calls external APIs):
-
-| | Python | TypeScript |
-|---|---|---|
-| Unit files | `tests/*.py` | `tests/*.test.ts` |
-| Integration files | `tests/*.py` with `@pytest.mark.integration` | `tests/*.integration.test.ts` |
-| Run unit | `pytest -m "not integration"` | `npm test` |
-| Run integration | `pytest -m integration` | `npm run test:integration` |
-
-**Rules:**
-- Mark any test that calls an external service (FRED, EDGAR, etc.) with `@pytest.mark.integration` (Python) or place it in a `*.integration.test.ts` file (TypeScript).
-- Integration tests must **skip gracefully** when credentials are missing (use the `fred_api_key` fixture or similar).
-- CI runs unit tests on every PR. Integration tests run only on pushes to `main`.
-- `npm run preflight` runs unit tests only.
+- **Full suite (unit)**: `npm test` (from root)
+- **Linting**: `npm run lint` (root), `cd agents && ruff check src/ tests/`
 
 ### Pre-Push Preflight
 
-**Always run `npm run preflight` from the repo root before pushing.** This mirrors CI: build → unit test → lint (TypeScript), then ruff → unit pytest (Python). A push that fails CI is a wasted round-trip. Fix locally first.
+**Always run `npm run preflight` from the repo root before pushing.**
 
 ```bash
 npm run preflight   # must pass before every push
@@ -179,49 +182,28 @@ Every code change **must** include tests. No exceptions.
 
 #### Positive Tests
 - Cover the happy path for each unit of new or changed functionality
-- Use concrete, representative test fixtures (not randomly generated data)
+- Use concrete, representative test fixtures
 
 #### Negative Tests
 - Every boundary condition and error path must have a negative test
-- **Never assert on error codes or error message strings** — they couple tests to internals
+- **Never assert on error codes or error message strings**
 - **Assert on observable behavior**: return values, thrown vs not thrown, state changes, output shape
 
-```python
-# ❌ BAD
-assert err.code == "ERR_PARSE_DATE"
-
-# ✅ GOOD
-assert len(result.transactions) == 0
-# parser should not raise on malformed input
-result = parse(malformed)
-assert result is not None
-```
-
-```typescript
-// ❌ BAD
-expect(err.code).toBe('ERR_INVALID_TICKER');
-
-// ✅ GOOD
-expect(result.quotes).toHaveLength(0);
-expect(() => fetchQuote(invalidTicker)).not.toThrow();
-```
+#### Financial Logic Tests
+- All monetary calculations must be tested with `Decimal` precision
+- Tax-lot selection logic must have edge-case coverage (wash sales, zero-basis lots, same-day trades)
+- Rebalancing math must verify current→target drift calculations
+- Scenario stress tests must verify arithmetic against known expected losses
 
 #### Test Anti-Patterns
 
 | Anti-pattern | Why it's bad |
 |---|---|
 | Tautology (`assert True`) | Tests nothing |
-| Language validation (constructor/property tests) | Tests that the language works, not that your code works. `expect(new Foo(1).x).toBe(1)` is a tautology — the language guarantees this. |
+| Language validation (constructor/property tests) | Tests that the language works, not your code |
 | Mirror (reimplements production logic) | Breaks when logic changes |
 | Duplicate (same behavior twice) | Noise; keep the more expressive one |
-| Subsumed (A ⊂ B) | A is already covered by B. Keep B, remove A |
 | Error-code/message matching | Couples to internals |
-
-**Every test must validate behavior the code implements, not behavior the language guarantees.** If a test would pass with an empty implementation, it's not testing anything. If the same behavior is already asserted in another test, don't assert it again.
-
-#### Test Pruning
-
-After completing a feature: remove tautologies, mirrors, duplicates, subsumed tests. Verify negative coverage. Verify no error-code or message-string assertions remain.
 
 ## Communication Style
 
@@ -236,18 +218,16 @@ Multiple Copilot CLI sessions may work simultaneously. Always use git worktrees.
 
 All branches other than `main` **must** follow: `<username>/<MeaningfulDescription>`
 
-Examples: `tolginator/AddEdgarPipeline`, `copilot/RefactorAgentFramework`
-
 ### Making Changes
 
-0. **Never commit to main.** Main is only for PRs and production builds.
+0. **Never commit to main.**
 1. `git worktree add <path> -b <username>/<task> origin/main`
 2. Work exclusively in the worktree.
 3. Make **separate, descriptive commits** for each logical change within a PR.
-4. Do **not** amend or force-push — keep the commit history intact for review.
-5. Run `npm run preflight` — fix any failures before pushing.
+4. Do **not** amend or force-push.
+5. Run `npm run preflight` before pushing.
 6. Commit, push, create PR targeting `main`.
-7. **Squash merge** when merging PRs into main (`gh pr merge --squash`).
+7. **Squash merge** when merging PRs into main.
 
 ### After PR Merge
 
@@ -260,74 +240,16 @@ Examples: `tolginator/AddEdgarPipeline`, `copilot/RefactorAgentFramework`
 
 ### Issue-First Workflow
 
-**Every PR must have a corresponding issue created before the PR.** No exceptions. Issues are the unit of work; PRs are the delivery mechanism.
+**Every PR must have a corresponding issue created before the PR.** No exceptions.
 
 1. Before starting work, create an issue describing what will be built.
-2. For multi-step features, use **parent issue + sub-issues**:
-   - Create parent issue with goals, architecture, progress checklist.
-   - Create sub-issues referencing the parent (e.g., "Part of #1").
-   - Update parent checklist to link sub-issues.
-   - Close sub-issues as merged; close parent when all complete.
-3. Every PR body must reference its issue(s) via closing keywords (`Closes #N`) or references (`Part of #N`).
+2. For multi-step features, use **parent issue + sub-issues**.
+3. Every PR body must reference its issue(s) via closing keywords (`Closes #N`).
 
 ### Pull Requests
 
 - Use `gh pr create --title "..." --body "Closes #N"`.
-- **Assign every PR to the "finance-os" GitHub Project** (if one exists). If token lacks `read:project` scope, inform the user to assign manually.
-
-## Repository Structure
-
-```
-finance-os/
-├── package.json                    # Root workspace config
-├── .github/
-│   ├── copilot-instructions.md     # This file
-│   ├── skills/                     # Copilot Skills (SKILL.md workflows)
-│   │   ├── earnings-analysis/      # Earnings transcript analysis
-│   │   ├── thesis-evaluation/      # Thesis challenge + conviction scoring
-│   │   ├── research-digest/        # Watchlist digest + pipeline
-│   │   ├── risk-assessment/        # Portfolio risk + stress tests
-│   │   └── macro-overview/         # Macro regime classification
-│   ├── workflows/                  # CI/CD
-│   ├── ISSUE_TEMPLATE/             # Issue templates
-│   ├── acl/                        # CODEOWNERS, access
-│   ├── policies/                   # JIT access policies
-│   └── prompts/                    # Default Copilot prompt
-├── mcp-server/                     # TypeScript MCP server
-│   ├── package.json
-│   ├── tsconfig.json
-│   ├── src/
-│   │   ├── index.ts                # MCP server entry
-│   │   ├── tools/                  # MCP tool implementations
-│   │   ├── resources/              # MCP resource providers
-│   │   └── prompts/                # MCP prompt templates
-│   └── tests/
-├── agents/                         # Python agent framework
-│   ├── pyproject.toml
-│   ├── src/
-│   │   ├── core/                   # Agent base, orchestrator, memory
-│   │   ├── agents/                 # Domain-specific agents
-│   │   ├── application/            # Shared contracts, LLM gateway, services, registry
-│   │   ├── cli/                    # CLI entry points (finance-os command)
-│   │   ├── mcp_server.py           # Python MCP server (finance-os-mcp command)
-│   │   ├── web_api.py              # FastAPI web server (finance-os-api command)
-│   │   ├── tools/                  # Quant tools
-│   │   └── pipelines/             # Data ingestion pipelines
-│   └── tests/
-├── web-ui/                         # React frontend (Vite + TypeScript)
-│   ├── src/
-│   │   ├── App.tsx                  # Root component
-│   │   ├── api.ts                   # API client for Web API
-│   │   └── components/              # UI components
-│   └── tests/
-├── prompts/                        # Shared prompt library
-│   ├── roles/                      # Role-stacking personas
-│   ├── analysis/                   # Analytical templates
-│   ├── adversarial/                # Thesis-challenging
-│   └── synthesis/                  # Multi-document synthesis
-├── data/                           # Local data store (gitignored)
-└── docs/                           # Documentation
-```
+- **Assign every PR to the "finance-os" GitHub Project** (if one exists).
 
 ## @azure Rule
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # finance-os
 
-Personal Investment Intelligence OS — a modular, LLM-powered investing AI stack with agent orchestration, domain-tuned prompting, custom MCP tools, and deep integration with quant + NLP pipelines.
+Macro ETF Portfolio Intelligence — a modular, LLM-powered system for macroeconomic outlook-driven investment evaluation and goal-driven portfolio rebalancing.
 
-Not a chatbot. A **system**. The personal Bloomberg terminal + quant lab + research team.
+Built for a **wealthy family** ($2M–$10M investable assets): capital preservation with moderate growth, tax-efficient ETF portfolios, retirement readiness, and multi-generational wealth building. US-focused with global economy considerations.
+
+Not a stock picker. Not a chatbot. A **portfolio intelligence system**.
 
 ## Goals
 
-- **Automated research**: Ingest SEC filings, earnings transcripts, and macro data — extract signals, score sentiment, flag material changes
-- **Thesis monitoring**: Define investment theses with explicit assumptions — get alerts when assumptions weaken or break
-- **Risk analysis**: Scenario modeling, stress tests, tail-risk simulation, concentration analysis
-- **Adversarial challenge**: Every thesis gets systematically attacked before capital is deployed
-- **Quantitative signals**: Transform unstructured text into structured, timestamped, confidence-weighted quant features
-- **Multi-agent orchestration**: Agents collaborate and debate to produce consolidated research memos
-- **LLM-native**: Pluggable LLM gateway for direct inference (CLI, web) or delegate to host LLM (Copilot, Claude Desktop via MCP)
+- **Macro outlook**: Multi-dimensional regime classification (growth, rates, inflation, global trade) from FRED, BLS, Treasury, IMF, and World Bank data
+- **Portfolio evaluation**: Dimensioned health metrics — policy drift, concentration risk, macro alignment, liquidity adequacy, tax drag, scenario exposure
+- **Goal-driven rebalancing**: Retirement (3–4% SWR, capital preservation) and wealth building (growth tilt, accumulation) with custom goal support
+- **Scenario stress testing**: Historical scenarios (2008, 2022, stagflation, etc.) applied to your portfolio with loss estimates
+- **ETF taxonomy**: Look-through exposure analysis — asset class, sector, geography, duration breakdown
+- **Policy-first**: Macro tilts are bounded by your Investment Policy Statement — the system never overrides strategic allocation
+- **Credible data only**: Government and institutional sources. No social network data.
 
 ## Project Structure
 
@@ -21,22 +23,26 @@ finance-os/
 ├── mcp-server/          # TypeScript MCP server (data tools for LLMs)
 ├── agents/              # Python agent framework + application layer
 │   └── src/
-│       ├── agents/      # Domain agents (filing, earnings, macro, risk, etc.)
+│       ├── agents/      # Domain agents (macro, risk, outlook, evaluator, rebalancer)
 │       ├── core/        # BaseAgent, orchestrator, vector memory
 │       ├── application/ # Contracts, LLM gateway, services, config, registry
+│       │   └── services/
+│       │       ├── household_service.py   # Portfolio CRUD, import (CSV/QIF)
+│       │       ├── etf_taxonomy.py        # ETF → asset class mapping
+│       │       ├── ticker_service.py      # ETF summary lookup (Yahoo Finance)
+│       │       └── ...
 │       ├── cli/         # CLI entry points (finance-os command)
 │       ├── mcp_server.py # Python MCP server (finance-os-mcp command)
 │       ├── web_api.py   # FastAPI web server (finance-os-api command)
-│       └── pipelines/   # Research digest pipeline
+│       └── pipelines/   # Data ingestion pipelines
 ├── web-ui/              # React frontend (Vite + TypeScript)
 ├── prompts/             # Shared prompt library
 ├── docs/                # Architecture, agent, and tool documentation
 └── .github/             # CI, copilot instructions, skills, templates
 ```
 
-See [docs/architecture.md](docs/architecture.md) for the full system architecture, LLM gateway design, and data flow.
+See [docs/architecture.md](docs/architecture.md) for the full system architecture.
 See [docs/agents.md](docs/agents.md) for agent descriptions and the orchestration model.
-See [docs/tools.md](docs/tools.md) for MCP tool reference and how to add new tools.
 
 ## Getting Started
 
@@ -72,8 +78,8 @@ Create `~/.config/finance-os/config.json`:
 ```json
 {
   "fred_api_key": "your-fred-api-key",
+  "bls_api_key": "your-bls-api-key",
   "llm_provider": "skip",
-  "sec_edgar_email": "your-email@example.com",
   "azure": {
     "endpoint": "",
     "deployment": "",
@@ -86,15 +92,28 @@ Environment variables (`FINANCE_OS_*`) override config file values — use doubl
 
 | Field | Values | Description |
 |-------|--------|-------------|
-| `llm_provider` | `"skip"` (default), `"azure_openai"` | `skip` returns raw agent data without LLM synthesis — ideal for the MCP path where Copilot/Claude reasons over the output. `azure_openai` enables LLM synthesis via Azure OpenAI with Entra ID (OAuth2/OIDC) authentication — no API keys required. |
-| `azure.endpoint` | URL string | Azure OpenAI resource endpoint (e.g. `https://my-instance.openai.azure.com`). Required when provider is `"azure_openai"`. |
-| `azure.deployment` | Deployment name | Azure OpenAI model deployment name (e.g. `gpt-4.1-mini`). This is the deployment you created in Azure AI Studio. Required when provider is `"azure_openai"`. |
+| `llm_provider` | `"skip"` (default), `"azure_openai"` | `skip` returns raw agent data without LLM synthesis — ideal for the MCP path where Copilot/Claude reasons over the output. `azure_openai` enables LLM synthesis via Azure OpenAI. |
+| `azure.endpoint` | URL string | Azure OpenAI resource endpoint. Required when provider is `"azure_openai"`. |
+| `azure.deployment` | Deployment name | Azure OpenAI model deployment name. Required when provider is `"azure_openai"`. |
 | `azure.api_version` | API version string | Azure OpenAI API version. Default `"2024-10-21"`. |
 | `llm_temperature` | `0.0`–`2.0` | Sampling temperature for LLM calls. Default `0.0` (deterministic). |
-| `fred_api_key` | API key string | [FRED API](https://fred.stlouisfed.org/docs/api/api_key.html) key for the macro-regime agent. Free to obtain. |
-| `sec_edgar_email` | Email address | **Required for SEC API access.** SEC requires a valid contact email in request headers — set this to a real email you control. |
+| `fred_api_key` | API key string | [FRED API](https://fred.stlouisfed.org/docs/api/api_key.html) key for macro data. Free to obtain. |
+| `bls_api_key` | API key string | [BLS API](https://www.bls.gov/developers/) key for employment and CPI data. Free to obtain. |
 
-> **Azure authentication**: Uses `DefaultAzureCredential` which supports Azure CLI (`az login`), managed identity, workload identity, and environment credentials. No API keys are stored in config. Requires the `Cognitive Services OpenAI User` RBAC role on the Azure OpenAI resource. See the [Azure Deployment Guide](docs/azure-deployment.md) for step-by-step setup.
+> **Azure authentication**: Uses `DefaultAzureCredential` which supports Azure CLI (`az login`), managed identity, workload identity, and environment credentials. No API keys are stored in config.
+
+### Data Sources
+
+All data comes from credible government and institutional sources. **No social network data.**
+
+| Source | Data | Auth | Cost |
+|--------|------|------|------|
+| [FRED](https://fred.stlouisfed.org/) | GDP, employment, inflation, rates, spreads, sentiment, production | API key | Free |
+| [Yahoo Finance](https://finance.yahoo.com/) | ETF prices, holdings (best-effort), expense ratios, categories | None | Free |
+| [BLS](https://www.bls.gov/developers/) | Detailed CPI components, employment by sector, productivity | API key | Free |
+| [Treasury.gov](https://home.treasury.gov/data) | Yield curves, real yields, fiscal data, auction results | None | Free |
+| [IMF Data](https://data.imf.org/) | Global GDP forecasts, trade balances, exchange rates | None | Free |
+| [World Bank](https://data.worldbank.org/) | Development indicators, global growth trends | None | Free |
 
 ### Agent CLI
 
@@ -103,15 +122,12 @@ After installing the agents package (`pip install -e ".[dev]"`), the `finance-os
 ```bash
 finance-os list                                      # List available agents
 finance-os config                                    # Show current config
-finance-os run macro-regime                          # Run a single agent
-finance-os run filing-analyst --ticker AAPL           # With options
-finance-os pipeline --ticker AAPL                     # Multi-agent research pipeline
-finance-os digest --tickers AAPL,MSFT,GOOG            # Research digest
-finance-os --output json run macro-regime             # JSON output
-finance-os run adversarial --prompt "Bull case" --synthesize  # LLM synthesis
+finance-os run macro-regime                          # Classify macro regime
+finance-os run risk-analyst                          # Portfolio risk analysis
+finance-os run quant-signal                          # Generate macro signals
+finance-os pipeline --ticker VTI                     # Multi-agent research pipeline
+finance-os --output json run macro-regime            # JSON output
 ```
-
-Use `--synthesize` to pass agent output through the LLM gateway (requires a configured LLM provider). Use `--output json` for structured output.
 
 ### Python MCP Server
 
@@ -121,8 +137,6 @@ The Python MCP server exposes agents as tools for any MCP-compatible client (Cop
 finance-os-mcp              # via console script (stdio transport)
 python -m src.mcp_server    # direct invocation
 ```
-
-Tools available: `analyze_earnings`, `classify_macro`, `research_digest`, `orchestrate`. The `analyze_earnings` tool accepts a ticker symbol and auto-fetches the latest transcript from Yahoo Finance. See [docs/tools.md](docs/tools.md) for details.
 
 ### Web API
 
@@ -142,28 +156,19 @@ uvicorn src.web_api:app --reload            # development with auto-reload
 
 Once running, open http://127.0.0.1:8000/docs for interactive Swagger UI.
 
-**Endpoints:**
+**Current Endpoints:**
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/health` | Health check |
 | GET | `/agents` | List available agents |
-| GET | `/ticker/{symbol}/summary` | Fetch company summary from Yahoo Finance (cached 5 min) |
+| GET | `/ticker/{symbol}/summary` | Fetch ETF/company summary from Yahoo Finance (cached 5 min) |
 | GET | `/ticker/{symbol}/transcript` | Fetch latest earnings transcript (cached 1 hour) |
-| POST | `/agents/earnings_interpreter` | Analyze earnings transcripts (accepts ticker or transcript) |
-| POST | `/agents/macro_regime` | Classify macro regime |
-| POST | `/agents/filing_analyst` | Search SEC filings |
+| POST | `/agents/macro_regime` | Classify macro regime from FRED data |
 | POST | `/agents/quant_signal` | Generate quant signals |
-| POST | `/agents/thesis_guardian` | Evaluate investment theses |
 | POST | `/agents/risk_analyst` | Portfolio risk analysis |
-| POST | `/agents/adversarial` | Challenge thesis adversarially |
 | POST | `/pipeline` | Multi-agent research pipeline |
 | POST | `/digest` | Research digest for watchlist |
-| POST | `/kg/extract` | Extract entities/relationships into knowledge graph |
-| POST | `/kg/query/related` | Find entities related to a given entity |
-| POST | `/kg/query/supply-chain` | Trace supply chain from an entity |
-| POST | `/kg/query/shared-risks` | Find shared risks across entities |
-| GET | `/kg/stats` | Knowledge graph summary statistics |
 | GET | `/watchlists` | List all watchlists |
 | POST | `/watchlists` | Create a new watchlist |
 | GET | `/watchlists/{name}` | Get a specific watchlist |
@@ -171,25 +176,15 @@ Once running, open http://127.0.0.1:8000/docs for interactive Swagger UI.
 | DELETE | `/watchlists/{name}` | Delete a watchlist |
 | PUT | `/watchlists/{name}/activate` | Set a watchlist as active |
 
-**Example:**
+**Planned Endpoints (coming in Phases 1–4):**
 
-```bash
-# Health check
-curl http://127.0.0.1:8000/health
-
-# Look up a ticker
-curl http://127.0.0.1:8000/ticker/AAPL/summary
-
-# Run a research digest
-curl -X POST http://127.0.0.1:8000/digest \
-  -H "Content-Type: application/json" \
-  -d '{"tickers": ["AAPL", "MSFT"], "lookback_days": 7}'
-
-# Search SEC filings
-curl -X POST http://127.0.0.1:8000/agents/filing_analyst \
-  -H "Content-Type: application/json" \
-  -d '{"ticker": "AAPL", "form_type": "10-K"}'
-```
+| Method | Path | Description |
+|--------|------|-------------|
+| GET/POST | `/portfolio/*` | Household portfolio CRUD, import |
+| POST | `/agents/macro_outlook` | Forward-looking macro outlook with asset-class tilts |
+| POST | `/agents/portfolio_evaluator` | Dimensioned portfolio evaluation |
+| POST | `/agents/rebalance` | Goal-driven rebalancing recommendations |
+| GET | `/scenarios` | Scenario library for stress testing |
 
 ### Web UI
 
@@ -211,30 +206,6 @@ The dev server proxies `/api/*` requests to the backend at `http://127.0.0.1:800
 cd web-ui && npm run build    # outputs to web-ui/dist/
 ```
 
-**UI Features:**
-
-| Feature | Description |
-|---------|-------------|
-| **Ticker Bar** | Enter a ticker symbol to auto-discover company data from Yahoo Finance — name, sector, price, market cap, 52W range, earnings date, and latest transcript |
-| **Agent Runner** | Run any agent with a dynamic form. Fields auto-populate from ticker context (e.g. entering AAPL fills transcript and ticker fields automatically). Dirty-field tracking preserves manual edits. |
-| **Pipeline Runner** | Define and execute multi-agent pipelines with dependency ordering. Visualizes per-task results and overall duration. Detects dependency cycles before execution. |
-| **Knowledge Graph** | Extract entities and relationships from text, then query the graph — related entities, supply chain tracing, shared risk analysis. Displays entity/relationship counts by type. |
-| **Watchlists** | Create, switch, and manage named ticker watchlists. Active watchlist auto-loads into the digest panel. |
-| **Research Digest** | Run a multi-agent digest for your watchlist tickers. Configure lookback period. View materiality alerts and signal counts. |
-| **System Health** | Live API connectivity indicator, agent catalog, and knowledge graph statistics. |
-
-### Copilot Skills
-
-Copilot Skills (`.github/skills/`) teach Copilot how to use finance-os tools together for investment analysis workflows. They are auto-detected by Copilot in IDE and CLI.
-
-| Skill | Trigger | What it does |
-|-------|---------|-------------|
-| `earnings-analysis` | "analyze earnings for AAPL" | Run earnings interpreter, score sentiment, extract guidance |
-| `thesis-evaluation` | "challenge my bull thesis on MSFT" | Adversarial challenge + blind spots + conviction scoring |
-| `research-digest` | "daily briefing for my watchlist" | Auto-fetch filings, classify macro, generate alerts |
-| `risk-assessment` | "stress test my portfolio" | VaR, concentration, scenario analysis |
-| `macro-overview` | "what's the macro regime?" | FRED-based regime classification + implications |
-
 ### Preflight (run before every push)
 
 From the repo root:
@@ -245,6 +216,25 @@ npm run preflight
 
 This mirrors CI: build → unit test → lint (TypeScript), then ruff → unit pytest (Python). Integration tests run in CI only on pushes to `main`.
 
+## Asset Class Taxonomy
+
+The system uses a two-layer taxonomy for ETF classification:
+
+**Canonical** (for allocation decisions): US Equity, International Developed, Emerging Markets, US Treasuries, IG Corporate Bonds, High Yield, TIPS/Inflation-Linked, Real Assets (REITs/Commodities), Cash/Money Market
+
+**Diagnostic** (for deeper analysis): Large/Small cap, Value/Growth, Sector, Duration buckets, Credit quality, Currency exposure
+
+## Wealthy Family Persona
+
+The system is calibrated for a wealthy family, not an average household:
+
+- **$2M–$10M investable assets** — beyond basic financial planning, below institutional complexity
+- **Can retire anytime** — capital preservation priority, not accumulation-only
+- **3–4% safe withdrawal rate** — sustainable, inflation-adjusted spending
+- **Tax-efficiency matters** — account type awareness (taxable, IRA, Roth, 401k, HSA, Trust)
+- **Multi-generational** — wealth transfer considerations, not just single-lifetime planning
+- **Not lavish** — comfortable lifestyle maintenance, not luxury optimization
+
 ## Development
 
 ### Git Workflow
@@ -254,18 +244,6 @@ This mirrors CI: build → unit test → lint (TypeScript), then ruff → unit p
 - Branch naming: `<username>/<MeaningfulDescription>`
 - Every PR must have a corresponding issue created first
 - Run `npm run preflight` before pushing
-
-### Adding a New MCP Tool
-
-1. Create `mcp-server/src/tools/<name>.ts` exporting `registerXxxTool(server)`
-2. Register in `src/index.ts`
-3. Add tests in `mcp-server/tests/<name>.test.ts`
-
-### Adding a New Agent
-
-1. Create `agents/src/agents/<name>.py` extending `BaseAgent`
-2. Implement `run()` and `system_prompt` property
-3. Add tests in `agents/tests/test_<name>.py`
 
 ## License
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -13,22 +13,39 @@ Agents currently perform deterministic data processing (regex, heuristics, stati
 
 ## Agent Catalog
 
+### Active Agents
+
 | Agent | Module | Purpose |
 |---|---|---|
-| Filing Analyst | `filing_analyst.py` | Extracts deltas, risk language shifts, capex changes from SEC filings |
-| Earnings Interpreter | `earnings_interpreter.py` | Tone analysis, sentiment drift, management confidence scoring from transcripts |
-| Macro Regime | `macro_regime.py` | Classifies macro environment (expansion/contraction/transition) from FRED data |
-| Quant Signal | `quant_signal.py` | Transforms textual insights into structured, confidence-weighted quant features |
-| Thesis Guardian | `thesis_guardian.py` | Monitors investment theses, evaluates assumptions, flags broken conditions |
-| Risk Agent | `risk_agent.py` | VaR/CVaR, volatility, scenario stress tests, correlation analysis |
-| Adversarial | `adversarial.py` | Systematic thesis challenger — counter-arguments, blind spots, conviction scoring |
+| Macro Regime | `macro_regime.py` | Classifies macro environment (growth/rates/inflation/trade regimes) from FRED data |
+| Quant Signal | `quant_signal.py` | Transforms macro insights into structured, confidence-weighted quant features |
+| Risk Agent | `risk_agent.py` | VaR/CVaR, volatility, scenario stress tests, correlation analysis, factor decomposition |
+
+### Planned Agents (in development)
+
+| Agent | Module | Purpose |
+|---|---|---|
+| Macro Outlook | `macro_outlook.py` | Synthesizes multi-source macro data into forward-looking asset-class tilts bounded by policy allocation |
+| Portfolio Evaluator | `portfolio_evaluator.py` | Dimensioned portfolio evaluation — policy drift, concentration, macro alignment, liquidity, tax drag, scenario exposure |
+| Rebalancing | `rebalancing.py` | Goal-driven rebalancing recommendations — directional (v1), account-aware (v2), tax-lot-aware (v3) |
+
+### Retiring Agents (being removed after new UI is ready)
+
+| Agent | Module | Reason |
+|---|---|---|
+| Filing Analyst | `filing_analyst.py` | Stock-picking focused — extracts SEC filing deltas, risk language shifts |
+| Earnings Interpreter | `earnings_interpreter.py` | Stock-picking focused — individual company transcript analysis |
+| Thesis Guardian | `thesis_guardian.py` | Stock-picking focused — per-ticker thesis monitoring |
+| Adversarial | `adversarial.py` | Stock-picking focused — individual company thesis challenger |
+
+These agents remain functional during the transition but will be removed from the registry, API endpoints, MCP tools, and UI once the portfolio-centric UI redesign (Phase 5A) is complete.
 
 ## Orchestration
 
 The `Orchestrator` (`agents/src/core/orchestrator.py`) coordinates agents:
 
 - **Agent registry** — register and discover agents by name
-- **Task identity** — tasks have explicit `task_id` (falls back to agent name), enabling the same agent to run multiple times in a pipeline
+- **Task identity** — tasks have explicit `task_id`, enabling the same agent to run multiple times in a pipeline
 - **Dependency-aware pipeline** — tasks declare dependencies by task ID; independent tasks run in parallel via `asyncio.gather`
 - **Priority ordering** — higher-priority tasks execute first within each dependency level
 - **Graceful failure** — failed tasks don't crash the pipeline; dependent tasks get error messages
@@ -41,19 +58,48 @@ The application layer (`agents/src/application/services/`) provides typed wrappe
 - **`AgentService`** — maps Pydantic request/response contracts to agent `run()` calls. Validates inputs, normalizes metadata, and caches agent instances.
 - **`PipelineService`** — wraps orchestrator with task definitions from typed contracts, optional memo generation.
 - **`DigestService`** — wraps research pipeline with typed I/O and formatted output.
+- **`HouseholdService`** (planned) — portfolio CRUD, CSV/QIF import, schema validation, change journaling.
+- **`ETFTaxonomyService`** (planned) — ETF → asset class mapping, look-through exposure aggregation.
+- **`TickerService`** — ETF/company summary and transcript lookup from Yahoo Finance with caching and dedup.
 
-## Vector Memory
+### New Agent Integration Pattern
 
-The `VectorMemory` class (`agents/src/core/memory.py`) provides RAG capabilities:
+Each new agent follows the existing pattern:
+1. Create agent class extending `BaseAgent` in `src/agents/`
+2. Add to `AGENT_CATALOG` in `src/application/registry.py`
+3. Create Pydantic request/response contracts in `src/application/contracts/`
+4. Add `AgentService` method wrapping the agent
+5. Add API endpoint in `src/web_api.py`
+6. Add MCP tool in `src/mcp_server.py`
+7. Add tests for all layers
 
-- ChromaDB-backed semantic search with metadata filtering (ticker, date, doc type)
-- Word-boundary-respecting text chunking with configurable overlap
-- Deterministic document IDs for deduplication
-- Optional dependency — graceful error if chromadb not installed
+## Data Sources
+
+### Active
+
+| Source | Used By | Data |
+|---|---|---|
+| FRED | Macro Regime, Macro Outlook (planned) | GDP, employment, inflation, rates, spreads, sentiment, production |
+| Yahoo Finance | Ticker Service, ETF Taxonomy (planned) | ETF prices, holdings, expense ratios, categories |
+
+### Planned
+
+| Source | Used By | Data |
+|---|---|---|
+| BLS | Macro Outlook | Detailed CPI components, employment by sector, productivity |
+| Treasury.gov | Macro Outlook | Yield curves, real yields, fiscal data |
+| IMF | Macro Outlook | Global GDP, trade balances, exchange rates |
+| World Bank | Macro Outlook | Development indicators, global growth |
+
+### Retired
+
+| Source | Reason |
+|---|---|
+| SEC EDGAR | Stock-picking focused — individual company filings not needed for macro ETF analysis |
 
 ## MCP Server (Python)
 
-The Python MCP server (`agents/src/mcp_server.py`) exposes agents as tools for any MCP-compatible client (Copilot CLI, Claude Desktop, Cursor, etc.) via stdio transport.
+The Python MCP server (`agents/src/mcp_server.py`) exposes agents as tools for any MCP-compatible client via stdio transport.
 
 ### Running
 
@@ -67,22 +113,23 @@ python -m src.mcp_server  # direct invocation
 
 | Tool | Wraps | Purpose |
 |---|---|---|
-| `analyze_earnings` | `AgentService.analyze_earnings()` | Earnings transcript analysis — tone, sentiment, guidance |
 | `classify_macro` | `AgentService.classify_macro()` | Macro regime classification from FRED data |
 | `research_digest` | `DigestService.run_digest()` | Watchlist digest — materiality scoring, alerts |
 | `orchestrate` | `PipelineService.run_pipeline()` | Multi-agent pipeline with dependency ordering |
 
+Planned tools: `macro_outlook`, `evaluate_portfolio`, `rebalance`
+
 ### Design
 
 - **Per-request services** — fresh agent instances per tool call to avoid state leakage
-- **Structured responses** — tools return dicts (not JSON strings); MCP protocol handles serialization
+- **Structured responses** — tools return dicts; MCP protocol handles serialization
 - **Server-side config** — secrets (FRED API key) come from `AppConfig`, not tool inputs
-- **Agent validation** — `orchestrate` rejects unknown agent names upfront (no silent skip)
+- **Agent validation** — `orchestrate` rejects unknown agent names upfront
 - **LLM gateway skipped** — host LLM reasons; agents return structured data
 
 ## Web API (FastAPI)
 
-The Web API (`agents/src/web_api.py`) exposes the same application layer services as the MCP server, but over HTTP/REST for web frontends and programmatic access.
+The Web API (`agents/src/web_api.py`) exposes the same application layer services over HTTP/REST.
 
 ### Running
 
@@ -92,36 +139,10 @@ finance-os-api            # via console script (127.0.0.1:8000)
 uvicorn src.web_api:app --reload  # development mode
 ```
 
-### Endpoint Catalog
-
-| Endpoint | Wraps | Purpose |
-|---|---|---|
-| `POST /agents/earnings_interpreter` | `AgentService.analyze_earnings()` | Earnings transcript analysis — tone, sentiment, guidance |
-| `POST /agents/macro_regime` | `AgentService.classify_macro()` | Macro regime classification from FRED data |
-| `POST /agents/filing_analyst` | `AgentService.search_filings()` | SEC filing search |
-| `POST /agents/quant_signal` | `AgentService.generate_signals()` | Quant signal generation |
-| `POST /agents/thesis_guardian` | `AgentService.evaluate_thesis()` | Thesis evaluation |
-| `POST /agents/risk_analyst` | `AgentService.assess_risk()` | Portfolio risk analysis |
-| `POST /agents/adversarial` | `AgentService.challenge_thesis()` | Adversarial thesis challenge |
-| `POST /pipeline` | `PipelineService.run_pipeline()` | Multi-agent pipeline with dependency ordering |
-| `POST /digest` | `DigestService.run_digest()` | Watchlist digest — materiality scoring, alerts |
-| `GET /agents` | `AGENT_CATALOG` | List available agents |
-| `GET /health` | — | Health check |
-
 ### Design
 
 - **Per-request services** — fresh agent instances per request to avoid state leakage
 - **Pydantic contracts** — same request/response models as MCP server; FastAPI auto-validates and generates OpenAPI schema
-- **Lazy config** — `AppConfig` via `@lru_cache`, injected into services on each request
 - **Error mapping** — domain `ValueError` → HTTP 400; Pydantic validation → 422
 - **CORS** — enabled for local frontend development
-- **LLM gateway available** — Web API path can invoke LLM gateway for synthesis (unlike MCP path)
-
-## Research Pipeline
-
-The `ResearchPipeline` (`agents/src/pipelines/research_digest.py`) automates analysis:
-
-- Ingest data sources (EDGAR filings, transcripts, market data)
-- Classify materiality based on sentiment thresholds
-- Generate alerts with severity levels (HIGH/MEDIUM/LOW)
-- Produce research digests with summaries and actionable items
+- **LLM gateway available** — Web API path can invoke LLM gateway for synthesis


### PR DESCRIPTION
Rewrites all project documentation to reflect the pivot from stock-picking to macro ETF portfolio intelligence.

## Changes

- **README.md**: Complete rewrite — macro outlook-driven evaluation, ETF-based portfolios, wealthy family persona, new data sources table, asset class taxonomy, current + planned endpoints
- **copilot-instructions.md**: Updated architecture, design decisions, financial accuracy rules, data source catalog, testing philosophy, security policy
- **docs/agents.md**: Active/planned/retiring agent catalog, new agent integration pattern, updated orchestration and service descriptions

## What changed conceptually

- Stock-picking focus → macro-level ETF portfolio intelligence
- SEC EDGAR → BLS, Treasury.gov, IMF, World Bank data sources
- Individual company analysis → household portfolio evaluation + goal-driven rebalancing
- Single health score → dimensioned evaluation (drift, concentration, liquidity, tax drag, scenario)

Closes #98