### PR TITLE
feat: ETF taxonomy service with classification, overrides, and diagnostics

### DIFF
--- a/agents/src/application/data_services/etf_service.py
+++ b/agents/src/application/data_services/etf_service.py
@@ -250,16 +250,28 @@ class OverrideStore:
     def __init__(self, path: Path = OVERRIDES_FILE) -> None:
         self._path = path
         self._lock = threading.Lock()
+        self._cached_data: OverridesFile | None = None
+        self._cached_mtime: float = 0.0
 
     def load(self) -> OverridesFile:
-        """Load overrides from disk. Returns empty on missing/corrupt file."""
+        """Load overrides from disk with mtime-based caching."""
         if not self._path.exists():
+            self._cached_data = None
+            self._cached_mtime = 0.0
             return OverridesFile()
         try:
+            mtime = self._path.stat().st_mtime
+            if self._cached_data is not None and mtime == self._cached_mtime:
+                return self._cached_data
             raw = json.loads(self._path.read_text(encoding="utf-8"))
-            return OverridesFile.model_validate(raw)
+            data = OverridesFile.model_validate(raw)
+            self._cached_data = data
+            self._cached_mtime = mtime
+            return data
         except (json.JSONDecodeError, OSError, ValueError) as exc:
             logger.warning("Corrupt overrides file %s: %s", self._path, exc)
+            self._cached_data = None
+            self._cached_mtime = 0.0
             return OverridesFile()
 
     def _save(self, data: OverridesFile) -> None:
@@ -292,6 +304,9 @@ class OverrideStore:
         finally:
             if dir_fd is not None:
                 os.close(dir_fd)
+        # Invalidate mtime cache so next load() re-reads
+        self._cached_data = None
+        self._cached_mtime = 0.0
 
     def get(self, ticker: str) -> ETFOverride | None:
         """Get override for a single ticker."""
@@ -437,13 +452,15 @@ def _extract_diagnostics(profile: ETFProfile, category: str) -> None:
         elif "blend" in cat_lower:
             profile.style = "blend"
 
+    ex_japan = "ex-japan" in cat_lower or "ex japan" in cat_lower
+
     if "foreign" in cat_lower or "international" in cat_lower:
         profile.geography = "international"
     elif "emerging" in cat_lower:
         profile.geography = "emerging"
     elif "europe" in cat_lower:
         profile.geography = "europe"
-    elif "japan" in cat_lower:
+    elif "japan" in cat_lower and not ex_japan:
         profile.geography = "japan"
     elif "china" in cat_lower or "india" in cat_lower:
         profile.geography = "emerging"
@@ -568,10 +585,11 @@ class ETFService:
                 update={"profile": profile, "served_from_cache": True},
             )
 
-        # Fetch from Yahoo and cache the provider-derived profile only.
+        # Fetch from Yahoo and cache only successful classifications.
         profile = self._fetch_and_classify(ticker)
         base_response = ETFProfileResponse(profile=profile)
-        self._cache_put(ticker, base_response)
+        if profile.asset_class is not None and not profile.warnings:
+            self._cache_put(ticker, base_response)
 
         # Apply override if present to a copy so the cache remains the
         # unmodified provider-derived result.

--- a/agents/src/application/data_services/etf_service.py
+++ b/agents/src/application/data_services/etf_service.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import os
+import tempfile
 import threading
 import time
 from datetime import UTC, date, datetime
@@ -257,33 +258,46 @@ class OverrideStore:
         try:
             raw = json.loads(self._path.read_text(encoding="utf-8"))
             return OverridesFile.model_validate(raw)
-        except (json.JSONDecodeError, ValueError) as exc:
+        except (json.JSONDecodeError, OSError, ValueError) as exc:
             logger.warning("Corrupt overrides file %s: %s", self._path, exc)
             return OverridesFile()
 
     def _save(self, data: OverridesFile) -> None:
         """Atomic write to disk with fsync for durability."""
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix(".tmp")
-        content = data.model_dump_json(indent=2)
-        fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+        content = data.model_dump_json(indent=2).encode("utf-8")
+        fd = tempfile.mkstemp(
+            dir=str(self._path.parent), suffix=".tmp"
+        )
+        tmp_fd, tmp_path = fd[0], Path(fd[1])
         try:
-            os.write(fd, content.encode("utf-8"))
-            os.fsync(fd)
+            os.write(tmp_fd, content)
+            os.fsync(tmp_fd)
         finally:
-            os.close(fd)
-        tmp.replace(self._path)
-        # fsync parent directory to persist the rename
-        dir_fd = os.open(str(self._path.parent), os.O_RDONLY)
+            os.close(tmp_fd)
+        os.chmod(str(tmp_path), 0o600)
+        tmp_path.replace(self._path)
+        # Best-effort fsync of parent directory to persist the rename.
+        # Some platforms/filesystems do not support this.
+        dir_fd: int | None = None
         try:
+            dir_fd = os.open(str(self._path.parent), os.O_RDONLY)
             os.fsync(dir_fd)
+        except OSError as exc:
+            logger.warning(
+                "Could not fsync parent directory %s: %s",
+                self._path.parent,
+                exc,
+            )
         finally:
-            os.close(dir_fd)
+            if dir_fd is not None:
+                os.close(dir_fd)
 
     def get(self, ticker: str) -> ETFOverride | None:
         """Get override for a single ticker."""
-        data = self.load()
-        return data.overrides.get(ticker.upper())
+        with self._lock:
+            data = self.load()
+            return data.overrides.get(ticker.upper())
 
     def set(self, ticker: str, override: ETFOverride) -> None:
         """Set override for a single ticker."""

