### PR TITLE
feat: Household Portfolio Model (Layer 0)

### DIFF
--- a/agents/src/application/contracts/household.py
+++ b/agents/src/application/contracts/household.py
@@ -1,0 +1,225 @@
+"""Pydantic contracts for the household portfolio model.
+
+The household model is the foundational data structure for the portfolio
+intelligence system.  It stores accounts, positions (as tax lots), cash
+holdings, and cash-flow assumptions for a wealthy-family household.
+
+All monetary values use ``decimal.Decimal`` — never ``float``.
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, field_validator
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+class AccountType(StrEnum):
+    """Supported brokerage / retirement account types."""
+
+    TAXABLE = "taxable"
+    TRADITIONAL_IRA = "traditional_ira"
+    ROTH_IRA = "roth_ira"
+    FOUR01K = "401k"
+    HSA = "hsa"
+    TRUST = "trust"
+
+
+class AssetClass(StrEnum):
+    """Canonical asset classes for allocation decisions."""
+
+    US_EQUITY = "us_equity"
+    INTL_DEVELOPED = "intl_developed"
+    EMERGING_MARKETS = "emerging_markets"
+    US_TREASURIES = "us_treasuries"
+    IG_CORPORATE = "ig_corporate"
+    HIGH_YIELD = "high_yield"
+    TIPS = "tips"
+    REAL_ASSETS = "real_assets"
+    CASH_MONEY_MARKET = "cash_money_market"
+
+
+class CashFlowType(StrEnum):
+    """Direction of a recurring cash flow."""
+
+    CONTRIBUTION = "contribution"
+    WITHDRAWAL = "withdrawal"
+    INCOME = "income"
+
+
+# ---------------------------------------------------------------------------
+# Core domain models
+# ---------------------------------------------------------------------------
+
+class TaxLot(BaseModel):
+    """A single tax lot within a position.
+
+    Each lot retains its own cost basis and purchase date — lots are never
+    merged or averaged.
+    """
+
+    ticker: str = Field(description="ETF ticker symbol (uppercase)")
+    shares: Decimal = Field(gt=0, description="Number of shares in this lot")
+    cost_basis_per_share: Decimal = Field(
+        ge=0, description="Per-share cost basis at purchase"
+    )
+    purchase_date: date = Field(description="Date the lot was acquired")
+
+    @field_validator("ticker", mode="before")
+    @classmethod
+    def _uppercase_ticker(cls, v: str) -> str:
+        return v.strip().upper()
+
+
+class CashHolding(BaseModel):
+    """Cash or money-market position within an account.
+
+    Cash is a first-class asset class for allocation math.
+    """
+
+    amount: Decimal = Field(ge=0, description="Dollar amount")
+    valuation_date: date = Field(description="As-of date for this balance")
+    is_money_market: bool = Field(
+        default=False,
+        description="True if this is a money-market fund, not settled cash",
+    )
+    ticker: str | None = Field(
+        default=None,
+        description="Money-market fund ticker (if is_money_market)",
+    )
+    counts_toward_liquidity_reserve: bool = Field(
+        default=True,
+        description="Whether this balance counts toward the liquidity reserve",
+    )
+
+
+class Account(BaseModel):
+    """A single brokerage or retirement account."""
+
+    name: str = Field(min_length=1, description="Human-readable account label")
+    account_type: AccountType
+    tax_lots: list[TaxLot] = Field(default_factory=list)
+    cash_holdings: list[CashHolding] = Field(default_factory=list)
+
+
+class CashFlowAssumption(BaseModel):
+    """A recurring cash-flow assumption for simulation / planning."""
+
+    description: str = Field(min_length=1)
+    amount_annual: Decimal = Field(
+        gt=0, description="Annual dollar amount (always positive; direction from type)"
+    )
+    flow_type: CashFlowType
+    account_name: str | None = Field(
+        default=None,
+        description="Target account name (None = household-level)",
+    )
+    start_year: int | None = Field(default=None, ge=2000, le=2100)
+    end_year: int | None = Field(default=None, ge=2000, le=2100)
+    inflation_adjusted: bool = Field(
+        default=True,
+        description="Whether this amount grows with inflation in simulations",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Root household model
+# ---------------------------------------------------------------------------
+
+class Household(BaseModel):
+    """Root data model for a household's investment portfolio.
+
+    Persisted to ``~/.config/finance-os/household.json``.
+    ``schema_version`` tracks file-format migrations.
+    ``revision`` is an optimistic-concurrency token incremented on every save.
+    """
+
+    name: str = Field(min_length=1, description="Household label")
+    accounts: list[Account] = Field(default_factory=list)
+    cash_flow_assumptions: list[CashFlowAssumption] = Field(default_factory=list)
+    liquidity_reserve_floor: Decimal = Field(
+        default=Decimal("0"),
+        ge=0,
+        description="Minimum cash/short-term balance to maintain (Total NAV basis)",
+    )
+    schema_version: int = Field(
+        default=1,
+        description="File-format version for future migrations",
+    )
+    revision: int = Field(
+        default=0,
+        description="Optimistic-concurrency token — incremented on every save",
+    )
+    updated_at: datetime = Field(
+        default_factory=datetime.now,
+        description="Timestamp of last persisted change",
+    )
+
+
+# ---------------------------------------------------------------------------
+# API request / response contracts
+# ---------------------------------------------------------------------------
+
+class GetHouseholdResponse(BaseModel):
+    """Response for GET /household."""
+
+    household: Household
+    exists: bool = Field(
+        default=True,
+        description="False when no household.json exists yet (returns defaults)",
+    )
+
+
+class UpdateHouseholdRequest(BaseModel):
+    """Request for PUT /household.
+
+    Clients supply the business fields; server owns schema_version,
+    revision, and updated_at.  ``expected_revision`` is the concurrency
+    check — the server rejects the write if it doesn't match.
+    """
+
+    name: str = Field(min_length=1)
+    accounts: list[Account]
+    cash_flow_assumptions: list[CashFlowAssumption] = Field(default_factory=list)
+    liquidity_reserve_floor: Decimal = Field(default=Decimal("0"), ge=0)
+    expected_revision: int = Field(
+        description="Must match current revision on disk, or 409 Conflict"
+    )
+
+
+class UpdateHouseholdResponse(BaseModel):
+    """Response for PUT /household."""
+
+    household: Household
+    journal_entry: str = Field(description="Summary written to the change journal")
+
+
+class ImportPreviewRequest(BaseModel):
+    """Request for POST /household/import/csv/preview.
+
+    Parse-only: returns proposed accounts/lots + warnings without mutating
+    persisted data.
+    """
+
+    csv_content: str = Field(min_length=1, description="Raw CSV file content")
+
+
+class ImportWarning(BaseModel):
+    """A warning generated during import parsing."""
+
+    line: int | None = Field(default=None, description="CSV line number (if applicable)")
+    message: str
+
+
+class ImportPreviewResponse(BaseModel):
+    """Preview result from CSV import parsing."""
+
+    accounts: list[Account] = Field(description="Proposed accounts from parsed CSV")
+    warnings: list[ImportWarning] = Field(default_factory=list)
+    position_only: bool = Field(
+        default=False,
+        description="True if tax-lot fidelity could not be established",
+    )

--- a/agents/src/application/contracts/household.py
+++ b/agents/src/application/contracts/household.py
@@ -11,7 +11,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from enum import StrEnum
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -123,6 +123,17 @@ class CashFlowAssumption(BaseModel):
         default=True,
         description="Whether this amount grows with inflation in simulations",
     )
+
+    @model_validator(mode="after")
+    def _check_year_range(self) -> "CashFlowAssumption":
+        if (
+            self.start_year is not None
+            and self.end_year is not None
+            and self.end_year < self.start_year
+        ):
+            msg = f"end_year ({self.end_year}) must be >= start_year ({self.start_year})"
+            raise ValueError(msg)
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/agents/src/application/household_math.py
+++ b/agents/src/application/household_math.py
@@ -1,0 +1,107 @@
+"""Pure domain helpers for household portfolio math.
+
+Stateless functions — no I/O, no side effects.  Easy to test
+independently of persistence or API layers.
+
+All arithmetic uses ``decimal.Decimal``.
+"""
+
+from collections import defaultdict
+from decimal import Decimal
+
+from src.application.contracts.household import Account, Household, TaxLot
+
+
+def total_cash(account: Account) -> Decimal:
+    """Sum of all cash holdings in an account."""
+    return sum((h.amount for h in account.cash_holdings), Decimal("0"))
+
+
+def total_cash_household(household: Household) -> Decimal:
+    """Sum of all cash holdings across every account."""
+    return sum((total_cash(a) for a in household.accounts), Decimal("0"))
+
+
+def liquidity_reserve_cash(household: Household) -> Decimal:
+    """Sum of cash holdings that count toward the liquidity reserve."""
+    total = Decimal("0")
+    for account in household.accounts:
+        for ch in account.cash_holdings:
+            if ch.counts_toward_liquidity_reserve:
+                total += ch.amount
+    return total
+
+
+def aggregate_lots(lots: list[TaxLot]) -> dict[str, Decimal]:
+    """Aggregate tax lots into total shares per ticker.
+
+    Returns:
+        ``{ticker: total_shares}``
+    """
+    agg: dict[str, Decimal] = defaultdict(Decimal)
+    for lot in lots:
+        agg[lot.ticker] += lot.shares
+    return dict(agg)
+
+
+def total_cost_basis(lots: list[TaxLot]) -> Decimal:
+    """Total cost basis across all lots (shares × cost_basis_per_share)."""
+    return sum(
+        (lot.shares * lot.cost_basis_per_share for lot in lots),
+        Decimal("0"),
+    )
+
+
+def cost_basis_by_ticker(lots: list[TaxLot]) -> dict[str, Decimal]:
+    """Total cost basis per ticker."""
+    basis: dict[str, Decimal] = defaultdict(Decimal)
+    for lot in lots:
+        basis[lot.ticker] += lot.shares * lot.cost_basis_per_share
+    return dict(basis)
+
+
+def account_summary(account: Account) -> dict[str, Decimal]:
+    """Quick summary for an account: shares per ticker + total cash."""
+    result = aggregate_lots(account.tax_lots)
+    result["_cash"] = total_cash(account)
+    return result
+
+
+def household_summary(household: Household) -> dict[str, dict[str, Decimal]]:
+    """Per-account summary of positions and cash.
+
+    Returns:
+        ``{account_name: {ticker: shares, "_cash": cash_amount}}``
+    """
+    return {a.name: account_summary(a) for a in household.accounts}
+
+
+def lot_count(household: Household) -> int:
+    """Total number of tax lots across all accounts."""
+    return sum(len(a.tax_lots) for a in household.accounts)
+
+
+def cash_holding_count(household: Household) -> int:
+    """Total number of cash holding records across all accounts."""
+    return sum(len(a.cash_holdings) for a in household.accounts)
+
+
+def unique_tickers(household: Household) -> set[str]:
+    """Set of all unique tickers held across the household."""
+    tickers: set[str] = set()
+    for account in household.accounts:
+        for lot in account.tax_lots:
+            tickers.add(lot.ticker)
+    return tickers
+
+
+def has_complete_lots(household: Household) -> bool:
+    """True if all lots have non-zero cost basis and a meaningful date.
+
+    Used to gate tax-lot-dependent features (tax drag, TLH).
+    """
+    for account in household.accounts:
+        for lot in account.tax_lots:
+            if lot.cost_basis_per_share == Decimal("0"):
+                return False
+    return True

--- a/agents/src/application/household_math.py
+++ b/agents/src/application/household_math.py
@@ -96,7 +96,7 @@ def unique_tickers(household: Household) -> set[str]:
 
 
 def has_complete_lots(household: Household) -> bool:
-    """True if all lots have non-zero cost basis and a meaningful date.
+    """True if all lots have non-zero cost basis.
 
     Used to gate tax-lot-dependent features (tax drag, TLH).
     """

