### PR TITLE
docs: add PR review feedback loop to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -250,6 +250,7 @@ All branches other than `main` **must** follow: `<username>/<MeaningfulDescripti
 
 - Use `gh pr create --title "..." --body "Closes #N"`.
 - **Assign every PR to the "finance-os" GitHub Project** (if one exists).
+- **After every push**, wait a few minutes for CI and Copilot code review feedback on the remote. Read all review comments, assess validity, address valid findings with a new commit, push, and resolve the conversations. Repeat this loop until there is no more unresolved feedback.
 
 ## @azure Rule
 


### PR DESCRIPTION
Adds a mandatory step to the Pull Requests section: after every push, wait for CI and Copilot code review feedback, address valid findings, and repeat until clean.