--- a/agents/src/application/data_services/etf_service.py
+++ b/agents/src/application/data_services/etf_service.py
@@ -1,0 +1,627 @@
+"""ETF classification and taxonomy service.
+
+Maps ETF tickers to canonical asset classes and diagnostic attributes
+using Yahoo Finance data with manual override support. All yfinance
+calls are dispatched to threads to avoid blocking async event loops.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import threading
+import time
+from datetime import UTC, date, datetime
+from decimal import Decimal, InvalidOperation
+from enum import StrEnum
+from pathlib import Path
+
+import yfinance as yf
+from pydantic import BaseModel, Field, field_validator
+
+from src.application.config import CONFIG_DIR
+from src.application.contracts.household import AssetClass
+
+logger = logging.getLogger(__name__)
+
+OVERRIDES_FILE = CONFIG_DIR / "etf-overrides.json"
+_OVERRIDES_SCHEMA_VERSION = 1
+_STALE_OVERRIDE_DAYS = 90
+
+
+# ---------------------------------------------------------------------------
+# Classification confidence
+# ---------------------------------------------------------------------------
+
+
+class Confidence(StrEnum):
+    """How confident the classification is."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    UNCLASSIFIED = "unclassified"
+
+
+# ---------------------------------------------------------------------------
+# Category → AssetClass mapping
+# ---------------------------------------------------------------------------
+
+# Maps yfinance category strings to (AssetClass, Confidence).
+# Categories not in this map get heuristic fallback.
+CATEGORY_MAP: dict[str, tuple[AssetClass, Confidence]] = {
+    # US Equity
+    "Large Blend": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Large Growth": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Large Value": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Mid-Cap Blend": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Mid-Cap Growth": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Mid-Cap Value": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Small Blend": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Small Growth": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Small Value": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Technology": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Health": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Financial": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Real Estate": (AssetClass.REAL_ASSETS, Confidence.HIGH),
+    "Communications": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Utilities": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Energy": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Industrials": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Consumer Cyclical": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Consumer Defensive": (AssetClass.US_EQUITY, Confidence.HIGH),
+    "Basic Materials": (AssetClass.US_EQUITY, Confidence.HIGH),
+    # International Developed
+    "Foreign Large Blend": (AssetClass.INTL_DEVELOPED, Confidence.HIGH),
+    "Foreign Large Growth": (AssetClass.INTL_DEVELOPED, Confidence.HIGH),
+    "Foreign Large Value": (AssetClass.INTL_DEVELOPED, Confidence.HIGH),
+    "Foreign Small/Mid Blend": (AssetClass.INTL_DEVELOPED, Confidence.HIGH),
+    "Foreign Small/Mid Growth": (AssetClass.INTL_DEVELOPED, Confidence.HIGH),
+    "Foreign Small/Mid Value": (AssetClass.INTL_DEVELOPED, Confidence.HIGH),
+    "Europe Stock": (AssetClass.INTL_DEVELOPED, Confidence.HIGH),
+    "Japan Stock": (AssetClass.INTL_DEVELOPED, Confidence.HIGH),
+    "Pacific/Asia ex-Japan Stk": (AssetClass.INTL_DEVELOPED, Confidence.MEDIUM),
+    # Emerging Markets
+    "Diversified Emerging Mkts": (AssetClass.EMERGING_MARKETS, Confidence.HIGH),
+    "China Region": (AssetClass.EMERGING_MARKETS, Confidence.HIGH),
+    "India Equity": (AssetClass.EMERGING_MARKETS, Confidence.HIGH),
+    "Latin America Stock": (AssetClass.EMERGING_MARKETS, Confidence.HIGH),
+    # US Treasuries
+    "Long Government": (AssetClass.US_TREASURIES, Confidence.HIGH),
+    "Intermediate Government": (AssetClass.US_TREASURIES, Confidence.HIGH),
+    "Short Government": (AssetClass.US_TREASURIES, Confidence.HIGH),
+    "Ultrashort Bond": (AssetClass.US_TREASURIES, Confidence.MEDIUM),
+    # IG Corporate
+    "Corporate Bond": (AssetClass.IG_CORPORATE, Confidence.HIGH),
+    "Intermediate Core Bond": (AssetClass.IG_CORPORATE, Confidence.MEDIUM),
+    "Intermediate Core-Plus Bond": (AssetClass.IG_CORPORATE, Confidence.MEDIUM),
+    "Long-Term Bond": (AssetClass.IG_CORPORATE, Confidence.MEDIUM),
+    "Short-Term Bond": (AssetClass.IG_CORPORATE, Confidence.MEDIUM),
+    # High Yield
+    "High Yield Bond": (AssetClass.HIGH_YIELD, Confidence.HIGH),
+    # TIPS
+    "Inflation-Protected Bond": (AssetClass.TIPS, Confidence.HIGH),
+    # Real Assets
+    "Commodities Broad Basket": (AssetClass.REAL_ASSETS, Confidence.HIGH),
+    "Commodities Focused": (AssetClass.REAL_ASSETS, Confidence.HIGH),
+    "Natural Resources": (AssetClass.REAL_ASSETS, Confidence.HIGH),
+    "Global Real Estate": (AssetClass.REAL_ASSETS, Confidence.HIGH),
+    # Cash / Money Market
+    "Money Market-Taxable": (AssetClass.CASH_MONEY_MARKET, Confidence.HIGH),
+    "Money Market-Tax-Free": (AssetClass.CASH_MONEY_MARKET, Confidence.HIGH),
+}
+
+# Keyword fallbacks when category is missing or unknown
+_KEYWORD_RULES: list[tuple[list[str], AssetClass, Confidence]] = [
+    (
+        ["treasury", "govt", "government bond"],
+        AssetClass.US_TREASURIES,
+        Confidence.MEDIUM,
+    ),
+    (["tips", "inflation"], AssetClass.TIPS, Confidence.MEDIUM),
+    (["high yield", "junk"], AssetClass.HIGH_YIELD, Confidence.MEDIUM),
+    (
+        ["corporate bond", "investment grade"],
+        AssetClass.IG_CORPORATE,
+        Confidence.MEDIUM,
+    ),
+    (["emerging", "em "], AssetClass.EMERGING_MARKETS, Confidence.MEDIUM),
+    (
+        ["international", "foreign", "ex-us", "world ex", "eafe"],
+        AssetClass.INTL_DEVELOPED,
+        Confidence.MEDIUM,
+    ),
+    (
+        ["reit", "real estate", "commodity", "gold", "silver"],
+        AssetClass.REAL_ASSETS,
+        Confidence.MEDIUM,
+    ),
+    (
+        ["money market", "cash", "ultra-short"],
+        AssetClass.CASH_MONEY_MARKET,
+        Confidence.MEDIUM,
+    ),
+    (
+        ["s&p 500", "total market", "russell", "nasdaq", "dow jones"],
+        AssetClass.US_EQUITY,
+        Confidence.MEDIUM,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# ETF Profile model
+# ---------------------------------------------------------------------------
+
+
+class FieldProvenance(BaseModel):
+    """Tracks where a field's value came from."""
+
+    source: str = Field(description="'yahoo', 'override', or 'inferred'")
+    as_of: date | None = None
+    confidence: Confidence = Confidence.HIGH
+
+
+class ETFProfile(BaseModel):
+    """Classification and metadata for a single ETF."""
+
+    ticker: str
+    name: str = ""
+    asset_class: AssetClass | None = None
+    classification_confidence: Confidence = Confidence.UNCLASSIFIED
+    classification_rule: str = ""
+
+    # Diagnostic attributes
+    category: str = ""
+    expense_ratio: Decimal | None = None
+    fund_family: str = ""
+    inception_date: date | None = None
+    aum: Decimal | None = None
+
+    # Diagnostic breakdown (optional)
+    cap_size: str = ""
+    style: str = ""
+    sector_focus: str = ""
+    geography: str = "US"
+    duration_bucket: str = ""
+    credit_quality: str = ""
+
+    # Field provenance
+    provenance: dict[str, FieldProvenance] = Field(default_factory=dict)
+
+    # Warnings accumulated during classification
+    warnings: list[str] = Field(default_factory=list)
+
+
+class ETFProfileResponse(BaseModel):
+    """Wrapper for an ETF profile with freshness metadata."""
+
+    profile: ETFProfile
+    fetched_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    served_from_cache: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Override models
+# ---------------------------------------------------------------------------
+
+
+class ETFOverride(BaseModel):
+    """Manual override for a single ETF's classification."""
+
+    asset_class: AssetClass | None = None
+    sector: str | None = None
+    geography: str | None = None
+    duration: str | None = None
+    credit_quality: str | None = None
+    as_of: date
+    mode: str = "replace"
+
+    @field_validator("mode")
+    @classmethod
+    def valid_mode(cls, v: str) -> str:
+        if v not in ("replace", "patch"):
+            raise ValueError("mode must be 'replace' or 'patch'")
+        return v
+
+
+class OverridesFile(BaseModel):
+    """Schema for etf-overrides.json."""
+
+    schema_version: int = _OVERRIDES_SCHEMA_VERSION
+    overrides: dict[str, ETFOverride] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Override store
+# ---------------------------------------------------------------------------
+
+
+class OverrideStore:
+    """Loads/saves ETF overrides from persistent storage.
+
+    Uses a threading lock for concurrent write safety and fsync
+    for durability before replacing the target file.
+    """
+
+    def __init__(self, path: Path = OVERRIDES_FILE) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+
+    def load(self) -> OverridesFile:
+        """Load overrides from disk. Returns empty on missing/corrupt file."""
+        if not self._path.exists():
+            return OverridesFile()
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            return OverridesFile.model_validate(raw)
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.warning("Corrupt overrides file %s: %s", self._path, exc)
+            return OverridesFile()
+
+    def save(self, data: OverridesFile) -> None:
+        """Atomic write to disk with fsync for durability."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_suffix(".tmp")
+        content = data.model_dump_json(indent=2)
+        fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+        try:
+            os.write(fd, content.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        tmp.replace(self._path)
+
+    def get(self, ticker: str) -> ETFOverride | None:
+        """Get override for a single ticker."""
+        data = self.load()
+        return data.overrides.get(ticker.upper())
+
+    def set(self, ticker: str, override: ETFOverride) -> None:
+        """Set override for a single ticker."""
+        with self._lock:
+            data = self.load()
+            data.overrides[ticker.upper()] = override
+            self.save(data)
+
+    def remove(self, ticker: str) -> bool:
+        """Remove override. Returns True if existed."""
+        with self._lock:
+            data = self.load()
+            removed = data.overrides.pop(ticker.upper(), None) is not None
+            if removed:
+                self.save(data)
+            return removed
+
+
+# ---------------------------------------------------------------------------
+# Classification logic
+# ---------------------------------------------------------------------------
+
+
+def _safe_decimal(val: object) -> Decimal | None:
+    """Parse a value to Decimal, returning None on failure."""
+    if val is None:
+        return None
+    try:
+        return Decimal(str(val))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def classify_from_yahoo(info: dict[str, object]) -> ETFProfile:
+    """Build an ETFProfile from a yfinance info dict.
+
+    Uses category mapping first, then keyword fallback on fund name.
+    """
+    ticker = str(info.get("symbol", "")).upper()
+    name = str(info.get("longName") or info.get("shortName") or "")
+    category = str(info.get("category") or "")
+    fund_family = str(info.get("fundFamily") or "")
+
+    profile = ETFProfile(
+        ticker=ticker,
+        name=name,
+        category=category,
+        fund_family=fund_family,
+        expense_ratio=_safe_decimal(info.get("annualReportExpenseRatio")),
+        aum=_safe_decimal(info.get("totalAssets")),
+    )
+
+    # Parse inception date
+    fund_inception = info.get("fundInceptionDate")
+    if fund_inception:
+        try:
+            if isinstance(fund_inception, (int, float)):
+                profile.inception_date = datetime.fromtimestamp(
+                    fund_inception, tz=UTC
+                ).date()
+            else:
+                profile.inception_date = date.fromisoformat(str(fund_inception))
+        except (ValueError, OSError):
+            pass
+
+    # Parse diagnostic attributes from category
+    _extract_diagnostics(profile, category)
+
+    # Provenance for yahoo-sourced fields
+    today = date.today()
+    for field_name in ("name", "category", "expense_ratio", "fund_family", "aum"):
+        profile.provenance[field_name] = FieldProvenance(
+            source="yahoo", as_of=today
+        )
+
+    # Step 1: Try direct category mapping
+    if category and category in CATEGORY_MAP:
+        ac, conf = CATEGORY_MAP[category]
+        profile.asset_class = ac
+        profile.classification_confidence = conf
+        profile.classification_rule = f"category_map:{category}"
+        profile.provenance["asset_class"] = FieldProvenance(
+            source="yahoo", as_of=today, confidence=conf
+        )
+        return profile
+
+    # Step 2: Keyword fallback on name + category
+    search_text = f"{name} {category}".lower()
+    for keywords, ac, conf in _KEYWORD_RULES:
+        if any(kw in search_text for kw in keywords):
+            profile.asset_class = ac
+            profile.classification_confidence = conf
+            profile.classification_rule = f"keyword:{keywords[0]}"
+            profile.provenance["asset_class"] = FieldProvenance(
+                source="inferred", as_of=today, confidence=conf
+            )
+            return profile
+
+    # Step 3: Unclassified
+    profile.classification_confidence = Confidence.UNCLASSIFIED
+    profile.classification_rule = "none"
+    profile.warnings.append(
+        f"Could not classify {ticker} (category='{category}'). "
+        "Manual override recommended."
+    )
+    return profile
+
+
+def _extract_diagnostics(profile: ETFProfile, category: str) -> None:
+    """Extract cap_size, style, geography from category string."""
+    cat_lower = category.lower()
+
+    # Bond categories should not get equity-style diagnostics.
+    _bond_hints = (
+        "bond", "government", "treasury", "corporate", "high yield",
+        "inflation", "money market", "ultrashort",
+    )
+    is_bond = any(h in cat_lower for h in _bond_hints)
+
+    if not is_bond:
+        if "large" in cat_lower:
+            profile.cap_size = "large"
+        elif "mid-cap" in cat_lower or "mid cap" in cat_lower:
+            profile.cap_size = "mid"
+        elif "small" in cat_lower:
+            profile.cap_size = "small"
+
+        if "growth" in cat_lower:
+            profile.style = "growth"
+        elif "value" in cat_lower:
+            profile.style = "value"
+        elif "blend" in cat_lower:
+            profile.style = "blend"
+
+    if "foreign" in cat_lower or "international" in cat_lower:
+        profile.geography = "international"
+    elif "emerging" in cat_lower:
+        profile.geography = "emerging"
+    elif "europe" in cat_lower:
+        profile.geography = "europe"
+    elif "japan" in cat_lower:
+        profile.geography = "japan"
+    elif "china" in cat_lower or "india" in cat_lower:
+        profile.geography = "emerging"
+    elif "latin" in cat_lower:
+        profile.geography = "emerging"
+
+    if "short" in cat_lower:
+        profile.duration_bucket = "short"
+    elif "intermediate" in cat_lower:
+        profile.duration_bucket = "intermediate"
+    elif "long" in cat_lower:
+        profile.duration_bucket = "long"
+
+
+def apply_override(
+    profile: ETFProfile, override: ETFOverride
+) -> ETFProfile:
+    """Apply a manual override to an ETF profile.
+
+    In 'replace' mode, provided override fields replace provider values.
+    In 'patch' mode, override fields are only used to fill provider gaps;
+    existing provider values are preserved. Geography also treats a default
+    "US" value as a gap that a patch override may replace.
+    """
+    today = date.today()
+    stale = (today - override.as_of).days > _STALE_OVERRIDE_DAYS
+    if stale:
+        profile.warnings.append(
+            f"Override for {profile.ticker} is {(today - override.as_of).days} "
+            f"days old (as_of={override.as_of}). Consider updating."
+        )
+
+    prov = FieldProvenance(
+        source="override",
+        as_of=override.as_of,
+        confidence=Confidence.HIGH if not stale else Confidence.MEDIUM,
+    )
+
+    if override.mode == "replace":
+        if override.asset_class is not None:
+            profile.asset_class = override.asset_class
+            profile.classification_confidence = prov.confidence
+            profile.classification_rule = "override:replace"
+            profile.provenance["asset_class"] = prov
+        if override.sector is not None:
+            profile.sector_focus = override.sector
+            profile.provenance["sector_focus"] = prov
+        if override.geography is not None:
+            profile.geography = override.geography
+            profile.provenance["geography"] = prov
+        if override.duration is not None:
+            profile.duration_bucket = override.duration
+            profile.provenance["duration_bucket"] = prov
+        if override.credit_quality is not None:
+            profile.credit_quality = override.credit_quality
+            profile.provenance["credit_quality"] = prov
+    else:
+        # Patch: override fills gaps only (except asset_class always wins)
+        if override.asset_class is not None:
+            profile.asset_class = override.asset_class
+            profile.classification_confidence = prov.confidence
+            profile.classification_rule = "override:patch"
+            profile.provenance["asset_class"] = prov
+        if override.sector is not None and not profile.sector_focus:
+            profile.sector_focus = override.sector
+            profile.provenance["sector_focus"] = prov
+        if override.geography is not None and profile.geography == "US":
+            profile.geography = override.geography
+            profile.provenance["geography"] = prov
+        if override.duration is not None and not profile.duration_bucket:
+            profile.duration_bucket = override.duration
+            profile.provenance["duration_bucket"] = prov
+        if (
+            override.credit_quality is not None
+            and not profile.credit_quality
+        ):
+            profile.credit_quality = override.credit_quality
+            profile.provenance["credit_quality"] = prov
+
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# ETF Service
+# ---------------------------------------------------------------------------
+
+
+class ETFService:
+    """Classifies ETFs using Yahoo Finance with manual override support.
+
+    All yfinance calls dispatched to threads. Results cached per-ticker.
+    """
+
+    def __init__(
+        self,
+        cache_ttl: float = 3600.0,
+        override_store: OverrideStore | None = None,
+    ) -> None:
+        self._cache: dict[str, tuple[float, ETFProfileResponse]] = {}
+        self._cache_ttl = cache_ttl
+        self._cache_lock = threading.Lock()
+        self._override_store = override_store or OverrideStore()
+
+    def classify_sync(self, ticker: str) -> ETFProfileResponse:
+        """Classify an ETF synchronously (blocking yfinance call)."""
+        ticker = ticker.upper()
+
+        # Check cache
+        cached = self._cache_get(ticker)
+        if cached is not None:
+            return cached
+
+        # Fetch from Yahoo
+        profile = self._fetch_and_classify(ticker)
+
+        # Apply override if present
+        override = self._override_store.get(ticker)
+        if override:
+            profile = apply_override(profile, override)
+
+        resp = ETFProfileResponse(profile=profile)
+        self._cache_put(ticker, resp)
+        return resp
+
+    async def classify(self, ticker: str) -> ETFProfileResponse:
+        """Classify an ETF asynchronously (thread-dispatched)."""
+        return await asyncio.to_thread(self.classify_sync, ticker)
+
+    async def classify_multiple(
+        self, tickers: list[str]
+    ) -> dict[str, ETFProfileResponse]:
+        """Classify multiple ETFs concurrently."""
+        upper_tickers = [t.upper() for t in tickers]
+        tasks = [
+            asyncio.create_task(self.classify(t)) for t in upper_tickers
+        ]
+        gathered = await asyncio.gather(*tasks, return_exceptions=True)
+        results: dict[str, ETFProfileResponse] = {}
+        for ticker, result in zip(upper_tickers, gathered, strict=False):
+            if isinstance(result, Exception):
+                logger.warning(
+                    "Failed to classify %s: %s", ticker, result
+                )
+                results[ticker] = ETFProfileResponse(
+                    profile=ETFProfile(
+                        ticker=ticker,
+                        warnings=[f"Classification failed: {result}"],
+                    )
+                )
+            else:
+                results[ticker] = result
+        return results
+
+    def _fetch_and_classify(self, ticker: str) -> ETFProfile:
+        """Fetch yfinance info and classify."""
+        try:
+            yf_ticker = yf.Ticker(ticker)
+            info = yf_ticker.info or {}
+        except Exception as exc:
+            logger.warning("yfinance fetch failed for %s: %s", ticker, exc)
+            return ETFProfile(
+                ticker=ticker,
+                warnings=[f"Yahoo Finance fetch failed: {exc}"],
+            )
+
+        if not info:
+            return ETFProfile(
+                ticker=ticker,
+                warnings=["No data returned from Yahoo Finance"],
+            )
+
+        quote_type = info.get("quoteType")
+        qt_upper = (
+            quote_type.strip().upper()
+            if isinstance(quote_type, str)
+            else None
+        )
+        if qt_upper != "ETF":
+            warning = (
+                f"quoteType is '{quote_type}', not ETF"
+                if quote_type is not None
+                else "quoteType missing; cannot confirm ETF"
+            )
+            return ETFProfile(ticker=ticker, warnings=[warning])
+
+        return classify_from_yahoo(info)
+
+    # -- Cache helpers (thread-safe) --
+
+    def _cache_get(self, key: str) -> ETFProfileResponse | None:
+        with self._cache_lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                return None
+            ts, resp = entry
+            if time.monotonic() - ts > self._cache_ttl:
+                self._cache.pop(key, None)
+                return None
+            copy = resp.model_copy(deep=True)
+            copy.served_from_cache = True
+            return copy
+
+    def _cache_put(self, key: str, resp: ETFProfileResponse) -> None:
+        with self._cache_lock:
+            self._cache[key] = (
+                time.monotonic(),
+                resp.model_copy(deep=True),
+            )

--- a/agents/src/application/data_services/etf_service.py
+++ b/agents/src/application/data_services/etf_service.py
@@ -241,7 +241,9 @@ class OverrideStore:
     """Loads/saves ETF overrides from persistent storage.
 
     Uses a threading lock for concurrent write safety and fsync
-    for durability before replacing the target file.
+    for durability before replacing the target file. Thread-safe
+    public methods are `get`, `set`, and `remove`. The `_save`
+    helper is private and always called under the lock.
     """
 
     def __init__(self, path: Path = OVERRIDES_FILE) -> None:
@@ -259,7 +261,7 @@ class OverrideStore:
             logger.warning("Corrupt overrides file %s: %s", self._path, exc)
             return OverridesFile()
 
-    def save(self, data: OverridesFile) -> None:
+    def _save(self, data: OverridesFile) -> None:
         """Atomic write to disk with fsync for durability."""
         self._path.parent.mkdir(parents=True, exist_ok=True)
         tmp = self._path.with_suffix(".tmp")
@@ -288,7 +290,7 @@ class OverrideStore:
         with self._lock:
             data = self.load()
             data.overrides[ticker.upper()] = override
-            self.save(data)
+            self._save(data)
 
     def remove(self, ticker: str) -> bool:
         """Remove override. Returns True if existed."""
@@ -296,7 +298,7 @@ class OverrideStore:
             data = self.load()
             removed = data.overrides.pop(ticker.upper(), None) is not None
             if removed:
-                self.save(data)
+                self._save(data)
             return removed
 
 
@@ -522,6 +524,8 @@ class ETFService:
     All yfinance calls dispatched to threads. Results cached per-ticker.
     """
 
+    _MAX_CONCURRENT_CLASSIFY = 10
+
     def __init__(
         self,
         cache_ttl: float = 3600.0,
@@ -545,8 +549,9 @@ class ETFService:
             override = self._override_store.get(ticker)
             if override:
                 profile = apply_override(profile, override)
-            return ETFProfileResponse(
-                profile=profile, served_from_cache=True
+            return cached.model_copy(
+                deep=True,
+                update={"profile": profile, "served_from_cache": True},
             )
 
         # Fetch from Yahoo and cache the provider-derived profile only.
@@ -570,11 +575,15 @@ class ETFService:
     async def classify_multiple(
         self, tickers: list[str]
     ) -> dict[str, ETFProfileResponse]:
-        """Classify multiple ETFs concurrently."""
+        """Classify multiple ETFs concurrently (bounded concurrency)."""
+        sem = asyncio.Semaphore(self._MAX_CONCURRENT_CLASSIFY)
         upper_tickers = [t.upper() for t in tickers]
-        tasks = [
-            asyncio.create_task(self.classify(t)) for t in upper_tickers
-        ]
+
+        async def _limited(t: str) -> ETFProfileResponse:
+            async with sem:
+                return await self.classify(t)
+
+        tasks = [asyncio.create_task(_limited(t)) for t in upper_tickers]
         gathered = await asyncio.gather(*tasks, return_exceptions=True)
         results: dict[str, ETFProfileResponse] = {}
         for ticker, result in zip(upper_tickers, gathered, strict=False):

--- a/agents/src/application/data_services/etf_service.py
+++ b/agents/src/application/data_services/etf_service.py
@@ -125,7 +125,7 @@ _KEYWORD_RULES: list[tuple[list[str], AssetClass, Confidence]] = [
         AssetClass.IG_CORPORATE,
         Confidence.MEDIUM,
     ),
-    (["emerging", "em "], AssetClass.EMERGING_MARKETS, Confidence.MEDIUM),
+    (["emerging", "emerging markets"], AssetClass.EMERGING_MARKETS, Confidence.MEDIUM),
     (
         ["international", "foreign", "ex-us", "world ex", "eafe"],
         AssetClass.INTL_DEVELOPED,
@@ -271,6 +271,12 @@ class OverrideStore:
         finally:
             os.close(fd)
         tmp.replace(self._path)
+        # fsync parent directory to persist the rename
+        dir_fd = os.open(str(self._path.parent), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
 
     def get(self, ticker: str) -> ETFOverride | None:
         """Get override for a single ticker."""
@@ -385,7 +391,12 @@ def classify_from_yahoo(info: dict[str, object]) -> ETFProfile:
 
 
 def _extract_diagnostics(profile: ETFProfile, category: str) -> None:
-    """Extract cap_size, style, geography from category string."""
+    """Extract diagnostic attributes from a category string.
+
+    May populate `cap_size`, `style`, `geography`, and
+    `duration_bucket` on the provided profile when those hints are
+    present in the category text.
+    """
     cat_lower = category.lower()
 
     # Bond categories should not get equity-style diagnostics.
@@ -437,9 +448,10 @@ def apply_override(
     """Apply a manual override to an ETF profile.
 
     In 'replace' mode, provided override fields replace provider values.
-    In 'patch' mode, override fields are only used to fill provider gaps;
-    existing provider values are preserved. Geography also treats a default
-    "US" value as a gap that a patch override may replace.
+    In 'patch' mode, override fields are used to fill provider gaps, except
+    `asset_class`, which is treated as authoritative and replaces any
+    existing provider classification when supplied. Geography also treats a
+    default "US" value as a gap that a patch override may replace.
     """
     today = date.today()
     stale = (today - override.as_of).days > _STALE_OVERRIDE_DAYS
@@ -524,22 +536,32 @@ class ETFService:
         """Classify an ETF synchronously (blocking yfinance call)."""
         ticker = ticker.upper()
 
-        # Check cache
+        # Check cache for the provider-derived profile, then apply the
+        # latest override on a copy so override changes are visible
+        # immediately without mutating the cached base result.
         cached = self._cache_get(ticker)
         if cached is not None:
-            return cached
+            profile = cached.profile.model_copy(deep=True)
+            override = self._override_store.get(ticker)
+            if override:
+                profile = apply_override(profile, override)
+            return ETFProfileResponse(
+                profile=profile, served_from_cache=True
+            )
 
-        # Fetch from Yahoo
+        # Fetch from Yahoo and cache the provider-derived profile only.
         profile = self._fetch_and_classify(ticker)
+        base_response = ETFProfileResponse(profile=profile)
+        self._cache_put(ticker, base_response)
 
-        # Apply override if present
+        # Apply override if present to a copy so the cache remains the
+        # unmodified provider-derived result.
+        effective_profile = profile.model_copy(deep=True)
         override = self._override_store.get(ticker)
         if override:
-            profile = apply_override(profile, override)
+            effective_profile = apply_override(effective_profile, override)
 
-        resp = ETFProfileResponse(profile=profile)
-        self._cache_put(ticker, resp)
-        return resp
+        return ETFProfileResponse(profile=effective_profile)
 
     async def classify(self, ticker: str) -> ETFProfileResponse:
         """Classify an ETF asynchronously (thread-dispatched)."""

--- a/agents/src/application/data_services/etf_service.py
+++ b/agents/src/application/data_services/etf_service.py
@@ -283,12 +283,23 @@ class OverrideStore:
         )
         tmp_fd, tmp_path = fd[0], Path(fd[1])
         try:
-            os.write(tmp_fd, content)
-            os.fsync(tmp_fd)
-        finally:
-            os.close(tmp_fd)
-        os.chmod(str(tmp_path), 0o600)
-        tmp_path.replace(self._path)
+            try:
+                os.write(tmp_fd, content)
+                os.fsync(tmp_fd)
+            finally:
+                os.close(tmp_fd)
+            os.chmod(str(tmp_path), 0o600)
+            tmp_path.replace(self._path)
+        except Exception:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError as cleanup_exc:
+                logger.warning(
+                    "Could not remove temp file %s: %s",
+                    tmp_path,
+                    cleanup_exc,
+                )
+            raise
         # Best-effort fsync of parent directory to persist the rename.
         # Some platforms/filesystems do not support this.
         dir_fd: int | None = None
@@ -430,6 +441,15 @@ def _extract_diagnostics(profile: ETFProfile, category: str) -> None:
     """
     cat_lower = category.lower()
 
+    # Detect "ex-<region>" exclusion patterns so we don't tag a
+    # geography that the category explicitly excludes.
+    def _excluded(region: str) -> bool:
+        """Return True if category says 'ex-<region>' (excluding it)."""
+        return (
+            f"ex-{region}" in cat_lower
+            or f"ex {region}" in cat_lower
+        )
+
     # Bond categories should not get equity-style diagnostics.
     _bond_hints = (
         "bond", "government", "treasury", "corporate", "high yield",
@@ -452,19 +472,20 @@ def _extract_diagnostics(profile: ETFProfile, category: str) -> None:
         elif "blend" in cat_lower:
             profile.style = "blend"
 
-    ex_japan = "ex-japan" in cat_lower or "ex japan" in cat_lower
-
     if "foreign" in cat_lower or "international" in cat_lower:
         profile.geography = "international"
-    elif "emerging" in cat_lower:
+    elif "emerging" in cat_lower and not _excluded("emerging"):
         profile.geography = "emerging"
-    elif "europe" in cat_lower:
+    elif "europe" in cat_lower and not _excluded("europe"):
         profile.geography = "europe"
-    elif "japan" in cat_lower and not ex_japan:
+    elif "japan" in cat_lower and not _excluded("japan"):
         profile.geography = "japan"
-    elif "china" in cat_lower or "india" in cat_lower:
+    elif (
+        ("china" in cat_lower and not _excluded("china"))
+        or ("india" in cat_lower and not _excluded("india"))
+    ):
         profile.geography = "emerging"
-    elif "latin" in cat_lower:
+    elif "latin" in cat_lower and not _excluded("latin"):
         profile.geography = "emerging"
 
     if "short" in cat_lower:

--- a/agents/tests/test_etf_service.py
+++ b/agents/tests/test_etf_service.py
@@ -229,6 +229,12 @@ class TestExtractDiagnostics:
         _extract_diagnostics(profile, "China Region")
         assert profile.geography == "emerging"
 
+    def test_ex_japan_not_tagged_japan(self) -> None:
+        """'Pacific/Asia ex-Japan Stk' should not set geography to japan."""
+        profile = self._base_profile()
+        _extract_diagnostics(profile, "Pacific/Asia ex-Japan Stk")
+        assert profile.geography != "japan"
+
 
 class TestOverrideModels:
     """Tests for override Pydantic models."""

--- a/agents/tests/test_etf_service.py
+++ b/agents/tests/test_etf_service.py
@@ -235,6 +235,27 @@ class TestExtractDiagnostics:
         _extract_diagnostics(profile, "Pacific/Asia ex-Japan Stk")
         assert profile.geography != "japan"
 
+    def test_ex_china_not_tagged_emerging(self) -> None:
+        profile = self._base_profile()
+        _extract_diagnostics(profile, "EM ex-China")
+        assert profile.geography != "emerging"
+
+    def test_ex_europe_not_tagged_europe(self) -> None:
+        profile = self._base_profile()
+        _extract_diagnostics(profile, "World ex-Europe")
+        assert profile.geography != "europe"
+
+    def test_japan_stock_tagged_japan(self) -> None:
+        """Positive case: 'Japan Stock' should set geography to japan."""
+        profile = self._base_profile()
+        _extract_diagnostics(profile, "Japan Stock")
+        assert profile.geography == "japan"
+
+    def test_europe_stock_tagged_europe(self) -> None:
+        profile = self._base_profile()
+        _extract_diagnostics(profile, "Europe Stock")
+        assert profile.geography == "europe"
+
 
 class TestOverrideModels:
     """Tests for override Pydantic models."""

--- a/agents/tests/test_etf_service.py
+++ b/agents/tests/test_etf_service.py
@@ -1,0 +1,557 @@
+"""Tests for ETF classification and taxonomy service."""
+
+import json
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.application.contracts.household import AssetClass
+from src.application.data_services.etf_service import (
+    CATEGORY_MAP,
+    Confidence,
+    ETFOverride,
+    ETFProfile,
+    ETFService,
+    OverrideStore,
+    _extract_diagnostics,
+    apply_override,
+    classify_from_yahoo,
+)
+
+# ---------------------------------------------------------------------------
+# Golden corpus — one representative ETF per canonical asset class
+# ---------------------------------------------------------------------------
+
+_AC = AssetClass
+_C = Confidence
+
+_GOLDEN_CORPUS: list[
+    tuple[str, str, str, AssetClass, Confidence]
+] = [
+    ("SPY", "SPDR S&P 500 ETF", "Large Blend",
+     _AC.US_EQUITY, _C.HIGH),
+    ("IWM", "iShares Russell 2000 ETF", "Small Blend",
+     _AC.US_EQUITY, _C.HIGH),
+    ("VGK", "Vanguard FTSE Europe ETF", "Europe Stock",
+     _AC.INTL_DEVELOPED, _C.HIGH),
+    ("EFA", "iShares MSCI EAFE ETF", "Foreign Large Blend",
+     _AC.INTL_DEVELOPED, _C.HIGH),
+    ("VWO", "Vanguard FTSE EM ETF", "Diversified Emerging Mkts",
+     _AC.EMERGING_MARKETS, _C.HIGH),
+    ("SHY", "iShares 1-3Y Treasury", "Short Government",
+     _AC.US_TREASURIES, _C.HIGH),
+    ("TLT", "iShares 20+Y Treasury", "Long Government",
+     _AC.US_TREASURIES, _C.HIGH),
+    ("LQD", "iShares IG Corp Bond ETF", "Corporate Bond",
+     _AC.IG_CORPORATE, _C.HIGH),
+    ("HYG", "iShares HY Corp Bond ETF", "High Yield Bond",
+     _AC.HIGH_YIELD, _C.HIGH),
+    ("TIP", "iShares TIPS Bond ETF", "Inflation-Protected Bond",
+     _AC.TIPS, _C.HIGH),
+    ("VNQ", "Vanguard Real Estate ETF", "Real Estate",
+     _AC.REAL_ASSETS, _C.HIGH),
+    ("GLD", "SPDR Gold Shares", "Commodities Focused",
+     _AC.REAL_ASSETS, _C.HIGH),
+]
+
+
+class TestClassifyFromYahoo:
+    """Tests for the core classification logic."""
+
+    @pytest.mark.parametrize(
+        "ticker,name,category,expected_class,expected_confidence",
+        _GOLDEN_CORPUS,
+        ids=[c[0] for c in _GOLDEN_CORPUS],
+    )
+    def test_golden_corpus(
+        self,
+        ticker: str,
+        name: str,
+        category: str,
+        expected_class: AssetClass,
+        expected_confidence: Confidence,
+    ) -> None:
+        info = {
+            "symbol": ticker,
+            "longName": name,
+            "category": category,
+        }
+        profile = classify_from_yahoo(info)
+        assert profile.asset_class == expected_class
+        assert profile.classification_confidence == expected_confidence
+        assert profile.ticker == ticker
+
+    def test_keyword_fallback_when_category_missing(self) -> None:
+        info = {
+            "symbol": "VXUS",
+            "longName": "Vanguard Total International Stock ETF",
+            "category": "",
+        }
+        profile = classify_from_yahoo(info)
+        assert profile.asset_class == AssetClass.INTL_DEVELOPED
+        assert profile.classification_confidence == Confidence.MEDIUM
+        assert "keyword:" in profile.classification_rule
+
+    def test_keyword_fallback_treasury(self) -> None:
+        info = {
+            "symbol": "GOVT",
+            "longName": "iShares US Treasury Bond ETF",
+            "category": "Some Unknown Category",
+        }
+        profile = classify_from_yahoo(info)
+        assert profile.asset_class == AssetClass.US_TREASURIES
+
+    def test_unclassified_when_no_match(self) -> None:
+        info = {
+            "symbol": "XYZ",
+            "longName": "Exotic Leveraged Volatility Fund",
+            "category": "Trading--Leveraged Equity",
+        }
+        profile = classify_from_yahoo(info)
+        assert profile.asset_class is None
+        assert profile.classification_confidence == Confidence.UNCLASSIFIED
+        assert len(profile.warnings) > 0
+
+    def test_diagnostic_extraction_large_growth(self) -> None:
+        info = {
+            "symbol": "VUG",
+            "longName": "Vanguard Growth ETF",
+            "category": "Large Growth",
+        }
+        profile = classify_from_yahoo(info)
+        assert profile.cap_size == "large"
+        assert profile.style == "growth"
+
+    def test_diagnostic_extraction_foreign(self) -> None:
+        info = {
+            "symbol": "VEA",
+            "longName": "Vanguard FTSE Developed Markets ETF",
+            "category": "Foreign Large Blend",
+        }
+        profile = classify_from_yahoo(info)
+        assert profile.geography == "international"
+        assert profile.cap_size == "large"
+        assert profile.style == "blend"
+
+    def test_diagnostic_extraction_bond_duration(self) -> None:
+        info = {
+            "symbol": "IEF",
+            "longName": "iShares 7-10 Year Treasury Bond ETF",
+            "category": "Intermediate Government",
+        }
+        profile = classify_from_yahoo(info)
+        assert profile.duration_bucket == "intermediate"
+
+    def test_expense_ratio_parsed(self) -> None:
+        info = {
+            "symbol": "VTI",
+            "longName": "Vanguard Total Stock Market ETF",
+            "category": "Large Blend",
+            "annualReportExpenseRatio": 0.0003,
+        }
+        profile = classify_from_yahoo(info)
+        assert profile.expense_ratio == Decimal("0.0003")
+
+    def test_aum_parsed(self) -> None:
+        info = {
+            "symbol": "SPY",
+            "longName": "SPDR S&P 500 ETF",
+            "category": "Large Blend",
+            "totalAssets": 500000000000,
+        }
+        profile = classify_from_yahoo(info)
+        assert profile.aum == Decimal("500000000000")
+
+    def test_provenance_tracked(self) -> None:
+        info = {
+            "symbol": "SPY",
+            "longName": "SPDR S&P 500 ETF",
+            "category": "Large Blend",
+        }
+        profile = classify_from_yahoo(info)
+        assert "asset_class" in profile.provenance
+        assert profile.provenance["asset_class"].source == "yahoo"
+        assert "name" in profile.provenance
+
+    def test_inception_date_from_timestamp(self) -> None:
+        info = {
+            "symbol": "SPY",
+            "longName": "SPDR S&P 500 ETF",
+            "category": "Large Blend",
+            "fundInceptionDate": 759024000,  # 1994-01-22
+        }
+        profile = classify_from_yahoo(info)
+        assert profile.inception_date is not None
+        assert profile.inception_date.year == 1994
+
+    def test_empty_info_returns_minimal_profile(self) -> None:
+        profile = classify_from_yahoo({})
+        assert profile.ticker == ""
+        assert profile.asset_class is None
+
+
+class TestExtractDiagnostics:
+    """Tests for diagnostic extraction from category strings."""
+
+    def _base_profile(self) -> ETFProfile:
+        return ETFProfile(ticker="TEST", name="Test ETF")
+
+    def test_mid_cap_equity(self) -> None:
+        profile = self._base_profile()
+        _extract_diagnostics(profile, "Mid-Cap Blend")
+        assert profile.cap_size == "mid"
+        assert profile.style == "blend"
+
+    def test_bond_category_skips_equity_diagnostics(self) -> None:
+        """Intermediate Government should not set cap_size='mid'."""
+        profile = self._base_profile()
+        _extract_diagnostics(profile, "Intermediate Government")
+        assert profile.cap_size == ""
+        assert profile.duration_bucket == "intermediate"
+
+    def test_corporate_bond_no_equity_diagnostics(self) -> None:
+        profile = self._base_profile()
+        _extract_diagnostics(profile, "Corporate Bond")
+        assert profile.cap_size == ""
+        assert profile.style == ""
+
+    def test_geography_international(self) -> None:
+        profile = self._base_profile()
+        _extract_diagnostics(profile, "Foreign Large Blend")
+        assert profile.geography == "international"
+        assert profile.cap_size == "large"
+
+    def test_geography_emerging(self) -> None:
+        profile = self._base_profile()
+        _extract_diagnostics(profile, "China Region")
+        assert profile.geography == "emerging"
+
+
+class TestOverrideModels:
+    """Tests for override Pydantic models."""
+
+    def test_invalid_mode_rejected(self) -> None:
+        with pytest.raises(ValueError, match="mode"):
+            ETFOverride(as_of=date.today(), mode="invalid")
+
+    def test_replace_mode_accepted(self) -> None:
+        override = ETFOverride(as_of=date.today(), mode="replace")
+        assert override.mode == "replace"
+
+
+class TestApplyOverride:
+    """Tests for override application logic."""
+
+    def _base_profile(self) -> ETFProfile:
+        return ETFProfile(
+            ticker="TEST",
+            name="Test ETF",
+            asset_class=AssetClass.US_EQUITY,
+            classification_confidence=Confidence.MEDIUM,
+            geography="US",
+        )
+
+    def test_replace_asset_class(self) -> None:
+        profile = self._base_profile()
+        override = ETFOverride(
+            as_of=date.today(),
+            asset_class=AssetClass.REAL_ASSETS,
+        )
+        result = apply_override(profile, override)
+        assert result.asset_class == AssetClass.REAL_ASSETS
+        assert result.provenance["asset_class"].source == "override"
+
+    def test_replace_geography(self) -> None:
+        profile = self._base_profile()
+        override = ETFOverride(
+            as_of=date.today(),
+            geography="emerging",
+        )
+        result = apply_override(profile, override)
+        assert result.geography == "emerging"
+
+    def test_stale_override_warns(self) -> None:
+        profile = self._base_profile()
+        old_date = date.today() - timedelta(days=100)
+        override = ETFOverride(
+            as_of=old_date,
+            asset_class=AssetClass.TIPS,
+        )
+        result = apply_override(profile, override)
+        assert result.asset_class == AssetClass.TIPS
+        assert any("days old" in w for w in result.warnings)
+        assert result.classification_confidence == Confidence.MEDIUM
+
+    def test_fresh_override_high_confidence(self) -> None:
+        profile = self._base_profile()
+        override = ETFOverride(
+            as_of=date.today(),
+            asset_class=AssetClass.TIPS,
+        )
+        result = apply_override(profile, override)
+        assert result.classification_confidence == Confidence.HIGH
+
+    def test_patch_mode_fills_gaps(self) -> None:
+        profile = self._base_profile()
+        profile.sector_focus = ""
+        override = ETFOverride(
+            as_of=date.today(),
+            mode="patch",
+            sector="technology",
+        )
+        result = apply_override(profile, override)
+        assert result.sector_focus == "technology"
+
+    def test_patch_mode_preserves_existing(self) -> None:
+        profile = self._base_profile()
+        profile.sector_focus = "healthcare"
+        profile.duration_bucket = "intermediate"
+        override = ETFOverride(
+            as_of=date.today(),
+            mode="patch",
+            sector="technology",
+            duration="long",
+        )
+        result = apply_override(profile, override)
+        # Patch should NOT overwrite existing values
+        assert result.sector_focus == "healthcare"
+        assert result.duration_bucket == "intermediate"
+
+
+class TestOverrideStore:
+    """Tests for persistent override storage."""
+
+    def test_load_empty_when_missing(self, tmp_path: Path) -> None:
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        data = store.load()
+        assert len(data.overrides) == 0
+
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        path = tmp_path / "overrides.json"
+        store = OverrideStore(path=path)
+        override = ETFOverride(
+            as_of=date.today(),
+            asset_class=AssetClass.TIPS,
+        )
+        store.set("TIP", override)
+        loaded = store.get("TIP")
+        assert loaded is not None
+        assert loaded.asset_class == AssetClass.TIPS
+
+    def test_ticker_uppercased(self, tmp_path: Path) -> None:
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        store.set("tip", ETFOverride(as_of=date.today()))
+        assert store.get("TIP") is not None
+
+    def test_remove(self, tmp_path: Path) -> None:
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        store.set("SPY", ETFOverride(as_of=date.today()))
+        assert store.remove("SPY") is True
+        assert store.get("SPY") is None
+        assert store.remove("SPY") is False
+
+    def test_corrupt_file_returns_empty(self, tmp_path: Path) -> None:
+        path = tmp_path / "overrides.json"
+        path.write_text("not json!", encoding="utf-8")
+        store = OverrideStore(path=path)
+        data = store.load()
+        assert len(data.overrides) == 0
+
+    def test_schema_version_preserved(self, tmp_path: Path) -> None:
+        path = tmp_path / "overrides.json"
+        store = OverrideStore(path=path)
+        store.set("SPY", ETFOverride(as_of=date.today()))
+        raw = json.loads(path.read_text())
+        assert raw["schema_version"] == 1
+
+    def test_save_calls_fsync(self, tmp_path: Path) -> None:
+        """Save must fsync the temp file before replacing target."""
+        path = tmp_path / "overrides.json"
+        store = OverrideStore(path=path)
+        with patch("src.application.data_services.etf_service.os.fsync") as mock_fsync:
+            store.set("SPY", ETFOverride(as_of=date.today()))
+        assert mock_fsync.call_count == 1
+
+
+class TestETFService:
+    """Tests for the main service class."""
+
+    def _mock_info(
+        self,
+        ticker: str = "SPY",
+        name: str = "SPDR S&P 500 ETF",
+        category: str = "Large Blend",
+    ) -> dict:
+        return {
+            "symbol": ticker,
+            "longName": name,
+            "category": category,
+            "quoteType": "ETF",
+            "annualReportExpenseRatio": 0.0009,
+            "totalAssets": 500_000_000_000,
+            "fundFamily": "SPDR State Street Global Advisors",
+        }
+
+    def test_classify_sync_caches(self, tmp_path: Path) -> None:
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        service = ETFService(override_store=store)
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = self._mock_info()
+
+        _yf = "src.application.data_services.etf_service.yf.Ticker"
+        with patch(_yf, return_value=mock_ticker) as yf_mock:
+            r1 = service.classify_sync("SPY")
+            r2 = service.classify_sync("SPY")
+
+        assert r1.profile.asset_class == AssetClass.US_EQUITY
+        assert r1.served_from_cache is False
+        assert r2.served_from_cache is True
+        yf_mock.assert_called_once_with("SPY")
+
+    def test_classify_sync_applies_override(
+        self, tmp_path: Path
+    ) -> None:
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        store.set(
+            "XYZ",
+            ETFOverride(
+                as_of=date.today(),
+                asset_class=AssetClass.TIPS,
+            ),
+        )
+        service = ETFService(override_store=store)
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = self._mock_info(
+            ticker="XYZ", category="Unknown Category"
+        )
+
+        with patch("src.application.data_services.etf_service.yf.Ticker", return_value=mock_ticker):
+            result = service.classify_sync("XYZ")
+
+        assert result.profile.asset_class == AssetClass.TIPS
+
+    def test_classify_sync_handles_yfinance_failure(
+        self, tmp_path: Path
+    ) -> None:
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        service = ETFService(override_store=store)
+
+        with patch(
+            "src.application.data_services.etf_service.yf.Ticker",
+            side_effect=Exception("network error"),
+        ):
+            result = service.classify_sync("FAIL")
+
+        assert result.profile.ticker == "FAIL"
+        assert len(result.profile.warnings) > 0
+
+    def test_classify_sync_handles_empty_info(
+        self, tmp_path: Path
+    ) -> None:
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        service = ETFService(override_store=store)
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = {}
+
+        with patch("src.application.data_services.etf_service.yf.Ticker", return_value=mock_ticker):
+            result = service.classify_sync("EMPTY")
+
+        assert result.profile.ticker == "EMPTY"
+        assert len(result.profile.warnings) > 0
+
+    def test_rejects_non_etf_quote_type(
+        self, tmp_path: Path
+    ) -> None:
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        service = ETFService(override_store=store)
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = {
+            "symbol": "AAPL",
+            "quoteType": "EQUITY",
+            "longName": "Apple Inc.",
+        }
+
+        _yf = "src.application.data_services.etf_service.yf.Ticker"
+        with patch(_yf, return_value=mock_ticker):
+            result = service.classify_sync("AAPL")
+
+        assert result.profile.asset_class is None
+        assert any("not ETF" in w for w in result.profile.warnings)
+
+    @pytest.mark.asyncio
+    async def test_classify_async(self, tmp_path: Path) -> None:
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        service = ETFService(override_store=store)
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = self._mock_info()
+
+        with patch("src.application.data_services.etf_service.yf.Ticker", return_value=mock_ticker):
+            result = await service.classify("SPY")
+
+        assert result.profile.asset_class == AssetClass.US_EQUITY
+
+    @pytest.mark.asyncio
+    async def test_classify_multiple(self, tmp_path: Path) -> None:
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        service = ETFService(override_store=store)
+
+        def make_ticker(symbol: str) -> MagicMock:
+            mock = MagicMock()
+            if symbol == "SPY":
+                mock.info = self._mock_info("SPY", "SPDR S&P 500", "Large Blend")
+            elif symbol == "TLT":
+                mock.info = self._mock_info("TLT", "iShares 20+ Year Treasury", "Long Government")
+            else:
+                mock.info = {}
+            return mock
+
+        with patch("src.application.data_services.etf_service.yf.Ticker", side_effect=make_ticker):
+            results = await service.classify_multiple(["SPY", "TLT"])
+
+        assert results["SPY"].profile.asset_class == AssetClass.US_EQUITY
+        assert results["TLT"].profile.asset_class == AssetClass.US_TREASURIES
+
+    def test_cache_expiry(self, tmp_path: Path) -> None:
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        service = ETFService(cache_ttl=10.0, override_store=store)
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = self._mock_info()
+
+        with patch("src.application.data_services.etf_service.yf.Ticker", return_value=mock_ticker):
+            service.classify_sync("SPY")
+
+        # Manually expire by manipulating cache entry
+        for key in service._cache:
+            ts, resp = service._cache[key]
+            service._cache[key] = (ts - 20, resp)
+
+        mock_ticker2 = MagicMock()
+        mock_ticker2.info = self._mock_info()
+        with patch(
+            "src.application.data_services.etf_service.yf.Ticker",
+            return_value=mock_ticker2,
+        ) as yf_mock:
+            r2 = service.classify_sync("SPY")
+            assert r2.served_from_cache is False
+            yf_mock.assert_called_once()
+
+
+class TestCategoryMapCoverage:
+    """Verify the category map has expected coverage."""
+
+    def test_all_asset_classes_represented(self) -> None:
+        """Every canonical AssetClass should appear in CATEGORY_MAP."""
+        mapped_classes = {v[0] for v in CATEGORY_MAP.values()}
+        for ac in AssetClass:
+            assert ac in mapped_classes, (
+                f"{ac} not represented in CATEGORY_MAP"
+            )

--- a/agents/tests/test_etf_service.py
+++ b/agents/tests/test_etf_service.py
@@ -373,7 +373,7 @@ class TestOverrideStore:
         store = OverrideStore(path=path)
         with patch("src.application.data_services.etf_service.os.fsync") as mock_fsync:
             store.set("SPY", ETFOverride(as_of=date.today()))
-        assert mock_fsync.call_count == 1
+        assert mock_fsync.call_count >= 1
 
 
 class TestETFService:
@@ -434,6 +434,37 @@ class TestETFService:
             result = service.classify_sync("XYZ")
 
         assert result.profile.asset_class == AssetClass.TIPS
+
+    def test_override_change_reflects_on_cached_profile(
+        self, tmp_path: Path
+    ) -> None:
+        """Overrides applied after caching should be visible immediately."""
+        store = OverrideStore(path=tmp_path / "overrides.json")
+        service = ETFService(override_store=store)
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = self._mock_info(ticker="SPY")
+        yf_path = "src.application.data_services.etf_service.yf.Ticker"
+
+        with patch(yf_path, return_value=mock_ticker):
+            r1 = service.classify_sync("SPY")
+
+        assert r1.profile.asset_class == AssetClass.US_EQUITY
+
+        # Add override after profile is cached
+        store.set(
+            "SPY",
+            ETFOverride(
+                as_of=date.today(),
+                asset_class=AssetClass.TIPS,
+            ),
+        )
+
+        with patch(yf_path, return_value=mock_ticker):
+            r2 = service.classify_sync("SPY")
+
+        # Override should be visible even on cached result
+        assert r2.profile.asset_class == AssetClass.TIPS
 
     def test_classify_sync_handles_yfinance_failure(
         self, tmp_path: Path


### PR DESCRIPTION
ETF classification and taxonomy service — maps ETF tickers to canonical asset classes using Yahoo Finance data with manual override support.

## Changes
- **ETFProfile** with per-field provenance (source, as_of, confidence)
- **classify_from_yahoo()** with 30+ category mappings, keyword fallback, UNCLASSIFIED confidence
- **quoteType=ETF validation** — warns on non-ETF instruments
- **OverrideStore** with atomic writes, fsync for durability, threading lock for concurrency
- **Bond-aware diagnostics** — skips equity-style diagnostics (cap_size, style) for bond categories
- **Manual override** support with replace/patch modes (patch fills gaps only)
- **52 tests** covering golden corpus, diagnostics, overrides, store, service

Closes #127
Part of #103