--- a/agents/src/application/services/household_service.py
+++ b/agents/src/application/services/household_service.py
@@ -1,0 +1,452 @@
+"""Household portfolio persistence — load, save, journal, import.
+
+Storage location: ~/.config/finance-os/household.json
+Journal location: ~/.config/finance-os/household-journal.jsonl
+
+Uses OS-level file locking (``fcntl.flock``) to protect against
+concurrent writes from Web API, MCP server, and CLI processes.
+"""
+
+import fcntl
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from src.application.config import CONFIG_DIR
+from src.application.contracts.household import (
+    Account,
+    Household,
+    ImportPreviewRequest,
+    ImportPreviewResponse,
+    ImportWarning,
+    UpdateHouseholdRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+HOUSEHOLD_FILE = CONFIG_DIR / "household.json"
+JOURNAL_FILE = CONFIG_DIR / "household-journal.jsonl"
+LOCK_FILE = CONFIG_DIR / "household.lock"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class HouseholdCorruptError(Exception):
+    """Raised when household.json exists but cannot be parsed.
+
+    The corrupt file is preserved (renamed with a timestamp suffix) so the
+    user can recover manually.
+    """
+
+
+class StaleRevisionError(Exception):
+    """Raised when a write's expected_revision doesn't match the current revision.
+
+    Callers should surface this as HTTP 409 Conflict.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+class HouseholdService:
+    """Manages household portfolio persistence with optimistic concurrency.
+
+    All reads and writes use an OS-level advisory lock (``fcntl.flock``)
+    so that Web API, MCP, and CLI processes serialise access to the same
+    file.  Inside each process the lock file descriptor is held only for
+    the duration of the critical section.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or HOUSEHOLD_FILE
+        self._journal_path = path.parent / "household-journal.jsonl" if path else JOURNAL_FILE
+        self._lock_path = path.parent / "household.lock" if path else LOCK_FILE
+
+    # -- public API --------------------------------------------------------
+
+    def load(self) -> tuple[Household, bool]:
+        """Load the household from disk.
+
+        Returns:
+            (household, exists) — ``exists`` is False when no file was
+            found and a default household is returned.
+        """
+        with self._flock():
+            return self._load_unlocked()
+
+    def save(self, request: UpdateHouseholdRequest) -> tuple[Household, str]:
+        """Persist an updated household, enforcing optimistic concurrency.
+
+        Args:
+            request: The update payload including ``expected_revision``.
+
+        Returns:
+            (saved_household, journal_summary)
+
+        Raises:
+            StaleRevisionError: ``expected_revision`` doesn't match current.
+        """
+        with self._flock():
+            current, _exists = self._load_unlocked()
+
+            if request.expected_revision != current.revision:
+                raise StaleRevisionError(
+                    f"Expected revision {request.expected_revision}, "
+                    f"but current is {current.revision}"
+                )
+
+            updated = Household(
+                name=request.name,
+                accounts=request.accounts,
+                cash_flow_assumptions=request.cash_flow_assumptions,
+                liquidity_reserve_floor=request.liquidity_reserve_floor,
+                schema_version=current.schema_version,
+                revision=current.revision + 1,
+                updated_at=datetime.now(),
+            )
+
+            self._write_atomic(updated)
+
+            summary = (
+                f"Updated household '{updated.name}' "
+                f"(rev {current.revision} → {updated.revision}, "
+                f"{len(updated.accounts)} accounts)"
+            )
+            self._append_journal(
+                action="update",
+                base_revision=current.revision,
+                new_revision=updated.revision,
+                summary=summary,
+            )
+
+            return updated, summary
+
+    def preview_csv_import(self, request: ImportPreviewRequest) -> ImportPreviewResponse:
+        """Parse CSV content and return proposed accounts without persisting.
+
+        CSV schema (one row per tax lot or cash holding):
+            account_name, account_type, record_type, ticker, shares,
+            cost_basis_per_share, purchase_date, amount, valuation_date,
+            is_money_market, counts_toward_liquidity_reserve
+
+        ``record_type`` is ``lot`` or ``cash``.
+        """
+        import csv
+        import io
+        from decimal import Decimal, InvalidOperation
+
+        from src.application.contracts.household import (
+            AccountType,
+            CashHolding,
+            TaxLot,
+        )
+
+        warnings: list[ImportWarning] = []
+        accounts_map: dict[str, Account] = {}
+        position_only = False
+
+        reader = csv.DictReader(io.StringIO(request.csv_content))
+
+        required_headers = {"account_name", "account_type", "record_type"}
+        if reader.fieldnames is None:
+            return ImportPreviewResponse(
+                accounts=[],
+                warnings=[ImportWarning(message="CSV has no headers")],
+                position_only=True,
+            )
+
+        missing = required_headers - set(reader.fieldnames)
+        if missing:
+            return ImportPreviewResponse(
+                accounts=[],
+                warnings=[
+                    ImportWarning(message=f"Missing required columns: {sorted(missing)}")
+                ],
+                position_only=True,
+            )
+
+        for line_num, row in enumerate(reader, start=2):
+            acct_name = row.get("account_name", "").strip()
+            acct_type_raw = row.get("account_type", "").strip().lower()
+            record_type = row.get("record_type", "").strip().lower()
+
+            if not acct_name:
+                warnings.append(ImportWarning(line=line_num, message="Empty account_name"))
+                continue
+
+            # Resolve account type
+            try:
+                acct_type = AccountType(acct_type_raw)
+            except ValueError:
+                warnings.append(
+                    ImportWarning(
+                        line=line_num,
+                        message=f"Unknown account_type '{acct_type_raw}'",
+                    )
+                )
+                continue
+
+            if acct_name not in accounts_map:
+                accounts_map[acct_name] = Account(
+                    name=acct_name, account_type=acct_type
+                )
+
+            account = accounts_map[acct_name]
+
+            if record_type == "lot":
+                ticker = row.get("ticker", "").strip().upper()
+                shares_raw = row.get("shares", "").strip()
+                basis_raw = row.get("cost_basis_per_share", "").strip()
+                date_raw = row.get("purchase_date", "").strip()
+
+                if not ticker or not shares_raw:
+                    warnings.append(
+                        ImportWarning(line=line_num, message="Lot missing ticker or shares")
+                    )
+                    continue
+
+                try:
+                    shares = Decimal(shares_raw)
+                except InvalidOperation:
+                    warnings.append(
+                        ImportWarning(line=line_num, message=f"Invalid shares '{shares_raw}'")
+                    )
+                    continue
+
+                # If cost basis or date missing → position-only
+                if not basis_raw or not date_raw:
+                    position_only = True
+                    warnings.append(
+                        ImportWarning(
+                            line=line_num,
+                            message=(
+                                f"Lot for {ticker} missing cost_basis or purchase_date "
+                                "— imported as position-only"
+                            ),
+                        )
+                    )
+                    basis = Decimal("0")
+                    pdate = datetime.now().date()
+                else:
+                    try:
+                        basis = Decimal(basis_raw)
+                    except InvalidOperation:
+                        warnings.append(
+                            ImportWarning(
+                                line=line_num,
+                                message=f"Invalid cost_basis '{basis_raw}'",
+                            )
+                        )
+                        continue
+                    try:
+                        from datetime import date as date_type
+
+                        pdate = date_type.fromisoformat(date_raw)
+                    except ValueError:
+                        warnings.append(
+                            ImportWarning(
+                                line=line_num,
+                                message=f"Invalid purchase_date '{date_raw}' (use YYYY-MM-DD)",
+                            )
+                        )
+                        continue
+
+                account.tax_lots.append(
+                    TaxLot(
+                        ticker=ticker,
+                        shares=shares,
+                        cost_basis_per_share=basis,
+                        purchase_date=pdate,
+                    )
+                )
+
+            elif record_type == "cash":
+                amount_raw = row.get("amount", "").strip()
+                val_date_raw = row.get("valuation_date", "").strip()
+                is_mm = row.get("is_money_market", "").strip().lower() in ("true", "1", "yes")
+                counts = row.get("counts_toward_liquidity_reserve", "true").strip().lower()
+                counts_liq = counts in ("true", "1", "yes", "")
+
+                if not amount_raw:
+                    warnings.append(
+                        ImportWarning(line=line_num, message="Cash row missing amount")
+                    )
+                    continue
+
+                try:
+                    amount = Decimal(amount_raw)
+                except InvalidOperation:
+                    warnings.append(
+                        ImportWarning(line=line_num, message=f"Invalid amount '{amount_raw}'")
+                    )
+                    continue
+
+                if val_date_raw:
+                    try:
+                        from datetime import date as date_type
+
+                        val_date = date_type.fromisoformat(val_date_raw)
+                    except ValueError:
+                        warnings.append(
+                            ImportWarning(
+                                line=line_num,
+                                message=f"Invalid valuation_date '{val_date_raw}'",
+                            )
+                        )
+                        continue
+                else:
+                    val_date = datetime.now().date()
+
+                mm_ticker = row.get("ticker", "").strip().upper() or None
+
+                account.cash_holdings.append(
+                    CashHolding(
+                        amount=amount,
+                        valuation_date=val_date,
+                        is_money_market=is_mm,
+                        ticker=mm_ticker if is_mm else None,
+                        counts_toward_liquidity_reserve=counts_liq,
+                    )
+                )
+            else:
+                warnings.append(
+                    ImportWarning(
+                        line=line_num,
+                        message=f"Unknown record_type '{record_type}' (expected 'lot' or 'cash')",
+                    )
+                )
+
+        return ImportPreviewResponse(
+            accounts=list(accounts_map.values()),
+            warnings=warnings,
+            position_only=position_only,
+        )
+
+    # -- internals ---------------------------------------------------------
+
+    def _flock(self) -> "_FileLockContext":
+        """Return a context manager that holds an OS-level advisory lock."""
+        return _FileLockContext(self._lock_path)
+
+    def _load_unlocked(self) -> tuple[Household, bool]:
+        """Load without acquiring the lock (caller must hold it)."""
+        if not self._path.is_file():
+            return self._default_household(), False
+
+        raw_text = self._path.read_text(encoding="utf-8")
+        try:
+            raw = json.loads(raw_text)
+        except json.JSONDecodeError as exc:
+            self._preserve_corrupt_file()
+            raise HouseholdCorruptError(
+                f"household.json is not valid JSON: {exc}"
+            ) from exc
+
+        try:
+            return Household.model_validate(raw), True
+        except ValidationError as exc:
+            self._preserve_corrupt_file()
+            raise HouseholdCorruptError(
+                f"household.json has invalid schema: {exc}"
+            ) from exc
+
+    def _write_atomic(self, household: Household) -> None:
+        """Atomically write household to disk (temp file + rename)."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        content = json.dumps(
+            household.model_dump(mode="json"),
+            indent=2,
+            ensure_ascii=False,
+            default=str,
+        )
+        temp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                dir=self._path.parent,
+                suffix=".tmp",
+                delete=False,
+                encoding="utf-8",
+            ) as fd:
+                temp_path = Path(fd.name)
+                fd.write(content)
+                fd.flush()
+                os.fsync(fd.fileno())
+            temp_path.replace(self._path)
+        except BaseException:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+            raise
+
+    def _preserve_corrupt_file(self) -> None:
+        """Rename a corrupt household.json so the user can recover it."""
+        if self._path.is_file():
+            ts = datetime.now().strftime("%Y%m%dT%H%M%S")
+            backup = self._path.with_suffix(f".corrupt.{ts}.json")
+            self._path.rename(backup)
+            logger.error(
+                "Corrupt household.json preserved as %s", backup,
+            )
+
+    def _append_journal(
+        self,
+        action: str,
+        base_revision: int,
+        new_revision: int,
+        summary: str,
+    ) -> None:
+        """Append a line to the change journal (best-effort)."""
+        entry = {
+            "timestamp": datetime.now().isoformat(),
+            "action": action,
+            "base_revision": base_revision,
+            "new_revision": new_revision,
+            "summary": summary,
+        }
+        try:
+            self._journal_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._journal_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(entry, default=str) + "\n")
+        except OSError:
+            logger.warning("Failed to write household journal entry", exc_info=True)
+
+    @staticmethod
+    def _default_household() -> Household:
+        return Household(name="My Household")
+
+
+# ---------------------------------------------------------------------------
+# OS-level file lock context manager
+# ---------------------------------------------------------------------------
+
+class _FileLockContext:
+    """Advisory file lock using ``fcntl.flock``.
+
+    Serialises access across processes (Web API, MCP, CLI) sharing the
+    same config directory.
+    """
+
+    def __init__(self, lock_path: Path) -> None:
+        self._lock_path = lock_path
+        self._fd: int | None = None
+
+    def __enter__(self) -> "_FileLockContext":
+        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._fd = os.open(str(self._lock_path), os.O_CREAT | os.O_RDWR)
+        fcntl.flock(self._fd, fcntl.LOCK_EX)
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        if self._fd is not None:
+            fcntl.flock(self._fd, fcntl.LOCK_UN)
+            os.close(self._fd)
+            self._fd = None

--- a/agents/src/application/services/household_service.py
+++ b/agents/src/application/services/household_service.py
@@ -199,6 +199,19 @@ class HouseholdService:
                 accounts_map[acct_name] = Account(
                     name=acct_name, account_type=acct_type
                 )
+            else:
+                existing = accounts_map[acct_name]
+                if existing.account_type != acct_type:
+                    warnings.append(
+                        ImportWarning(
+                            line=line_num,
+                            message=(
+                                f"Account '{acct_name}' has conflicting types: "
+                                f"'{existing.account_type}' vs '{acct_type}' — skipping row"
+                            ),
+                        )
+                    )
+                    continue
 
             account = accounts_map[acct_name]
 
@@ -260,14 +273,22 @@ class HouseholdService:
                         )
                         continue
 
-                account.tax_lots.append(
-                    TaxLot(
-                        ticker=ticker,
-                        shares=shares,
-                        cost_basis_per_share=basis,
-                        purchase_date=pdate,
+                try:
+                    account.tax_lots.append(
+                        TaxLot(
+                            ticker=ticker,
+                            shares=shares,
+                            cost_basis_per_share=basis,
+                            purchase_date=pdate,
+                        )
                     )
-                )
+                except ValidationError as exc:
+                    warnings.append(
+                        ImportWarning(
+                            line=line_num,
+                            message=f"Invalid lot data: {exc.errors()[0]['msg']}",
+                        )
+                    )
 
             elif record_type == "cash":
                 amount_raw = row.get("amount", "").strip()
@@ -308,15 +329,23 @@ class HouseholdService:
 
                 mm_ticker = row.get("ticker", "").strip().upper() or None
 
-                account.cash_holdings.append(
-                    CashHolding(
-                        amount=amount,
-                        valuation_date=val_date,
-                        is_money_market=is_mm,
-                        ticker=mm_ticker if is_mm else None,
-                        counts_toward_liquidity_reserve=counts_liq,
+                try:
+                    account.cash_holdings.append(
+                        CashHolding(
+                            amount=amount,
+                            valuation_date=val_date,
+                            is_money_market=is_mm,
+                            ticker=mm_ticker if is_mm else None,
+                            counts_toward_liquidity_reserve=counts_liq,
+                        )
                     )
-                )
+                except ValidationError as exc:
+                    warnings.append(
+                        ImportWarning(
+                            line=line_num,
+                            message=f"Invalid cash data: {exc.errors()[0]['msg']}",
+                        )
+                    )
             else:
                 warnings.append(
                     ImportWarning(

--- a/agents/src/web_api.py
+++ b/agents/src/web_api.py
@@ -49,6 +49,13 @@ from src.application.contracts.agents import (
     SearchFilingsRequest,
     SearchFilingsResponse,
 )
+from src.application.contracts.household import (
+    GetHouseholdResponse,
+    ImportPreviewRequest,
+    ImportPreviewResponse,
+    UpdateHouseholdRequest,
+    UpdateHouseholdResponse,
+)
 from src.application.contracts.knowledge_graph import (
     ExtractEntitiesRequest,
     ExtractEntitiesResponse,
@@ -64,6 +71,11 @@ from src.application.contracts.ticker import TickerSummary, TickerTranscript
 from src.application.registry import AGENT_CATALOG, create_pipeline_service
 from src.application.services.agent_service import AgentService
 from src.application.services.digest_service import DigestService
+from src.application.services.household_service import (
+    HouseholdCorruptError,
+    HouseholdService,
+    StaleRevisionError,
+)
 from src.application.services.kg_service import KnowledgeGraphService
 from src.application.watchlists import WatchlistNotFoundError, WatchlistStore
 from src.core.knowledge_graph import KnowledgeGraph
@@ -91,6 +103,9 @@ _kg_lock = asyncio.Lock()
 
 # Process-level watchlist store (persists to ~/.config/finance-os/watchlists.json)
 _watchlist_store = WatchlistStore()
+
+# Process-level household service (persists to ~/.config/finance-os/household.json)
+_household_service = HouseholdService()
 
 app = FastAPI(
     title="finance-os",
@@ -127,6 +142,22 @@ async def watchlist_not_found_handler(
 ) -> JSONResponse:
     """Map WatchlistNotFoundError to 404."""
     return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+
+@app.exception_handler(StaleRevisionError)
+async def stale_revision_handler(
+    _request: Request, exc: StaleRevisionError,
+) -> JSONResponse:
+    """Map StaleRevisionError to 409 Conflict."""
+    return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+
+@app.exception_handler(HouseholdCorruptError)
+async def household_corrupt_handler(
+    _request: Request, exc: HouseholdCorruptError,
+) -> JSONResponse:
+    """Map HouseholdCorruptError to 500 — corrupt file preserved for recovery."""
+    return JSONResponse(status_code=500, content={"detail": str(exc)})
 
 
 # --- Health & Info ---
@@ -340,6 +371,32 @@ async def kg_stats() -> Any:
             None, _kg_service().get_stats,
         )
     return response.model_dump(mode="json")
+
+
+# --- Household Portfolio ---
+
+
+@app.get("/household", response_model=GetHouseholdResponse)
+async def get_household() -> Any:
+    """Load the household portfolio (returns defaults if no file exists)."""
+    household, exists = await asyncio.to_thread(_household_service.load)
+    return GetHouseholdResponse(household=household, exists=exists).model_dump(mode="json")
+
+
+@app.put("/household", response_model=UpdateHouseholdResponse)
+async def update_household(request: UpdateHouseholdRequest) -> Any:
+    """Update the household portfolio (optimistic concurrency via expected_revision)."""
+    household, summary = await asyncio.to_thread(_household_service.save, request)
+    return UpdateHouseholdResponse(
+        household=household, journal_entry=summary,
+    ).model_dump(mode="json")
+
+
+@app.post("/household/import/csv/preview", response_model=ImportPreviewResponse)
+async def preview_csv_import(request: ImportPreviewRequest) -> Any:
+    """Parse CSV content and return proposed accounts without persisting."""
+    result = await asyncio.to_thread(_household_service.preview_csv_import, request)
+    return result.model_dump(mode="json")
 
 
 # --- Watchlists ---

--- a/agents/tests/test_household.py
+++ b/agents/tests/test_household.py
@@ -1,0 +1,657 @@
+"""Tests for household portfolio model — contracts, service, and math helpers."""
+
+import json
+import textwrap
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from src.application.contracts.household import (
+    Account,
+    AccountType,
+    AssetClass,
+    CashFlowAssumption,
+    CashFlowType,
+    CashHolding,
+    Household,
+    ImportPreviewRequest,
+    TaxLot,
+    UpdateHouseholdRequest,
+)
+from src.application.household_math import (
+    aggregate_lots,
+    cost_basis_by_ticker,
+    has_complete_lots,
+    household_summary,
+    liquidity_reserve_cash,
+    lot_count,
+    total_cash,
+    total_cash_household,
+    total_cost_basis,
+    unique_tickers,
+)
+from src.application.services.household_service import (
+    HouseholdCorruptError,
+    HouseholdService,
+    StaleRevisionError,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_lot() -> TaxLot:
+    return TaxLot(
+        ticker="VTI",
+        shares=Decimal("100"),
+        cost_basis_per_share=Decimal("200.50"),
+        purchase_date=date(2023, 1, 15),
+    )
+
+
+@pytest.fixture()
+def sample_cash() -> CashHolding:
+    return CashHolding(
+        amount=Decimal("50000"),
+        valuation_date=date(2024, 1, 1),
+        is_money_market=False,
+        counts_toward_liquidity_reserve=True,
+    )
+
+
+@pytest.fixture()
+def sample_account(sample_lot: TaxLot, sample_cash: CashHolding) -> Account:
+    return Account(
+        name="Taxable Brokerage",
+        account_type=AccountType.TAXABLE,
+        tax_lots=[sample_lot],
+        cash_holdings=[sample_cash],
+    )
+
+
+@pytest.fixture()
+def sample_household(sample_account: Account) -> Household:
+    return Household(
+        name="Test Household",
+        accounts=[sample_account],
+        liquidity_reserve_floor=Decimal("25000"),
+    )
+
+
+@pytest.fixture()
+def tmp_household_path(tmp_path: Path) -> Path:
+    return tmp_path / "household.json"
+
+
+@pytest.fixture()
+def service(tmp_household_path: Path) -> HouseholdService:
+    return HouseholdService(path=tmp_household_path)
+
+
+# ---------------------------------------------------------------------------
+# Contract validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestTaxLot:
+    def test_valid_lot(self, sample_lot: TaxLot) -> None:
+        assert sample_lot.ticker == "VTI"
+        assert sample_lot.shares == Decimal("100")
+
+    def test_ticker_uppercased(self) -> None:
+        lot = TaxLot(
+            ticker="vti",
+            shares=Decimal("10"),
+            cost_basis_per_share=Decimal("100"),
+            purchase_date=date(2023, 1, 1),
+        )
+        assert lot.ticker == "VTI"
+
+    def test_negative_shares_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TaxLot(
+                ticker="VTI",
+                shares=Decimal("-1"),
+                cost_basis_per_share=Decimal("100"),
+                purchase_date=date(2023, 1, 1),
+            )
+
+    def test_zero_shares_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TaxLot(
+                ticker="VTI",
+                shares=Decimal("0"),
+                cost_basis_per_share=Decimal("100"),
+                purchase_date=date(2023, 1, 1),
+            )
+
+    def test_negative_cost_basis_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TaxLot(
+                ticker="VTI",
+                shares=Decimal("10"),
+                cost_basis_per_share=Decimal("-5"),
+                purchase_date=date(2023, 1, 1),
+            )
+
+
+class TestCashHolding:
+    def test_valid_cash(self, sample_cash: CashHolding) -> None:
+        assert sample_cash.amount == Decimal("50000")
+        assert sample_cash.counts_toward_liquidity_reserve is True
+
+    def test_money_market_with_ticker(self) -> None:
+        ch = CashHolding(
+            amount=Decimal("100000"),
+            valuation_date=date(2024, 6, 1),
+            is_money_market=True,
+            ticker="VMFXX",
+        )
+        assert ch.ticker == "VMFXX"
+        assert ch.is_money_market is True
+
+    def test_negative_amount_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CashHolding(
+                amount=Decimal("-100"),
+                valuation_date=date(2024, 1, 1),
+            )
+
+
+class TestAccount:
+    def test_empty_name_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Account(name="", account_type=AccountType.TAXABLE)
+
+    def test_valid_account(self, sample_account: Account) -> None:
+        assert sample_account.account_type == AccountType.TAXABLE
+        assert len(sample_account.tax_lots) == 1
+        assert len(sample_account.cash_holdings) == 1
+
+
+class TestHousehold:
+    def test_defaults(self) -> None:
+        h = Household(name="Test")
+        assert h.schema_version == 1
+        assert h.revision == 0
+        assert h.accounts == []
+        assert h.liquidity_reserve_floor == Decimal("0")
+
+    def test_valid_household(self, sample_household: Household) -> None:
+        assert sample_household.name == "Test Household"
+        assert len(sample_household.accounts) == 1
+
+    def test_roundtrip_json(self, sample_household: Household) -> None:
+        dumped = sample_household.model_dump(mode="json")
+        restored = Household.model_validate(dumped)
+        assert restored.name == sample_household.name
+        assert len(restored.accounts) == len(sample_household.accounts)
+        lot = restored.accounts[0].tax_lots[0]
+        assert lot.shares == Decimal("100")
+        assert lot.cost_basis_per_share == Decimal("200.50")
+
+
+class TestCashFlowAssumption:
+    def test_valid_flow(self) -> None:
+        cf = CashFlowAssumption(
+            description="Annual savings",
+            amount_annual=Decimal("50000"),
+            flow_type=CashFlowType.CONTRIBUTION,
+            start_year=2024,
+            end_year=2044,
+        )
+        assert cf.inflation_adjusted is True  # default
+
+    def test_invalid_year_range(self) -> None:
+        with pytest.raises(ValidationError):
+            CashFlowAssumption(
+                description="Bad year",
+                amount_annual=Decimal("1000"),
+                flow_type=CashFlowType.WITHDRAWAL,
+                start_year=1990,
+            )
+
+
+class TestAssetClassEnum:
+    def test_all_nine_classes(self) -> None:
+        assert len(AssetClass) == 9
+
+    def test_values(self) -> None:
+        assert AssetClass.US_EQUITY.value == "us_equity"
+        assert AssetClass.CASH_MONEY_MARKET.value == "cash_money_market"
+
+
+class TestAccountTypeEnum:
+    def test_all_six_types(self) -> None:
+        assert len(AccountType) == 6
+
+    def test_401k(self) -> None:
+        assert AccountType.FOUR01K.value == "401k"
+
+
+# ---------------------------------------------------------------------------
+# Math helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestHouseholdMath:
+    def test_total_cash(self, sample_account: Account) -> None:
+        assert total_cash(sample_account) == Decimal("50000")
+
+    def test_total_cash_household(self, sample_household: Household) -> None:
+        assert total_cash_household(sample_household) == Decimal("50000")
+
+    def test_liquidity_reserve_cash(self, sample_household: Household) -> None:
+        assert liquidity_reserve_cash(sample_household) == Decimal("50000")
+
+    def test_liquidity_reserve_excludes_non_reserve(self) -> None:
+        account = Account(
+            name="Test",
+            account_type=AccountType.TAXABLE,
+            cash_holdings=[
+                CashHolding(
+                    amount=Decimal("10000"),
+                    valuation_date=date(2024, 1, 1),
+                    counts_toward_liquidity_reserve=True,
+                ),
+                CashHolding(
+                    amount=Decimal("5000"),
+                    valuation_date=date(2024, 1, 1),
+                    counts_toward_liquidity_reserve=False,
+                ),
+            ],
+        )
+        h = Household(name="Test", accounts=[account])
+        assert liquidity_reserve_cash(h) == Decimal("10000")
+
+    def test_aggregate_lots(self) -> None:
+        lots = [
+            TaxLot(
+                ticker="VTI",
+                shares=Decimal("50"),
+                cost_basis_per_share=Decimal("200"),
+                purchase_date=date(2023, 1, 1),
+            ),
+            TaxLot(
+                ticker="VTI",
+                shares=Decimal("30"),
+                cost_basis_per_share=Decimal("210"),
+                purchase_date=date(2023, 6, 1),
+            ),
+            TaxLot(
+                ticker="VXUS",
+                shares=Decimal("100"),
+                cost_basis_per_share=Decimal("55"),
+                purchase_date=date(2023, 3, 1),
+            ),
+        ]
+        agg = aggregate_lots(lots)
+        assert agg["VTI"] == Decimal("80")
+        assert agg["VXUS"] == Decimal("100")
+
+    def test_total_cost_basis(self) -> None:
+        lots = [
+            TaxLot(
+                ticker="VTI",
+                shares=Decimal("10"),
+                cost_basis_per_share=Decimal("200"),
+                purchase_date=date(2023, 1, 1),
+            ),
+            TaxLot(
+                ticker="VTI",
+                shares=Decimal("5"),
+                cost_basis_per_share=Decimal("210"),
+                purchase_date=date(2023, 6, 1),
+            ),
+        ]
+        # 10 * 200 + 5 * 210 = 2000 + 1050 = 3050
+        assert total_cost_basis(lots) == Decimal("3050")
+
+    def test_cost_basis_by_ticker(self) -> None:
+        lots = [
+            TaxLot(
+                ticker="VTI",
+                shares=Decimal("10"),
+                cost_basis_per_share=Decimal("200"),
+                purchase_date=date(2023, 1, 1),
+            ),
+            TaxLot(
+                ticker="VXUS",
+                shares=Decimal("20"),
+                cost_basis_per_share=Decimal("50"),
+                purchase_date=date(2023, 3, 1),
+            ),
+        ]
+        basis = cost_basis_by_ticker(lots)
+        assert basis["VTI"] == Decimal("2000")
+        assert basis["VXUS"] == Decimal("1000")
+
+    def test_household_summary(self, sample_household: Household) -> None:
+        summary = household_summary(sample_household)
+        assert "Taxable Brokerage" in summary
+        acct = summary["Taxable Brokerage"]
+        assert acct["VTI"] == Decimal("100")
+        assert acct["_cash"] == Decimal("50000")
+
+    def test_lot_count(self, sample_household: Household) -> None:
+        assert lot_count(sample_household) == 1
+
+    def test_unique_tickers(self, sample_household: Household) -> None:
+        assert unique_tickers(sample_household) == {"VTI"}
+
+    def test_has_complete_lots_true(self, sample_household: Household) -> None:
+        assert has_complete_lots(sample_household) is True
+
+    def test_has_complete_lots_false_zero_basis(self) -> None:
+        lot = TaxLot(
+            ticker="VTI",
+            shares=Decimal("10"),
+            cost_basis_per_share=Decimal("0"),
+            purchase_date=date(2024, 1, 1),
+        )
+        h = Household(
+            name="Test",
+            accounts=[Account(name="A", account_type=AccountType.TAXABLE, tax_lots=[lot])],
+        )
+        assert has_complete_lots(h) is False
+
+    def test_empty_household_math(self) -> None:
+        h = Household(name="Empty")
+        assert total_cash_household(h) == Decimal("0")
+        assert liquidity_reserve_cash(h) == Decimal("0")
+        assert lot_count(h) == 0
+        assert unique_tickers(h) == set()
+        assert has_complete_lots(h) is True  # vacuously true
+
+
+# ---------------------------------------------------------------------------
+# Household service tests
+# ---------------------------------------------------------------------------
+
+
+class TestHouseholdService:
+    def test_load_no_file(self, service: HouseholdService) -> None:
+        household, exists = service.load()
+        assert exists is False
+        assert household.name == "My Household"
+        assert household.revision == 0
+
+    def test_save_and_load(
+        self,
+        service: HouseholdService,
+        sample_account: Account,
+    ) -> None:
+        req = UpdateHouseholdRequest(
+            name="Acar Family",
+            accounts=[sample_account],
+            liquidity_reserve_floor=Decimal("25000"),
+            expected_revision=0,
+        )
+        saved, summary = service.save(req)
+        assert saved.revision == 1
+        assert saved.name == "Acar Family"
+        assert "rev 0 → 1" in summary
+
+        loaded, exists = service.load()
+        assert exists is True
+        assert loaded.name == "Acar Family"
+        assert loaded.revision == 1
+        assert len(loaded.accounts) == 1
+        # Verify Decimal precision round-trips
+        lot = loaded.accounts[0].tax_lots[0]
+        assert lot.cost_basis_per_share == Decimal("200.50")
+
+    def test_optimistic_concurrency_reject(
+        self,
+        service: HouseholdService,
+        sample_account: Account,
+    ) -> None:
+        # First save succeeds (revision 0 → 1)
+        req1 = UpdateHouseholdRequest(
+            name="First",
+            accounts=[sample_account],
+            expected_revision=0,
+        )
+        service.save(req1)
+
+        # Second save with stale revision 0 → StaleRevisionError
+        req2 = UpdateHouseholdRequest(
+            name="Stale",
+            accounts=[],
+            expected_revision=0,
+        )
+        with pytest.raises(StaleRevisionError):
+            service.save(req2)
+
+    def test_optimistic_concurrency_accept(
+        self,
+        service: HouseholdService,
+        sample_account: Account,
+    ) -> None:
+        req1 = UpdateHouseholdRequest(
+            name="First",
+            accounts=[sample_account],
+            expected_revision=0,
+        )
+        service.save(req1)
+
+        req2 = UpdateHouseholdRequest(
+            name="Second",
+            accounts=[],
+            expected_revision=1,
+        )
+        saved, _ = service.save(req2)
+        assert saved.revision == 2
+        assert saved.name == "Second"
+
+    def test_journal_written(
+        self,
+        service: HouseholdService,
+        tmp_path: Path,
+    ) -> None:
+        req = UpdateHouseholdRequest(
+            name="Journal Test",
+            accounts=[],
+            expected_revision=0,
+        )
+        service.save(req)
+
+        journal_path = tmp_path / "household-journal.jsonl"
+        assert journal_path.is_file()
+        lines = journal_path.read_text().strip().split("\n")
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["action"] == "update"
+        assert entry["base_revision"] == 0
+        assert entry["new_revision"] == 1
+
+    def test_corrupt_file_preserved(
+        self,
+        service: HouseholdService,
+        tmp_household_path: Path,
+    ) -> None:
+        tmp_household_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_household_path.write_text("not valid json {{{", encoding="utf-8")
+
+        with pytest.raises(HouseholdCorruptError):
+            service.load()
+
+        # Original file renamed to .corrupt.*.json
+        corrupt_files = list(tmp_household_path.parent.glob("*.corrupt.*.json"))
+        assert len(corrupt_files) == 1
+
+    def test_invalid_schema_preserved(
+        self,
+        service: HouseholdService,
+        tmp_household_path: Path,
+    ) -> None:
+        tmp_household_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_household_path.write_text(
+            json.dumps({"name": 12345}),  # name must be str
+            encoding="utf-8",
+        )
+
+        with pytest.raises(HouseholdCorruptError):
+            service.load()
+
+        corrupt_files = list(tmp_household_path.parent.glob("*.corrupt.*.json"))
+        assert len(corrupt_files) == 1
+
+    def test_atomic_write_creates_parent_dir(self, tmp_path: Path) -> None:
+        nested = tmp_path / "deep" / "nested" / "household.json"
+        svc = HouseholdService(path=nested)
+        req = UpdateHouseholdRequest(
+            name="Deep",
+            accounts=[],
+            expected_revision=0,
+        )
+        saved, _ = svc.save(req)
+        assert nested.is_file()
+        assert saved.name == "Deep"
+
+    def test_multiple_accounts_roundtrip(self, service: HouseholdService) -> None:
+        accounts = [
+            Account(
+                name="Taxable",
+                account_type=AccountType.TAXABLE,
+                tax_lots=[
+                    TaxLot(
+                        ticker="VTI",
+                        shares=Decimal("100"),
+                        cost_basis_per_share=Decimal("200"),
+                        purchase_date=date(2023, 1, 1),
+                    ),
+                ],
+                cash_holdings=[
+                    CashHolding(amount=Decimal("50000"), valuation_date=date(2024, 1, 1)),
+                ],
+            ),
+            Account(
+                name="Roth IRA",
+                account_type=AccountType.ROTH_IRA,
+                tax_lots=[
+                    TaxLot(
+                        ticker="VXUS",
+                        shares=Decimal("200"),
+                        cost_basis_per_share=Decimal("55"),
+                        purchase_date=date(2022, 6, 1),
+                    ),
+                ],
+            ),
+            Account(
+                name="Trust",
+                account_type=AccountType.TRUST,
+                cash_holdings=[
+                    CashHolding(
+                        amount=Decimal("100000"),
+                        valuation_date=date(2024, 1, 1),
+                        is_money_market=True,
+                        ticker="VMFXX",
+                    ),
+                ],
+            ),
+        ]
+        req = UpdateHouseholdRequest(
+            name="Multi-Account",
+            accounts=accounts,
+            liquidity_reserve_floor=Decimal("75000"),
+            expected_revision=0,
+        )
+        saved, _ = service.save(req)
+        assert len(saved.accounts) == 3
+
+        loaded, _ = service.load()
+        assert len(loaded.accounts) == 3
+        assert loaded.accounts[1].account_type == AccountType.ROTH_IRA
+        assert loaded.accounts[2].cash_holdings[0].ticker == "VMFXX"
+
+
+# ---------------------------------------------------------------------------
+# CSV import preview tests
+# ---------------------------------------------------------------------------
+
+
+class TestCSVImport:
+    def test_valid_lots_and_cash(self, service: HouseholdService) -> None:
+        csv = textwrap.dedent("""\
+            account_name,account_type,record_type,ticker,shares,cost_basis_per_share,purchase_date,amount,valuation_date,is_money_market,counts_toward_liquidity_reserve
+            Taxable,taxable,lot,VTI,100,200.50,2023-01-15,,,,
+            Taxable,taxable,lot,VXUS,50,55.00,2023-03-01,,,,
+            Taxable,taxable,cash,,,,,,2024-01-01,,true
+        """).replace(",,,,,2024-01-01,,true", ",,,,25000,2024-01-01,false,true")
+        # Fix the cash row properly
+        csv = textwrap.dedent("""\
+            account_name,account_type,record_type,ticker,shares,cost_basis_per_share,purchase_date,amount,valuation_date,is_money_market,counts_toward_liquidity_reserve
+            Taxable,taxable,lot,VTI,100,200.50,2023-01-15,,,,
+            Taxable,taxable,lot,VXUS,50,55.00,2023-03-01,,,,
+            Taxable,taxable,cash,,,,,,25000,2024-01-01,false,true
+        """)
+        result = service.preview_csv_import(ImportPreviewRequest(csv_content=csv))
+        assert len(result.accounts) == 1
+        assert len(result.accounts[0].tax_lots) == 2
+        assert result.accounts[0].tax_lots[0].ticker == "VTI"
+        assert result.position_only is False
+
+    def test_missing_lot_fields_marks_position_only(
+        self,
+        service: HouseholdService,
+    ) -> None:
+        csv = textwrap.dedent("""\
+            account_name,account_type,record_type,ticker,shares,cost_basis_per_share,purchase_date
+            Taxable,taxable,lot,VTI,100,,
+        """)
+        result = service.preview_csv_import(ImportPreviewRequest(csv_content=csv))
+        assert result.position_only is True
+        assert len(result.warnings) > 0
+
+    def test_missing_required_headers(self, service: HouseholdService) -> None:
+        csv = "ticker,shares\nVTI,100\n"
+        result = service.preview_csv_import(ImportPreviewRequest(csv_content=csv))
+        assert len(result.accounts) == 0
+        assert any("Missing required columns" in w.message for w in result.warnings)
+
+    def test_no_headers(self, service: HouseholdService) -> None:
+        result = service.preview_csv_import(ImportPreviewRequest(csv_content="\n"))
+        assert len(result.accounts) == 0
+
+    def test_unknown_account_type(self, service: HouseholdService) -> None:
+        csv = textwrap.dedent("""\
+            account_name,account_type,record_type,ticker,shares,cost_basis_per_share,purchase_date
+            Bad,unknown_type,lot,VTI,100,200,2023-01-01
+        """)
+        result = service.preview_csv_import(ImportPreviewRequest(csv_content=csv))
+        assert len(result.accounts) == 0
+        assert any("Unknown account_type" in w.message for w in result.warnings)
+
+    def test_unknown_record_type(self, service: HouseholdService) -> None:
+        csv = textwrap.dedent("""\
+            account_name,account_type,record_type,ticker,shares,cost_basis_per_share,purchase_date
+            Taxable,taxable,bond,VTI,100,200,2023-01-01
+        """)
+        result = service.preview_csv_import(ImportPreviewRequest(csv_content=csv))
+        assert any("Unknown record_type" in w.message for w in result.warnings)
+
+    def test_multiple_accounts_from_csv(self, service: HouseholdService) -> None:
+        csv = textwrap.dedent("""\
+            account_name,account_type,record_type,ticker,shares,cost_basis_per_share,purchase_date
+            Taxable,taxable,lot,VTI,100,200,2023-01-01
+            Roth,roth_ira,lot,VXUS,50,55,2023-06-01
+        """)
+        result = service.preview_csv_import(ImportPreviewRequest(csv_content=csv))
+        assert len(result.accounts) == 2
+        names = {a.name for a in result.accounts}
+        assert names == {"Taxable", "Roth"}
+
+    def test_invalid_decimal_in_shares(self, service: HouseholdService) -> None:
+        csv = textwrap.dedent("""\
+            account_name,account_type,record_type,ticker,shares,cost_basis_per_share,purchase_date
+            Taxable,taxable,lot,VTI,abc,200,2023-01-01
+        """)
+        result = service.preview_csv_import(ImportPreviewRequest(csv_content=csv))
+        assert len(result.accounts[0].tax_lots) == 0
+        assert any("Invalid shares" in w.message for w in result.warnings)

--- a/agents/tests/test_household.py
+++ b/agents/tests/test_household.py
@@ -207,13 +207,23 @@ class TestCashFlowAssumption:
         )
         assert cf.inflation_adjusted is True  # default
 
-    def test_invalid_year_range(self) -> None:
+    def test_start_year_below_minimum(self) -> None:
         with pytest.raises(ValidationError):
             CashFlowAssumption(
                 description="Bad year",
                 amount_annual=Decimal("1000"),
                 flow_type=CashFlowType.WITHDRAWAL,
                 start_year=1990,
+            )
+
+    def test_end_year_before_start_year(self) -> None:
+        with pytest.raises(ValidationError):
+            CashFlowAssumption(
+                description="Bad range",
+                amount_annual=Decimal("1000"),
+                flow_type=CashFlowType.WITHDRAWAL,
+                start_year=2030,
+                end_year=2025,
             )
 
 
@@ -582,13 +592,6 @@ class TestCSVImport:
             account_name,account_type,record_type,ticker,shares,cost_basis_per_share,purchase_date,amount,valuation_date,is_money_market,counts_toward_liquidity_reserve
             Taxable,taxable,lot,VTI,100,200.50,2023-01-15,,,,
             Taxable,taxable,lot,VXUS,50,55.00,2023-03-01,,,,
-            Taxable,taxable,cash,,,,,,2024-01-01,,true
-        """).replace(",,,,,2024-01-01,,true", ",,,,25000,2024-01-01,false,true")
-        # Fix the cash row properly
-        csv = textwrap.dedent("""\
-            account_name,account_type,record_type,ticker,shares,cost_basis_per_share,purchase_date,amount,valuation_date,is_money_market,counts_toward_liquidity_reserve
-            Taxable,taxable,lot,VTI,100,200.50,2023-01-15,,,,
-            Taxable,taxable,lot,VXUS,50,55.00,2023-03-01,,,,
             Taxable,taxable,cash,,,,,,25000,2024-01-01,false,true
         """)
         result = service.preview_csv_import(ImportPreviewRequest(csv_content=csv))
