### PR TITLE
fix: prevent fd leak in _FileLockContext when flock() raises

### DIFF
--- a/agents/src/application/services/household_service.py
+++ b/agents/src/application/services/household_service.py
@@ -471,7 +471,12 @@ class _FileLockContext:
     def __enter__(self) -> "_FileLockContext":
         self._lock_path.parent.mkdir(parents=True, exist_ok=True)
         self._fd = os.open(str(self._lock_path), os.O_CREAT | os.O_RDWR)
-        fcntl.flock(self._fd, fcntl.LOCK_EX)
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_EX)
+        except BaseException:
+            os.close(self._fd)
+            self._fd = None
+            raise
         return self
 
     def __exit__(self, *_: object) -> None:

--- a/agents/src/application/services/household_service.py
+++ b/agents/src/application/services/household_service.py
@@ -474,7 +474,10 @@ class _FileLockContext:
         try:
             fcntl.flock(self._fd, fcntl.LOCK_EX)
         except BaseException:
-            os.close(self._fd)
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
             self._fd = None
             raise
         return self

--- a/agents/tests/test_household.py
+++ b/agents/tests/test_household.py
@@ -1,6 +1,7 @@
 """Tests for household portfolio model — contracts, service, and math helpers."""
 
 import json
+import os
 import textwrap
 from datetime import date
 from decimal import Decimal
@@ -579,6 +580,33 @@ class TestHouseholdService:
         assert len(loaded.accounts) == 3
         assert loaded.accounts[1].account_type == AccountType.ROTH_IRA
         assert loaded.accounts[2].cash_holdings[0].ticker == "VMFXX"
+
+    def test_flock_failure_closes_fd(self, tmp_path: Path) -> None:
+        """File descriptor must be closed if fcntl.flock() raises."""
+        from unittest.mock import patch
+
+        svc = HouseholdService(path=tmp_path / "household.json")
+        closed_fds: list[int] = []
+        original_close = os.close
+
+        def tracking_close(fd: int) -> None:
+            closed_fds.append(fd)
+            original_close(fd)
+
+        with (
+            patch("src.application.services.household_service.fcntl") as mock_fcntl,
+            patch(
+                "src.application.services.household_service.os.close",
+                side_effect=tracking_close,
+            ),
+        ):
+            mock_fcntl.LOCK_EX = 2
+            mock_fcntl.flock.side_effect = OSError("mock flock failure")
+
+            with pytest.raises(OSError, match="mock flock failure"):
+                svc.load()
+
+        assert len(closed_fds) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`_FileLockContext.__enter__()` opens a file descriptor then calls `fcntl.flock()`. If `flock()` raises (e.g., `InterruptedError` from SIGTERM during shutdown), `__exit__()` is never called (per Python's context manager protocol), leaking the fd. Repeated occurrences can exhaust the process fd limit (`EMFILE`).

## Fix

Wrap `flock()` in try/except — on any exception, close the fd and re-raise.

Found during post-merge code review of #118.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>