@@ -655,3 +658,24 @@ class TestCSVImport:
         result = service.preview_csv_import(ImportPreviewRequest(csv_content=csv))
         assert len(result.accounts[0].tax_lots) == 0
         assert any("Invalid shares" in w.message for w in result.warnings)
+
+    def test_conflicting_account_type_warns(self, service: HouseholdService) -> None:
+        csv = textwrap.dedent("""\
+            account_name,account_type,record_type,ticker,shares,cost_basis_per_share,purchase_date
+            Mixed,taxable,lot,VTI,100,200,2023-01-01
+            Mixed,roth_ira,lot,VXUS,50,55,2023-06-01
+        """)
+        result = service.preview_csv_import(ImportPreviewRequest(csv_content=csv))
+        assert any("conflicting types" in w.message for w in result.warnings)
+        # Second row skipped, only 1 lot from first row
+        assert len(result.accounts) == 1
+        assert len(result.accounts[0].tax_lots) == 1
+
+    def test_negative_shares_warns(self, service: HouseholdService) -> None:
+        csv = textwrap.dedent("""\
+            account_name,account_type,record_type,ticker,shares,cost_basis_per_share,purchase_date
+            Taxable,taxable,lot,VTI,-10,200,2023-01-01
+        """)
+        result = service.preview_csv_import(ImportPreviewRequest(csv_content=csv))
+        assert any("Invalid lot data" in w.message for w in result.warnings)
+        assert len(result.accounts[0].tax_lots) == 0


### PR DESCRIPTION
## Summary

Implements **#101 — Household Portfolio Model**, the foundation Layer 0 data model that all downstream features depend on.

### What's included

**Contracts** (`agents/src/application/contracts/household.py`)
- `AccountType`, `AssetClass`, `CashFlowType` enums (StrEnum)
- `TaxLot`, `CashHolding`, `Account`, `CashFlowAssumption`, `Household` domain models
- API request/response contracts: `GetHouseholdResponse`, `UpdateHouseholdRequest/Response`, `ImportPreviewRequest/Response`
- Schema versioning (`schema_version`) + optimistic concurrency (`revision`)

**Service** (`agents/src/application/services/household_service.py`)
- OS-level file locking (`fcntl.flock`) — safe across Web API, MCP, and CLI processes
- Atomic writes (temp file + rename)
- Corruption detection — corrupt files renamed to `.corrupt.<timestamp>.json`, raises `HouseholdCorruptError`
- Change journaling — every write appended to `household-journal.jsonl`
- CSV import preview — parse proposed accounts + warnings without mutating state
- Optimistic concurrency — stale revision writes raise `StaleRevisionError`

**Math helpers** (`agents/src/application/household_math.py`)
- Pure domain functions: `total_cash`, `liquidity_reserve_cash`, `aggregate_lots`, `cost_basis_by_ticker`, `household_summary`, `unique_tickers`, `has_complete_lots`

**API endpoints** (`agents/src/web_api.py`)
- `GET /household` — load household (empty default if none exists)
- `PUT /household` — save with optimistic concurrency (409 on stale revision)
- `POST /household/import/csv/preview` — preview CSV import without side effects

**Tests** (`agents/tests/test_household.py`)
- 49 tests covering contracts, math, and service layers
- Persistence, concurrency, journal, corruption, CSV import scenarios

### Preflight
- ✅ All 597 tests pass (49 new + 548 existing)
- ✅ Lint clean (ruff + eslint)
- ✅ TypeScript build clean

Closes #101