### PR TITLE
feat: Policy Allocation & Goals service

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,26 @@
 # Copilot Instructions
 
+## Response Rules
+
+- Be concise. Minimize chat output.
+- Do not generate summaries.
+
+## Critical Invariants
+
+These override all other rules. Verify compliance before every commit.
+
+1. **Never commit secrets** — no passwords, API keys, tokens, or credentials anywhere in the codebase.
+2. **Use `decimal.Decimal` for all monetary arithmetic** — never `float` for money.
+3. **Every code change must include tests.**
+4. **Never commit to `main`** — use worktrees and branches.
+5. **Run `npm run preflight` before every push.**
+6. **Use `datetime.now(UTC)` from `datetime`** — never `datetime.utcnow()` (deprecated).
+
 ## Project Context
 
-**finance-os** is a macro ETF portfolio intelligence system — macroeconomic outlook-driven investment evaluation and goal-driven portfolio rebalancing for a wealthy family ($2M–$10M investable). Monorepo with a TypeScript MCP server, Python agent framework, FastAPI web API, and React frontend.
+**finance-os** — macro ETF portfolio intelligence system. Macroeconomic outlook-driven investment evaluation and goal-driven portfolio rebalancing for a wealthy family ($2M–$10M investable). Monorepo: TypeScript MCP server, Python agent framework, FastAPI web API, React frontend.
 
-**Target persona**: Wealthy family that can retire anytime keeping their lifestyle comfortably. Capital preservation + moderate growth. Tax-efficient ETF portfolios. Not average, not ultra-rich.
+**Persona**: Wealthy family, capital preservation + moderate growth, 3–4% SWR, tax-efficient ETF portfolios, multi-generational.
 
 ## Architecture
 
@@ -17,9 +33,7 @@
 
 ### Agents (`agents/`) — Python
 - **Framework**: Custom agent base classes in `src/core/`
-- **LLM Gateway**: Pluggable inference client — supports Azure OpenAI, or skip when host LLM reasons (MCP path)
-- **Active Agents**: Macro regime, risk analyst, quant signal (kept from v1). Macro outlook, portfolio evaluator, rebalancer (new, in development).
-- **Retiring Agents**: Filing analyst, earnings interpreter, thesis guardian, adversarial (stock-picking focused — being removed after new UI is ready)
+- **LLM Gateway**: Pluggable inference client — Azure OpenAI, or skipped when host LLM reasons (MCP path)
 - **Application Layer**: `src/application/` — shared contracts (Pydantic), LLM gateway, services. CLI, MCP server, and Web API are thin wrappers.
 - **Quant Tools**: `src/tools/` — regression, factor analysis, Monte Carlo, Bayesian updates
 - **Data Pipelines**: `src/pipelines/` — FRED, market data, research digest
@@ -40,27 +54,12 @@
 
 ## LLM Inference Model
 
-Agents perform deterministic data processing and construct prompts but **do not call LLMs directly**. The LLM gateway in the application layer provides inference when needed:
+Agents do deterministic data processing and prompt construction — they do not call LLMs directly.
 
 | Path | LLM reasoning | Gateway |
 |---|---|---|
 | MCP (Copilot, Claude Desktop) | Host LLM reasons | Skipped |
-| CLI | LLM gateway calls provider | Used |
-| Web API | LLM gateway calls provider | Used |
-
-## Data Flow
-
-```
-External APIs (FRED, BLS, Treasury, IMF, World Bank, Yahoo Finance)
-        ↓
-Data Services (Python) → Provider Abstraction (freshness tracking)
-        ↓
-Application Layer (contracts + LLM gateway)
-        ↓
-Agents (Python) — macro outlook, portfolio evaluation, rebalancing
-        ↓
-Portfolio Intelligence (evaluation, recommendations, stress tests)
-```
+| CLI / Web API | LLM gateway calls provider | Used |
 
 ## Tech Stack
 
@@ -71,12 +70,9 @@ Portfolio Intelligence (evaluation, recommendations, stress tests)
 | Application Layer | Python, Pydantic 2.11+, pydantic-settings, azure-identity |
 | Agents | Python 3.12+ |
 | LLM Gateway | Pluggable — Azure OpenAI, or host LLM via MCP |
-| Data Sources | FRED, BLS, Treasury.gov, IMF, World Bank, Yahoo Finance |
 | CLI | Python (`finance-os` console script) |
-| Web API | Python (`finance-os-api` console script, FastAPI + uvicorn) |
+| Web API | FastAPI + uvicorn (`finance-os-api` console script) |
 | Web UI | React 19, TypeScript, Vite |
-| MCP Server entry | Python (`finance-os-mcp` console script, stdio transport) |
-| Copilot Skills | Markdown workflow definitions (`.github/skills/`) |
 | Testing | Vitest (TS), pytest (Python) |
 | CI/CD | GitHub Actions |
 
@@ -90,161 +86,138 @@ Two-layer taxonomy for ETF classification:
 
 ## Key Design Decisions
 
-1. **Policy-first**: Macro outlook applies bounded tilts around strategic allocation (IPS), never overrides it
-2. **Dimensioned evaluation**: No single "health score" — policy drift, concentration, macro alignment, liquidity, tax drag, scenario exposure
-3. **Phased rebalancing**: Directional → account-aware → tax-lot (increasing complexity)
-4. **Provider abstraction**: All data behind interfaces for future source upgrades; track freshness/confidence
-5. **Wealthy family persona**: 3–4% SWR, capital preservation priority, tax-efficiency, multi-generational
-6. **No social network data**: Only government, institutional, and market data sources
-7. **ETF-level, not stock-level**: All analysis at macro/asset-class/ETF granularity
-8. **Decimal precision**: All monetary/financial arithmetic uses `decimal.Decimal`, never `float`
+1. **Policy-first**: Macro outlook applies bounded tilts around strategic allocation (IPS), never overrides it.
+2. **Dimensioned evaluation**: No single "health score" — separate dimensions for drift, concentration, macro alignment, liquidity, tax drag, scenario exposure.
+3. **Phased rebalancing**: Directional → account-aware → tax-lot (increasing complexity).
+4. **Provider abstraction**: All data behind interfaces; track freshness/confidence.
+5. **No social network data**: Only government, institutional, and market data sources.
+6. **ETF-level, not stock-level**: All analysis at macro/asset-class/ETF granularity.
 
 ## Code Guidelines
 
 ### General
-- **ES Modules**: All TypeScript and JavaScript uses ESM (`"type": "module"`)
-- **Dependencies**: Minimize. Justify every new dependency.
-- **Dependency versions**: Always use the latest stable version. No legacy compatibility — legacy systems must fail. When a dependency ships a breaking change, update all consuming code to work with the new version. Never pin to old versions to avoid migration work. **Legacy compatibility is an anti-pattern.**
-- **No secrets**: See [Security](#security) section below.
-- **Error handling**: Graceful degradation. Never crash on malformed input — log warnings and continue.
+- Use ES Modules everywhere (`"type": "module"`).
+- Minimize dependencies. Justify every new one.
+- Always use the latest stable version of dependencies. Never pin old versions to avoid migration. Update consuming code on breaking changes.
+- Graceful degradation on malformed input — log warnings and continue, never crash.
 
 ### TypeScript (MCP Server)
-- Strict TypeScript (`"strict": true`)
-- Use `interface` over `type` for object shapes
-- Async/await everywhere, no raw promises
-- Each MCP tool is a self-contained module in `src/tools/`
-- Tool implementations must validate all inputs and return structured error responses
+- Strict mode (`"strict": true`). Use `interface` over `type` for object shapes.
+- Async/await everywhere. No raw promises.
+- Each MCP tool is a self-contained module in `src/tools/`. Validate all inputs; return structured error responses.
 
 ### Python (Agents)
-- Python 3.12+ with type hints everywhere (use native `X | Y`, `list[str]`, etc. — no `from __future__ import annotations`)
-- PEP 8, `snake_case` for functions/variables, `PascalCase` for classes
-- Docstrings on all public functions and classes (Google style)
-- Use `pathlib.Path` over `os.path`
-- `#!/usr/bin/env python3` shebang on executable scripts
+- Python 3.12+ with type hints everywhere. Use native `X | Y`, `list[str]` — no `from __future__ import annotations`.
+- PEP 8: `snake_case` for functions/variables, `PascalCase` for classes.
+- Google-style docstrings on all public functions and classes.
+- Use `pathlib.Path` over `os.path`.
 
 ### Financial Accuracy Rules
 
-These rules exist because this is financial software. Violations produce incorrect dollar amounts.
-
-1. **All monetary arithmetic** uses `decimal.Decimal` (Python) or a decimal library (TypeScript). Never use floating point for money.
-2. **Net flow, not gross**: Income shows `income - expense` per category; expense shows `expense - income`.
-3. **Data source attribution**: Every data point must trace to its source (API, filing, calculation).
-4. **Timestamp everything**: All market data, signals, and analysis must carry timestamps.
-5. **No stale data assumptions**: Always check data freshness before analysis.
-6. **Tax-lot integrity**: When multiple lots exist per position, never merge or average cost basis. Each lot retains its purchase date and per-share cost.
+1. **Net flow, not gross**: Income shows `income - expense` per category; expense shows `expense - income`.
+2. **Data source attribution**: Every data point must trace to its source (API, filing, calculation).
+3. **Timestamp everything**: All market data, signals, and analysis must carry timestamps.
+4. **No stale data**: Always check data freshness before analysis.
+5. **Tax-lot integrity**: Never merge or average cost basis across lots. Each lot retains its purchase date and per-share cost.
 
 ## Defensive Coding Checklist
 
-These rules are distilled from recurring code review findings. Apply them **before** pushing to reduce review cycles.
+### Quick Decision Table
+
+| Situation | Do this |
+|---|---|
+| Money/weights/amounts | `decimal.Decimal`, never `float` |
+| PATCH update | `model_fields_set` to detect explicit `None` vs absent |
+| Optional dict/list missing entries | Merge with defaults in `@model_validator` |
+| After `model_copy(update=...)` | Re-validate: `Model.model_validate(obj.model_dump())`, use the returned object |
+| Enum in error message | `enum_value.value`, not the enum member |
+| Writing persistent files | Atomic write pattern (see Safe File I/O) |
+| Mtime-based cache read | Return `model_copy(deep=True)` to prevent mutation leaking |
 
 ### Pydantic Model Discipline
 
-1. **String fields**: Every user-facing string field (`name`, `ticker`, etc.) must have `Field(min_length=1)` and a `@field_validator` that strips whitespace and rejects blank values.
-2. **Numeric bounds**: Every numeric field with domain constraints must validate its range (e.g., weights in `[0, 1]`, positive-only amounts). Don't rely on downstream consumers to catch out-of-range values.
-3. **Request models mirror entity invariants**: If an entity model (e.g., `Goal`) has validators (goal-type invariants, name stripping), the corresponding request model (`CreateGoalRequest`) must enforce the same rules. Invalid requests must fail at the API boundary, not deep in service code.
-4. **Optional collections need safe defaults**: When a dict/list field is optional, populate missing entries with sensible defaults in a `@model_validator`. A partial dict (e.g., 3 of 9 asset classes provided) must be merged with defaults, not left incomplete.
-5. **Type annotations match nullability**: If a field can be `None` at runtime (including via `model_construct`), the type annotation must include `| None`. Defensive guards (`x or {}`) are good but don't substitute for correct types.
-6. **`model_copy` bypasses validators**: After `model_copy(update=...)`, always re-validate through `Model.model_validate(obj.model_dump())` and use the returned object — the copy itself is unvalidated.
-7. **PATCH update semantics**: Use `model_fields_set` to distinguish "field was explicitly set to None" from "field was not provided". Never use `if value is not None` for PATCH-style partial updates — it makes clearing optional fields impossible.
-8. **Enum error messages**: Use `enum_value.value` (not the enum member itself) in user-facing error messages so API clients get clean strings like `"wealth_building"` instead of `"GoalType.WEALTH_BUILDING"`.
+1. **String fields**: Add `Field(min_length=1)` + `@field_validator` that strips whitespace and rejects blank.
+2. **Numeric bounds**: Validate domain range on every constrained numeric field (e.g., weights in `[0, 1]`).
+3. **Request models mirror entity invariants**: If `Goal` validates goal-type invariants, `CreateGoalRequest` must too. Reject invalid input at the API boundary.
+4. **Optional collections**: Populate missing entries with defaults in `@model_validator`. A partial dict must be merged with defaults, not left incomplete.
+5. **Nullability**: If a field can be `None` at runtime (including via `model_construct`), annotate as `| None`.
+6. **`model_copy` bypasses validators** — always re-validate afterward and use the returned object.
+7. **PATCH semantics**: Use `model_fields_set` to distinguish "explicitly set to None" from "not provided". Never use `if value is not None`.
+8. **Enum in error messages**: Use `.value` so clients see `"wealth_building"` not `"GoalType.WEALTH_BUILDING"`.
 
 ### Safe File I/O Pattern
 
-When writing files atomically (the standard pattern for services with persistent state):
+Atomic write pattern for services with persistent state:
 
-1. **Use `os.fdopen`** (not raw `os.write`) to prevent short writes that silently truncate data.
-2. **Catch `BaseException`** (not `Exception`) in fd/lock cleanup so `KeyboardInterrupt` doesn't leak file descriptors.
-3. **Use `st_mtime_ns`** (int) for mtime-based caching, never `st_mtime` (float) — float equality is unreliable across filesystems.
-4. **Return deep copies** from mtime caches (`model_copy(deep=True)`). If callers mutate the cached object and `_write_atomic` fails, the in-memory cache diverges from disk.
-5. **File permissions**: `0o600` for sensitive data files. Best-effort `fsync` on parent directory with `try/except OSError`.
+1. Use `os.fdopen` (not raw `os.write`) — `os.write` can short-write, silently truncating data.
+2. Catch `BaseException` (not `Exception`) in fd/lock cleanup — `KeyboardInterrupt` leaks fds otherwise.
+3. Use `st_mtime_ns` (int) for mtime caching — `st_mtime` (float) equality is unreliable across filesystems.
+4. Return deep copies from mtime caches — prevents mutation/disk divergence if `_write_atomic` fails after cache update.
+5. Use `0o600` permissions for sensitive files. Best-effort `fsync` on parent directory.
 
-Reference implementation: `PolicyService._write_atomic()`, `OverrideStore._save()`.
+Reference: `PolicyService._write_atomic()`, `OverrideStore._save()`.
 
-### Docstrings and Descriptions
+### Docstrings and PR Descriptions
 
-1. **Docstrings must match behavior exactly.** If a method raises on not-found, don't say "returns False". If a method caches, don't say "loads from disk on every call".
-2. **PR descriptions must match the code being shipped.** Don't claim features (caching, validation) that aren't implemented yet.
+- Docstrings must match behavior exactly. If a method raises on not-found, do not document "returns False".
+- PR descriptions must match the code being shipped. Do not claim unimplemented features.
 
 ## Security
 
-Security is not optional. This is financial software handling sensitive portfolio data.
-
 ### No Portable Credentials
 
-- **No passwords, secrets, API keys, tokens, or credentials anywhere in the codebase** — not in source files, config files, environment files, comments, tests, documentation, or commit messages.
-- **No `.env` files committed to the repository.** Use `.env.example` with placeholder keys only. Actual `.env` files must be in `.gitignore`.
-- **No GitHub Secrets for PATs or service credentials.** Use only the built-in `GITHUB_TOKEN` and native GitHub features.
-- **No plaintext credential storage.**
+- No passwords, secrets, API keys, tokens, or credentials anywhere in the codebase — not in source, config, env files, comments, tests, docs, or commits.
+- No `.env` files committed. Use `.env.example` with placeholders only.
+- No GitHub Secrets for PATs or service credentials. Use only `GITHUB_TOKEN`.
 
-### Authentication Standards
+### Authentication
 
-- **Prefer credential-free authentication**: OIDC federation, managed identities, workload identity, certificate-based auth.
-- **When credentials are unavoidable** (e.g., FRED, BLS API keys): load from environment variables at runtime via `pydantic-settings` (`AppConfig`). Never hardcode, never log, never serialize.
+- Prefer credential-free: OIDC federation, managed identities, workload identity, certificate-based auth.
+- When credentials are unavoidable (FRED, BLS API keys): load from environment variables at runtime via `pydantic-settings` (`AppConfig`). Never hardcode, log, or serialize.
 
 ### Defense in Depth
 
-- **All portfolio and personal data stays local.** No PII sent to external APIs unless the user explicitly configures it.
-- **Validate all external input** — API responses, file contents, user input. Never trust external data.
-- **Log security-relevant events** but **never log credentials or sensitive data**.
-- **Fail closed**: if a security check cannot be performed, deny access.
+- All portfolio and personal data stays local. No PII sent to external APIs unless explicitly configured.
+- Validate all external input (API responses, file contents, user input).
+- Log security-relevant events but never log credentials or sensitive data.
+- Fail closed: if a security check cannot be performed, deny access.
 
 ## Testing
 
-### Running Tests
+### Commands
 
-- **MCP Server (unit)**: `cd mcp-server && npm test`
-- **Agents (unit)**: `cd agents && source .venv/bin/activate && pytest -m "not integration"`
-- **Agents (integration)**: `cd agents && source .venv/bin/activate && pytest -m integration`
-- **Full suite (unit)**: `npm test` (from root)
-- **Linting**: `npm run lint` (root), `cd agents && ruff check src/ tests/`
-
-### Pre-Push Preflight
-
-**Always run `npm run preflight` from the repo root before pushing.**
-
-```bash
-npm run preflight   # must pass before every push
-```
-
-### Testing Philosophy
-
-Every code change **must** include tests. No exceptions.
-
-#### Positive Tests
-- Cover the happy path for each unit of new or changed functionality
-- Use concrete, representative test fixtures
-
-#### Negative Tests
-- Every boundary condition and error path must have a negative test
-- **Never assert on error codes or error message strings**
-- **Assert on observable behavior**: return values, thrown vs not thrown, state changes, output shape
-
-#### Financial Logic Tests
-- All monetary calculations must be tested with `Decimal` precision
-- Tax-lot selection logic must have edge-case coverage (wash sales, zero-basis lots, same-day trades)
-- Rebalancing math must verify current→target drift calculations
-- Scenario stress tests must verify arithmetic against known expected losses
-
-#### Test Anti-Patterns and Quality Rules
-
-| Anti-pattern | Why it's bad |
+| Scope | Command |
 |---|---|
-| Tautology / placeholder (`assert True`, `pass`) | Tests nothing — overstates coverage. If a code path is unreachable under normal construction, use `model_construct` to bypass outer validation and test the guard directly. |
-| Language validation (constructor/property tests) | Tests that the language works, not your code |
-| Mirror (reimplements production logic) | Breaks when logic changes |
-| Duplicate (same behavior twice) | Noise; keep the more expressive one |
-| Range assertion when exact value is known | `>= expected` can hide regressions; use `== expected` when deterministic |
-| Strict time comparison (`>`) | Flaky on fast machines or coarse clocks; use `>=` |
-| Testing only returned objects | Always test the full write-read cycle — reload from a fresh instance to verify persistence |
+| MCP Server (unit) | `cd mcp-server && npm test` |
+| Agents (unit) | `cd agents && source .venv/bin/activate && pytest -m "not integration"` |
+| Agents (integration) | `cd agents && source .venv/bin/activate && pytest -m integration` |
+| Full suite | `npm test` (from root) |
+| Lint | `npm run lint` (root) |
+| **Preflight (pre-push)** | **`npm run preflight`** (from root) |
 
-## Communication Style
+### Test Requirements
 
-- Be concise and succinct, use as few words as possible. Words are at a premium.
-- Do not generate summaries in chat output.
+- Every code change must include tests.
+- Cover the happy path with concrete, representative fixtures.
+- Every boundary condition and error path must have a negative test.
+- Assert on observable behavior (return values, exceptions, state changes), not error message strings.
+- All monetary calculations tested with `Decimal` precision.
 
-## Git Workflow: Worktrees and Branches
+### Anti-Patterns
 
-Multiple Copilot CLI sessions may work simultaneously. Always use git worktrees.
+| Avoid | Do instead |
+|---|---|
+| `assert True`, `pass` (placeholder) | Use `model_construct` to bypass outer validation and test the guard directly |
+| Testing language features (constructor/property) | Test your logic, not that Python works |
+| Mirror test (reimplements production logic) | Use independent expected values |
+| Duplicate test (same behavior twice) | Keep the more expressive one |
+| `>= expected` when exact value is known | `== expected` — ranges hide regressions |
+| `>` for time comparisons | `>=` — strict comparison is flaky on fast machines |
+| Testing only returned objects | Write-read cycle: reload from a fresh instance to verify persistence |
+
+## Git Workflow
+
+Use git worktrees. Multiple sessions may work simultaneously.
 
 ### Branch Naming
 
@@ -252,14 +225,14 @@ All branches other than `main` **must** follow: `<username>/<MeaningfulDescripti
 
 ### Making Changes
 
-0. **Never commit to main.**
+0. Never commit to `main`.
 1. `git worktree add <path> -b <username>/<task> origin/main`
 2. Work exclusively in the worktree.
-3. Make **separate, descriptive commits** for each logical change within a PR.
-4. Do **not** amend or force-push.
-5. Run `npm run preflight` before pushing (see [Testing](#testing)).
+3. Separate, descriptive commits for each logical change.
+4. Do not amend or force-push.
+5. `npm run preflight` before pushing.
 6. Commit, push, create PR targeting `main`.
-7. **Squash merge** when merging PRs into main.
+7. Squash merge when merging PRs.
 
 ### After PR Merge
 
@@ -272,17 +245,17 @@ All branches other than `main` **must** follow: `<username>/<MeaningfulDescripti
 
 ### Issue-First Workflow
 
-**Every PR must have a corresponding issue created before the PR.** No exceptions.
+Every PR must have a corresponding issue created before the PR.
 
-1. Before starting work, create an issue describing what will be built.
-2. For multi-step features, use **parent issue + sub-issues**.
+1. Create an issue describing what will be built before starting work.
+2. For multi-step features, use parent issue + sub-issues.
 3. Every PR body must reference its issue(s) via closing keywords (`Closes #N`).
 
 ### Pull Requests
 
 - Use `gh pr create --title "..." --body "Closes #N"`.
-- **Assign every PR to the "finance-os" GitHub Project** (if one exists).
-- **After every push**, wait a few minutes for CI and Copilot code review feedback on the remote. Read all review comments, assess validity, address valid findings with a new commit, push, and resolve the conversations. Repeat this loop until there is no more unresolved feedback.
+- Assign every PR to the "finance-os" GitHub Project (if one exists).
+- After every push, wait for CI and Copilot code review feedback. Read all review comments, assess validity, address valid findings with a new commit, push, and resolve conversations. Repeat until no unresolved feedback remains.
 
 ## @azure Rule
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -135,6 +135,45 @@ These rules exist because this is financial software. Violations produce incorre
 5. **No stale data assumptions**: Always check data freshness before analysis.
 6. **Tax-lot integrity**: When multiple lots exist per position, never merge or average cost basis. Each lot retains its purchase date and per-share cost.
 
+## Defensive Coding Checklist
+
+These rules are distilled from recurring code review findings. Apply them **before** pushing to reduce review cycles.
+
+### Pydantic Model Discipline
+
+1. **String fields**: Every user-facing string field (`name`, `ticker`, etc.) must have `Field(min_length=1)` and a `@field_validator` that strips whitespace and rejects blank values.
+2. **Numeric bounds**: Every numeric field with domain constraints must validate its range (e.g., weights in `[0, 1]`, positive-only amounts). Don't rely on downstream consumers to catch out-of-range values.
+3. **Request models mirror entity invariants**: If an entity model (e.g., `Goal`) has validators (goal-type invariants, name stripping), the corresponding request model (`CreateGoalRequest`) must enforce the same rules. Invalid requests must fail at the API boundary, not deep in service code.
+4. **Optional collections need safe defaults**: When a dict/list field is optional, populate missing entries with sensible defaults in a `@model_validator`. A partial dict (e.g., 3 of 9 asset classes provided) must be merged with defaults, not left incomplete.
+5. **Type annotations match nullability**: If a field can be `None` at runtime (including via `model_construct`), the type annotation must include `| None`. Defensive guards (`x or {}`) are good but don't substitute for correct types.
+6. **`model_copy` bypasses validators**: After `model_copy(update=...)`, always re-validate through `Model.model_validate(obj.model_dump())` and use the returned object — the copy itself is unvalidated.
+7. **PATCH update semantics**: Use `model_fields_set` to distinguish "field was explicitly set to None" from "field was not provided". Never use `if value is not None` for PATCH-style partial updates — it makes clearing optional fields impossible.
+8. **Enum error messages**: Use `enum_value.value` (not the enum member itself) in user-facing error messages so API clients get clean strings like `"wealth_building"` instead of `"GoalType.WEALTH_BUILDING"`.
+
+### Safe File I/O Pattern
+
+When writing files atomically (the standard pattern for services with persistent state):
+
+1. **Use `os.fdopen`** (not raw `os.write`) to prevent short writes that silently truncate data.
+2. **Catch `BaseException`** (not `Exception`) in fd/lock cleanup so `KeyboardInterrupt` doesn't leak file descriptors.
+3. **Use `st_mtime_ns`** (int) for mtime-based caching, never `st_mtime` (float) — float equality is unreliable across filesystems.
+4. **Return deep copies** from mtime caches (`model_copy(deep=True)`). If callers mutate the cached object and `_write_atomic` fails, the in-memory cache diverges from disk.
+5. **File permissions**: `0o600` for sensitive data files. Best-effort `fsync` on parent directory with `try/except OSError`.
+
+Reference implementation: `PolicyService._write_atomic()`, `OverrideStore._save()`.
+
+### Docstrings and Descriptions
+
+1. **Docstrings must match behavior exactly.** If a method raises on not-found, don't say "returns False". If a method caches, don't say "loads from disk on every call".
+2. **PR descriptions must match the code being shipped.** Don't claim features (caching, validation) that aren't implemented yet.
+
+### Test Quality
+
+1. **No placeholder tests.** Every `def test_*` must contain at least one assertion. If a code path is unreachable under normal construction (e.g., defense-in-depth validators), use `model_construct` to bypass outer validation and test the guard directly.
+2. **Exact assertions over range assertions.** When the expected value is deterministic, assert `== expected`, not `>= expected`.
+3. **Time comparisons use `>=`**, not `>`, to avoid flakiness on fast machines or coarse-resolution clocks.
+4. **Test the full write-read cycle.** After creating/updating, reload from a fresh service instance to verify persistence, not just the returned object.
+
 ## Security
 
 Security is not optional. This is financial software handling sensitive portfolio data.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -107,7 +107,6 @@ Two-layer taxonomy for ETF classification:
 - **Dependency versions**: Always use the latest stable version. No legacy compatibility — legacy systems must fail. When a dependency ships a breaking change, update all consuming code to work with the new version. Never pin to old versions to avoid migration work. **Legacy compatibility is an anti-pattern.**
 - **No secrets**: See [Security](#security) section below.
 - **Error handling**: Graceful degradation. Never crash on malformed input — log warnings and continue.
-- **Privacy**: All portfolio/personal data stays local. No PII sent to external APIs unless explicitly configured.
 
 ### TypeScript (MCP Server)
 - Strict TypeScript (`"strict": true`)
@@ -121,7 +120,6 @@ Two-layer taxonomy for ETF classification:
 - PEP 8, `snake_case` for functions/variables, `PascalCase` for classes
 - Docstrings on all public functions and classes (Google style)
 - Use `pathlib.Path` over `os.path`
-- All monetary/financial arithmetic uses `decimal.Decimal`, never `float`
 - `#!/usr/bin/env python3` shebang on executable scripts
 
 ### Financial Accuracy Rules
@@ -166,13 +164,6 @@ Reference implementation: `PolicyService._write_atomic()`, `OverrideStore._save(
 
 1. **Docstrings must match behavior exactly.** If a method raises on not-found, don't say "returns False". If a method caches, don't say "loads from disk on every call".
 2. **PR descriptions must match the code being shipped.** Don't claim features (caching, validation) that aren't implemented yet.
-
-### Test Quality
-
-1. **No placeholder tests.** Every `def test_*` must contain at least one assertion. If a code path is unreachable under normal construction (e.g., defense-in-depth validators), use `model_construct` to bypass outer validation and test the guard directly.
-2. **Exact assertions over range assertions.** When the expected value is deterministic, assert `== expected`, not `>= expected`.
-3. **Time comparisons use `>=`**, not `>`, to avoid flakiness on fast machines or coarse-resolution clocks.
-4. **Test the full write-read cycle.** After creating/updating, reload from a fresh service instance to verify persistence, not just the returned object.
 
 ## Security
 
@@ -234,15 +225,17 @@ Every code change **must** include tests. No exceptions.
 - Rebalancing math must verify current→target drift calculations
 - Scenario stress tests must verify arithmetic against known expected losses
 
-#### Test Anti-Patterns
+#### Test Anti-Patterns and Quality Rules
 
 | Anti-pattern | Why it's bad |
 |---|---|
-| Tautology (`assert True`) | Tests nothing |
+| Tautology / placeholder (`assert True`, `pass`) | Tests nothing — overstates coverage. If a code path is unreachable under normal construction, use `model_construct` to bypass outer validation and test the guard directly. |
 | Language validation (constructor/property tests) | Tests that the language works, not your code |
 | Mirror (reimplements production logic) | Breaks when logic changes |
 | Duplicate (same behavior twice) | Noise; keep the more expressive one |
-| Error-code/message matching | Couples to internals |
+| Range assertion when exact value is known | `>= expected` can hide regressions; use `== expected` when deterministic |
+| Strict time comparison (`>`) | Flaky on fast machines or coarse clocks; use `>=` |
+| Testing only returned objects | Always test the full write-read cycle — reload from a fresh instance to verify persistence |
 
 ## Communication Style
 
@@ -264,7 +257,7 @@ All branches other than `main` **must** follow: `<username>/<MeaningfulDescripti
 2. Work exclusively in the worktree.
 3. Make **separate, descriptive commits** for each logical change within a PR.
 4. Do **not** amend or force-push.
-5. Run `npm run preflight` before pushing.
+5. Run `npm run preflight` before pushing (see [Testing](#testing)).
 6. Commit, push, create PR targeting `main`.
 7. **Squash merge** when merging PRs into main.
 

--- a/agents/src/application/contracts/policy.py
+++ b/agents/src/application/contracts/policy.py
@@ -282,6 +282,21 @@ class CreateGoalRequest(BaseModel):
     inflation_assumption: Decimal = Decimal("0.025")
     notes: str = ""
 
+    @model_validator(mode="after")
+    def _goal_type_invariants(self) -> Self:
+        if self.goal_type == GoalType.RETIREMENT and self.withdrawal_rate is None:
+            raise ValueError("Retirement goals require withdrawal_rate")
+        if (
+            self.goal_type != GoalType.RETIREMENT
+            and self.withdrawal_rate is not None
+        ):
+            raise ValueError(
+                f"{self.goal_type.value} goals should not have withdrawal_rate"
+            )
+        if self.horizon_years is not None and self.horizon_years < 1:
+            raise ValueError("horizon_years must be positive")
+        return self
+
 
 class UpdateGoalRequest(BaseModel):
     """Request to update an existing goal."""

--- a/agents/src/application/contracts/policy.py
+++ b/agents/src/application/contracts/policy.py
@@ -116,6 +116,7 @@ class InvestmentPolicy(BaseModel):
         provided = self.rebalancing_bands or {}
         self.rebalancing_bands = {**default_bands, **provided}
         return self
+
     benchmark_blend: list[BenchmarkComponent] = Field(default_factory=list)
     risk_budget: Decimal | None = None
     liquidity_floor: Decimal = Decimal("0.05")
@@ -223,7 +224,7 @@ class Goal(BaseModel):
         else:
             if self.withdrawal_rate is not None:
                 raise ValueError(
-                    f"{self.goal_type} goals should not have withdrawal_rate"
+                    f"{self.goal_type.value} goals should not have withdrawal_rate"
                 )
         if self.target_amount is not None and self.target_amount < 0:
             raise ValueError("target_amount must be non-negative")

--- a/agents/src/application/contracts/policy.py
+++ b/agents/src/application/contracts/policy.py
@@ -304,10 +304,31 @@ class CreateGoalRequest(BaseModel):
             raise ValueError("name must not be blank")
         return stripped
 
+    @field_validator("target_amount")
+    @classmethod
+    def _validate_target_amount(cls, value: Decimal | None) -> Decimal | None:
+        """Reject negative target amounts when provided."""
+        if value is None:
+            return None
+        if value < 0:
+            raise ValueError("target_amount must be non-negative")
+        return value
+
+    @field_validator("inflation_assumption")
+    @classmethod
+    def _validate_inflation_assumption(cls, value: Decimal) -> Decimal:
+        """Reject negative inflation assumption."""
+        if value < 0:
+            raise ValueError("inflation_assumption must be non-negative")
+        return value
+
     @model_validator(mode="after")
     def _goal_type_invariants(self) -> Self:
-        if self.goal_type == GoalType.RETIREMENT and self.withdrawal_rate is None:
-            raise ValueError("Retirement goals require withdrawal_rate")
+        if self.goal_type == GoalType.RETIREMENT:
+            if self.withdrawal_rate is None:
+                raise ValueError("Retirement goals require withdrawal_rate")
+            if self.withdrawal_rate <= 0:
+                raise ValueError("withdrawal_rate must be positive")
         if (
             self.goal_type != GoalType.RETIREMENT
             and self.withdrawal_rate is not None

--- a/agents/src/application/contracts/policy.py
+++ b/agents/src/application/contracts/policy.py
@@ -74,13 +74,16 @@ class RebalancingBand(BaseModel):
 class BenchmarkComponent(BaseModel):
     """One constituent of a synthetic benchmark blend."""
 
-    ticker: str
+    ticker: str = Field(min_length=1)
     weight: Decimal
 
     @field_validator("ticker")
     @classmethod
     def uppercase_ticker(cls, v: str) -> str:
-        return v.strip().upper()
+        v = v.strip().upper()
+        if not v:
+            raise ValueError("ticker must not be blank")
+        return v
 
     @field_validator("weight")
     @classmethod

--- a/agents/src/application/contracts/policy.py
+++ b/agents/src/application/contracts/policy.py
@@ -187,7 +187,16 @@ class Goal(BaseModel):
     """A financial goal with an embedded investment policy."""
 
     id: str = Field(default_factory=lambda: uuid4().hex[:12])
-    name: str
+    name: str = Field(min_length=1)
+
+    @field_validator("name")
+    @classmethod
+    def _strip_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Goal name must not be blank")
+        return v
+
     goal_type: GoalType
     policy: InvestmentPolicy
     horizon_years: int
@@ -274,7 +283,7 @@ class GoalsFile(BaseModel):
 class CreateGoalRequest(BaseModel):
     """Request to create a new goal."""
 
-    name: str
+    name: str = Field(min_length=1)
     goal_type: GoalType
     policy: InvestmentPolicy
     horizon_years: int

--- a/agents/src/application/contracts/policy.py
+++ b/agents/src/application/contracts/policy.py
@@ -105,17 +105,16 @@ class InvestmentPolicy(BaseModel):
     """
 
     allocations: dict[AssetClass, AllocationTarget]
-    rebalancing_bands: dict[AssetClass, RebalancingBand] = Field(
+    rebalancing_bands: dict[AssetClass, RebalancingBand] | None = Field(
         default=None,
     )
 
     @model_validator(mode="after")
     def _default_bands(self) -> Self:
-        """Populate rebalancing bands for all asset classes if not provided."""
-        if self.rebalancing_bands is None:
-            self.rebalancing_bands = {
-                ac: RebalancingBand() for ac in AssetClass
-            }
+        """Fill missing rebalancing bands with defaults for all asset classes."""
+        default_bands = {ac: RebalancingBand() for ac in AssetClass}
+        provided = self.rebalancing_bands or {}
+        self.rebalancing_bands = {**default_bands, **provided}
         return self
     benchmark_blend: list[BenchmarkComponent] = Field(default_factory=list)
     risk_budget: Decimal | None = None

--- a/agents/src/application/contracts/policy.py
+++ b/agents/src/application/contracts/policy.py
@@ -106,8 +106,17 @@ class InvestmentPolicy(BaseModel):
 
     allocations: dict[AssetClass, AllocationTarget]
     rebalancing_bands: dict[AssetClass, RebalancingBand] = Field(
-        default_factory=dict,
+        default=None,
     )
+
+    @model_validator(mode="after")
+    def _default_bands(self) -> Self:
+        """Populate rebalancing bands for all asset classes if not provided."""
+        if self.rebalancing_bands is None:
+            self.rebalancing_bands = {
+                ac: RebalancingBand() for ac in AssetClass
+            }
+        return self
     benchmark_blend: list[BenchmarkComponent] = Field(default_factory=list)
     risk_budget: Decimal | None = None
     liquidity_floor: Decimal = Decimal("0.05")
@@ -294,6 +303,11 @@ class DriftRequest(BaseModel):
 
     @model_validator(mode="after")
     def _allocations_valid(self) -> Self:
+        for ac, w in self.current_allocations.items():
+            if w < 0 or w > 1:
+                raise ValueError(
+                    f"Allocation for {ac.value} must be in [0, 1], got {w}"
+                )
         total = sum(self.current_allocations.values())
         if abs(total - 1) > Decimal("0.01"):
             raise ValueError(

--- a/agents/src/application/contracts/policy.py
+++ b/agents/src/application/contracts/policy.py
@@ -295,6 +295,15 @@ class CreateGoalRequest(BaseModel):
     inflation_assumption: Decimal = Decimal("0.025")
     notes: str = ""
 
+    @field_validator("name")
+    @classmethod
+    def _strip_name(cls, value: str) -> str:
+        """Strip whitespace and reject blank names."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("name must not be blank")
+        return stripped
+
     @model_validator(mode="after")
     def _goal_type_invariants(self) -> Self:
         if self.goal_type == GoalType.RETIREMENT and self.withdrawal_rate is None:
@@ -321,6 +330,49 @@ class UpdateGoalRequest(BaseModel):
     withdrawal_rate: Decimal | None = None
     inflation_assumption: Decimal | None = None
     notes: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str | None) -> str | None:
+        """Strip whitespace and reject blank names when provided."""
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("name must not be blank")
+        return stripped
+
+    @field_validator("horizon_years")
+    @classmethod
+    def _validate_horizon_years(cls, value: int | None) -> int | None:
+        """Reject non-positive horizon when provided."""
+        if value is None:
+            return None
+        if value < 1:
+            raise ValueError("horizon_years must be positive")
+        return value
+
+    @field_validator("target_amount")
+    @classmethod
+    def _validate_target_amount(cls, value: Decimal | None) -> Decimal | None:
+        """Reject negative target amounts when provided."""
+        if value is None:
+            return None
+        if value < 0:
+            raise ValueError("target_amount must be non-negative")
+        return value
+
+    @field_validator("inflation_assumption")
+    @classmethod
+    def _validate_inflation_assumption(
+        cls, value: Decimal | None,
+    ) -> Decimal | None:
+        """Reject negative inflation assumption when provided."""
+        if value is None:
+            return None
+        if value < 0:
+            raise ValueError("inflation_assumption must be non-negative")
+        return value
 
 
 class DriftRequest(BaseModel):

--- a/agents/src/application/contracts/policy.py
+++ b/agents/src/application/contracts/policy.py
@@ -1,0 +1,302 @@
+"""Pydantic contracts for investment policy and financial goals.
+
+An investment policy defines target asset-class allocations, rebalancing
+bands, a benchmark blend, and risk/liquidity constraints.  Goals embed
+a policy and add time-horizon + withdrawal/growth parameters.
+
+All weight values use ``decimal.Decimal`` and represent fractions of 1
+(e.g. 0.60 = 60 %).
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import StrEnum
+from typing import Self
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from src.application.contracts.household import AssetClass
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+_ALL_ASSET_CLASSES = frozenset(AssetClass)
+
+
+class GoalType(StrEnum):
+    """Supported goal archetypes."""
+
+    RETIREMENT = "retirement"
+    WEALTH_BUILDING = "wealth_building"
+    CUSTOM = "custom"
+
+
+# ---------------------------------------------------------------------------
+# Allocation primitives
+# ---------------------------------------------------------------------------
+
+
+class AllocationTarget(BaseModel):
+    """Per-asset-class allocation target with min/max bands."""
+
+    target_weight: Decimal
+    min_weight: Decimal = Decimal("0")
+    max_weight: Decimal = Decimal("1")
+
+    @model_validator(mode="after")
+    def _ordering(self) -> Self:
+        if not (0 <= self.min_weight <= self.target_weight <= self.max_weight <= 1):
+            raise ValueError(
+                f"Must have 0 <= min ({self.min_weight}) <= target "
+                f"({self.target_weight}) <= max ({self.max_weight}) <= 1"
+            )
+        return self
+
+
+class RebalancingBand(BaseModel):
+    """Drift threshold that triggers rebalancing for one asset class.
+
+    ``threshold`` is in absolute portfolio-weight points (e.g. 0.03 = ±3 pp).
+    """
+
+    threshold: Decimal = Decimal("0.05")
+
+    @field_validator("threshold")
+    @classmethod
+    def positive(cls, v: Decimal) -> Decimal:
+        if v <= 0:
+            raise ValueError("threshold must be positive")
+        return v
+
+
+class BenchmarkComponent(BaseModel):
+    """One constituent of a synthetic benchmark blend."""
+
+    ticker: str
+    weight: Decimal
+
+    @field_validator("ticker")
+    @classmethod
+    def uppercase_ticker(cls, v: str) -> str:
+        return v.strip().upper()
+
+    @field_validator("weight")
+    @classmethod
+    def non_negative(cls, v: Decimal) -> Decimal:
+        if v < 0:
+            raise ValueError("weight must be non-negative")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Investment Policy
+# ---------------------------------------------------------------------------
+
+
+class InvestmentPolicy(BaseModel):
+    """Target allocation, rebalancing rules, and benchmark definition.
+
+    ``allocations`` must cover all 9 canonical asset classes.  Targets
+    must sum to 1.  The min/max feasibility constraint
+    ``sum(min) <= 1 <= sum(max)`` is enforced so the policy is
+    satisfiable.
+    """
+
+    allocations: dict[AssetClass, AllocationTarget]
+    rebalancing_bands: dict[AssetClass, RebalancingBand] = Field(
+        default_factory=dict,
+    )
+    benchmark_blend: list[BenchmarkComponent] = Field(default_factory=list)
+    risk_budget: Decimal | None = None
+    liquidity_floor: Decimal = Decimal("0.05")
+
+    @field_validator("liquidity_floor")
+    @classmethod
+    def floor_non_negative(cls, v: Decimal) -> Decimal:
+        if v < 0:
+            raise ValueError("liquidity_floor must be non-negative")
+        return v
+
+    @model_validator(mode="after")
+    def _policy_invariants(self) -> Self:
+        # All asset classes required
+        missing = _ALL_ASSET_CLASSES - self.allocations.keys()
+        if missing:
+            names = ", ".join(sorted(m.value for m in missing))
+            raise ValueError(f"Missing allocations for: {names}")
+
+        # Targets sum to 1
+        total = sum(a.target_weight for a in self.allocations.values())
+        if abs(total - 1) > Decimal("0.001"):
+            raise ValueError(
+                f"Target weights must sum to 1.0, got {total}"
+            )
+
+        # Feasibility: sum(min) <= 1 <= sum(max)
+        min_sum = sum(a.min_weight for a in self.allocations.values())
+        max_sum = sum(a.max_weight for a in self.allocations.values())
+        if min_sum > 1:
+            raise ValueError(
+                f"sum(min_weight) = {min_sum} > 1; infeasible policy"
+            )
+        if max_sum < 1:
+            raise ValueError(
+                f"sum(max_weight) = {max_sum} < 1; infeasible policy"
+            )
+
+        # Cash floor consistency
+        cash = self.allocations.get(AssetClass.CASH_MONEY_MARKET)
+        if cash and cash.min_weight < self.liquidity_floor:
+            raise ValueError(
+                f"CASH_MONEY_MARKET min_weight ({cash.min_weight}) must be "
+                f">= liquidity_floor ({self.liquidity_floor})"
+            )
+
+        # Benchmark weights sum to 1 (if provided)
+        if self.benchmark_blend:
+            bw = sum(c.weight for c in self.benchmark_blend)
+            if abs(bw - 1) > Decimal("0.001"):
+                raise ValueError(
+                    f"Benchmark weights must sum to 1.0, got {bw}"
+                )
+            # Unique tickers
+            tickers = [c.ticker for c in self.benchmark_blend]
+            if len(tickers) != len(set(tickers)):
+                raise ValueError("Benchmark blend has duplicate tickers")
+
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Goal
+# ---------------------------------------------------------------------------
+
+
+class Goal(BaseModel):
+    """A financial goal with an embedded investment policy."""
+
+    id: str = Field(default_factory=lambda: uuid4().hex[:12])
+    name: str
+    goal_type: GoalType
+    policy: InvestmentPolicy
+    horizon_years: int
+    target_amount: Decimal | None = None
+    withdrawal_rate: Decimal | None = None
+    inflation_assumption: Decimal = Decimal("0.025")
+    notes: str = ""
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @field_validator("horizon_years")
+    @classmethod
+    def positive_horizon(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("horizon_years must be positive")
+        return v
+
+    @field_validator("inflation_assumption")
+    @classmethod
+    def non_negative_inflation(cls, v: Decimal) -> Decimal:
+        if v < 0:
+            raise ValueError("inflation_assumption must be non-negative")
+        return v
+
+    @model_validator(mode="after")
+    def _goal_type_invariants(self) -> Self:
+        if self.goal_type == GoalType.RETIREMENT:
+            if self.withdrawal_rate is None:
+                raise ValueError(
+                    "retirement goals require withdrawal_rate"
+                )
+            if self.withdrawal_rate <= 0:
+                raise ValueError("withdrawal_rate must be positive")
+        else:
+            if self.withdrawal_rate is not None:
+                raise ValueError(
+                    f"{self.goal_type} goals should not have withdrawal_rate"
+                )
+        if self.target_amount is not None and self.target_amount < 0:
+            raise ValueError("target_amount must be non-negative")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Drift computation
+# ---------------------------------------------------------------------------
+
+
+class DriftResult(BaseModel):
+    """Per-asset-class drift from target allocation."""
+
+    asset_class: AssetClass
+    target_weight: Decimal
+    current_weight: Decimal
+    drift: Decimal  # current - target (positive = overweight)
+    breaches_band: bool
+
+
+class DriftReport(BaseModel):
+    """Full drift analysis for a policy against current allocations."""
+
+    drifts: list[DriftResult]
+    any_breach: bool
+    total_drift: Decimal  # sum of |drift|
+
+
+# ---------------------------------------------------------------------------
+# Store schema
+# ---------------------------------------------------------------------------
+
+
+class GoalsFile(BaseModel):
+    """Schema for goals.json persistence."""
+
+    schema_version: int = 1
+    goals: dict[str, Goal] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Request / response
+# ---------------------------------------------------------------------------
+
+
+class CreateGoalRequest(BaseModel):
+    """Request to create a new goal."""
+
+    name: str
+    goal_type: GoalType
+    policy: InvestmentPolicy
+    horizon_years: int
+    target_amount: Decimal | None = None
+    withdrawal_rate: Decimal | None = None
+    inflation_assumption: Decimal = Decimal("0.025")
+    notes: str = ""
+
+
+class UpdateGoalRequest(BaseModel):
+    """Request to update an existing goal."""
+
+    name: str | None = None
+    policy: InvestmentPolicy | None = None
+    horizon_years: int | None = None
+    target_amount: Decimal | None = None
+    withdrawal_rate: Decimal | None = None
+    inflation_assumption: Decimal | None = None
+    notes: str | None = None
+
+
+class DriftRequest(BaseModel):
+    """Request for drift computation."""
+
+    current_allocations: dict[AssetClass, Decimal]
+
+    @model_validator(mode="after")
+    def _allocations_valid(self) -> Self:
+        total = sum(self.current_allocations.values())
+        if abs(total - 1) > Decimal("0.01"):
+            raise ValueError(
+                f"Current allocations must sum to ~1.0, got {total}"
+            )
+        return self

--- a/agents/src/application/services/policy_service.py
+++ b/agents/src/application/services/policy_service.py
@@ -1,0 +1,397 @@
+"""Policy & goal persistence — load, save, CRUD, drift computation.
+
+Storage location: ~/.config/finance-os/goals.json
+
+Uses OS-level file locking (``fcntl.flock``) to protect against
+concurrent writes from Web API, MCP server, and CLI processes.
+"""
+
+import fcntl
+import json
+import logging
+import os
+import tempfile
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from src.application.config import CONFIG_DIR
+from src.application.contracts.household import AssetClass
+from src.application.contracts.policy import (
+    AllocationTarget,
+    BenchmarkComponent,
+    CreateGoalRequest,
+    DriftReport,
+    DriftRequest,
+    DriftResult,
+    Goal,
+    GoalsFile,
+    GoalType,
+    InvestmentPolicy,
+    RebalancingBand,
+    UpdateGoalRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+GOALS_FILE = CONFIG_DIR / "goals.json"
+LOCK_FILE = CONFIG_DIR / "goals.lock"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class GoalNotFoundError(Exception):
+    """Raised when a goal ID does not exist."""
+
+
+class GoalsCorruptError(Exception):
+    """Raised when goals.json cannot be parsed."""
+
+
+# ---------------------------------------------------------------------------
+# File lock context
+# ---------------------------------------------------------------------------
+
+
+class _FileLockContext:
+    """OS-level advisory lock via fcntl.flock."""
+
+    def __init__(self, lock_path: Path) -> None:
+        self._lock_path = lock_path
+        self._fd: int | None = None
+
+    def __enter__(self) -> "_FileLockContext":
+        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._fd = os.open(str(self._lock_path), os.O_CREAT | os.O_RDWR)
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_EX)
+        except Exception:
+            os.close(self._fd)
+            self._fd = None
+            raise
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        if self._fd is not None:
+            try:
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+            finally:
+                os.close(self._fd)
+                self._fd = None
+
+
+# ---------------------------------------------------------------------------
+# Canned goal factories
+# ---------------------------------------------------------------------------
+
+
+def _all_class_allocations(
+    targets: dict[AssetClass, tuple[Decimal, Decimal, Decimal]],
+) -> dict[AssetClass, AllocationTarget]:
+    """Build a complete allocation dict from (target, min, max) tuples.
+
+    Any asset class not in ``targets`` gets a zero allocation.
+    """
+    result: dict[AssetClass, AllocationTarget] = {}
+    for ac in AssetClass:
+        if ac in targets:
+            t, mn, mx = targets[ac]
+            result[ac] = AllocationTarget(
+                target_weight=t, min_weight=mn, max_weight=mx,
+            )
+        else:
+            result[ac] = AllocationTarget(
+                target_weight=Decimal("0"),
+                min_weight=Decimal("0"),
+                max_weight=Decimal("0.10"),
+            )
+    return result
+
+
+def _default_bands() -> dict[AssetClass, RebalancingBand]:
+    return {ac: RebalancingBand() for ac in AssetClass}
+
+
+def create_retirement_goal(name: str = "Retirement") -> Goal:
+    """Conservative allocation: capital preservation + income."""
+    alloc = _all_class_allocations({
+        AssetClass.US_EQUITY: (Decimal("0.25"), Decimal("0.15"), Decimal("0.35")),
+        AssetClass.INTL_DEVELOPED: (Decimal("0.10"), Decimal("0.05"), Decimal("0.15")),
+        AssetClass.EMERGING_MARKETS: (Decimal("0.05"), Decimal("0"), Decimal("0.10")),
+        AssetClass.US_TREASURIES: (Decimal("0.20"), Decimal("0.10"), Decimal("0.30")),
+        AssetClass.IG_CORPORATE: (Decimal("0.15"), Decimal("0.05"), Decimal("0.25")),
+        AssetClass.HIGH_YIELD: (Decimal("0"), Decimal("0"), Decimal("0.05")),
+        AssetClass.TIPS: (Decimal("0.10"), Decimal("0.05"), Decimal("0.15")),
+        AssetClass.REAL_ASSETS: (Decimal("0.05"), Decimal("0"), Decimal("0.10")),
+        AssetClass.CASH_MONEY_MARKET: (Decimal("0.10"), Decimal("0.05"), Decimal("0.15")),
+    })
+    policy = InvestmentPolicy(
+        allocations=alloc,
+        rebalancing_bands=_default_bands(),
+        benchmark_blend=[
+            BenchmarkComponent(ticker="VTI", weight=Decimal("0.30")),
+            BenchmarkComponent(ticker="VXUS", weight=Decimal("0.10")),
+            BenchmarkComponent(ticker="BND", weight=Decimal("0.35")),
+            BenchmarkComponent(ticker="TIP", weight=Decimal("0.10")),
+            BenchmarkComponent(ticker="VNQ", weight=Decimal("0.05")),
+            BenchmarkComponent(ticker="VMFXX", weight=Decimal("0.10")),
+        ],
+        liquidity_floor=Decimal("0.05"),
+    )
+    return Goal(
+        name=name,
+        goal_type=GoalType.RETIREMENT,
+        policy=policy,
+        horizon_years=30,
+        withdrawal_rate=Decimal("0.035"),
+        inflation_assumption=Decimal("0.025"),
+    )
+
+
+def create_wealth_building_goal(
+    name: str = "Wealth Building",
+) -> Goal:
+    """Growth-tilted allocation: higher equity, longer horizon."""
+    alloc = _all_class_allocations({
+        AssetClass.US_EQUITY: (Decimal("0.40"), Decimal("0.30"), Decimal("0.50")),
+        AssetClass.INTL_DEVELOPED: (Decimal("0.15"), Decimal("0.10"), Decimal("0.25")),
+        AssetClass.EMERGING_MARKETS: (Decimal("0.10"), Decimal("0.05"), Decimal("0.15")),
+        AssetClass.US_TREASURIES: (Decimal("0.10"), Decimal("0.05"), Decimal("0.20")),
+        AssetClass.IG_CORPORATE: (Decimal("0.05"), Decimal("0"), Decimal("0.15")),
+        AssetClass.HIGH_YIELD: (Decimal("0.05"), Decimal("0"), Decimal("0.10")),
+        AssetClass.TIPS: (Decimal("0"), Decimal("0"), Decimal("0.10")),
+        AssetClass.REAL_ASSETS: (Decimal("0.10"), Decimal("0.05"), Decimal("0.15")),
+        AssetClass.CASH_MONEY_MARKET: (Decimal("0.05"), Decimal("0.05"), Decimal("0.10")),
+    })
+    policy = InvestmentPolicy(
+        allocations=alloc,
+        rebalancing_bands=_default_bands(),
+        benchmark_blend=[
+            BenchmarkComponent(ticker="VTI", weight=Decimal("0.40")),
+            BenchmarkComponent(ticker="VXUS", weight=Decimal("0.20")),
+            BenchmarkComponent(ticker="BND", weight=Decimal("0.15")),
+            BenchmarkComponent(ticker="VNQ", weight=Decimal("0.10")),
+            BenchmarkComponent(ticker="VWO", weight=Decimal("0.10")),
+            BenchmarkComponent(ticker="VMFXX", weight=Decimal("0.05")),
+        ],
+        liquidity_floor=Decimal("0.05"),
+    )
+    return Goal(
+        name=name,
+        goal_type=GoalType.WEALTH_BUILDING,
+        policy=policy,
+        horizon_years=20,
+        inflation_assumption=Decimal("0.025"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drift computation (pure math)
+# ---------------------------------------------------------------------------
+
+
+def compute_drift(
+    policy: InvestmentPolicy,
+    current_allocations: dict[AssetClass, Decimal],
+) -> DriftReport:
+    """Compute per-class drift from target allocation.
+
+    ``current_allocations`` values should sum to ~1.0.
+    Missing classes are treated as 0 current weight.
+    """
+    drifts: list[DriftResult] = []
+    for ac in AssetClass:
+        target = policy.allocations[ac].target_weight
+        current = current_allocations.get(ac, Decimal("0"))
+        drift = current - target
+        band = policy.rebalancing_bands.get(ac)
+        breaches = abs(drift) > band.threshold if band else False
+        drifts.append(DriftResult(
+            asset_class=ac,
+            target_weight=target,
+            current_weight=current,
+            drift=drift,
+            breaches_band=breaches,
+        ))
+    total_drift = sum(abs(d.drift) for d in drifts)
+    return DriftReport(
+        drifts=drifts,
+        any_breach=any(d.breaches_band for d in drifts),
+        total_drift=total_drift,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class PolicyService:
+    """Manages goal persistence with OS-level file locking."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or GOALS_FILE
+        self._lock_path = (
+            path.parent / "goals.lock" if path else LOCK_FILE
+        )
+
+    def _flock(self) -> _FileLockContext:
+        return _FileLockContext(self._lock_path)
+
+    def _load_unlocked(self) -> GoalsFile:
+        """Load goals without acquiring lock (caller must hold lock)."""
+        if not self._path.exists():
+            return GoalsFile()
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            return GoalsFile.model_validate(raw)
+        except (json.JSONDecodeError, ValidationError, OSError) as exc:
+            logger.error("Corrupt goals file %s: %s", self._path, exc)
+            raise GoalsCorruptError(str(exc)) from exc
+
+    def _write_atomic(self, data: GoalsFile) -> None:
+        """Atomic write with fsync (caller must hold lock)."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        content = data.model_dump_json(indent=2).encode("utf-8")
+        fd_num, tmp_name = tempfile.mkstemp(
+            dir=str(self._path.parent), suffix=".tmp",
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            try:
+                os.write(fd_num, content)
+                os.fsync(fd_num)
+            finally:
+                os.close(fd_num)
+            os.chmod(str(tmp_path), 0o600)
+            tmp_path.replace(self._path)
+        except Exception:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError as cleanup_exc:
+                logger.warning(
+                    "Could not remove temp file %s: %s",
+                    tmp_path, cleanup_exc,
+                )
+            raise
+        # Best-effort dir fsync
+        dir_fd: int | None = None
+        try:
+            dir_fd = os.open(str(self._path.parent), os.O_RDONLY)
+            os.fsync(dir_fd)
+        except OSError:
+            pass
+        finally:
+            if dir_fd is not None:
+                os.close(dir_fd)
+
+    # -- public API --------------------------------------------------------
+
+    def load(self) -> GoalsFile:
+        """Load all goals from disk."""
+        with self._flock():
+            return self._load_unlocked()
+
+    def list_goals(self) -> list[Goal]:
+        """Return all goals sorted by name."""
+        data = self.load()
+        return sorted(data.goals.values(), key=lambda g: g.name)
+
+    def get_goal(self, goal_id: str) -> Goal:
+        """Get a single goal by ID."""
+        data = self.load()
+        goal = data.goals.get(goal_id)
+        if goal is None:
+            raise GoalNotFoundError(f"Goal '{goal_id}' not found")
+        return goal
+
+    def create_goal(self, request: CreateGoalRequest) -> Goal:
+        """Create a new goal and persist."""
+        goal = Goal(
+            name=request.name,
+            goal_type=request.goal_type,
+            policy=request.policy,
+            horizon_years=request.horizon_years,
+            target_amount=request.target_amount,
+            withdrawal_rate=request.withdrawal_rate,
+            inflation_assumption=request.inflation_assumption,
+            notes=request.notes,
+        )
+        with self._flock():
+            data = self._load_unlocked()
+            data.goals[goal.id] = goal
+            self._write_atomic(data)
+        return goal
+
+    def create_from_template(self, goal_type: GoalType) -> Goal:
+        """Create a goal from a canned template."""
+        if goal_type == GoalType.RETIREMENT:
+            goal = create_retirement_goal()
+        elif goal_type == GoalType.WEALTH_BUILDING:
+            goal = create_wealth_building_goal()
+        else:
+            raise ValueError(
+                f"No template for goal_type '{goal_type}'. "
+                "Use 'retirement' or 'wealth_building'."
+            )
+        with self._flock():
+            data = self._load_unlocked()
+            data.goals[goal.id] = goal
+            self._write_atomic(data)
+        return goal
+
+    def update_goal(
+        self, goal_id: str, request: UpdateGoalRequest,
+    ) -> Goal:
+        """Update an existing goal (partial update)."""
+        with self._flock():
+            data = self._load_unlocked()
+            goal = data.goals.get(goal_id)
+            if goal is None:
+                raise GoalNotFoundError(f"Goal '{goal_id}' not found")
+
+            updates: dict[str, object] = {}
+            if request.name is not None:
+                updates["name"] = request.name
+            if request.policy is not None:
+                updates["policy"] = request.policy
+            if request.horizon_years is not None:
+                updates["horizon_years"] = request.horizon_years
+            if request.target_amount is not None:
+                updates["target_amount"] = request.target_amount
+            if request.withdrawal_rate is not None:
+                updates["withdrawal_rate"] = request.withdrawal_rate
+            if request.inflation_assumption is not None:
+                updates["inflation_assumption"] = request.inflation_assumption
+            if request.notes is not None:
+                updates["notes"] = request.notes
+            updates["updated_at"] = datetime.now(UTC)
+
+            updated = goal.model_copy(update=updates)
+            # Re-validate goal-type invariants on the updated goal
+            Goal.model_validate(updated.model_dump())
+            data.goals[goal_id] = updated
+            self._write_atomic(data)
+        return updated
+
+    def delete_goal(self, goal_id: str) -> bool:
+        """Delete a goal. Returns True if it existed."""
+        with self._flock():
+            data = self._load_unlocked()
+            if goal_id not in data.goals:
+                raise GoalNotFoundError(f"Goal '{goal_id}' not found")
+            del data.goals[goal_id]
+            self._write_atomic(data)
+        return True
+
+    def compute_drift(
+        self, goal_id: str, request: DriftRequest,
+    ) -> DriftReport:
+        """Compute drift for a goal against current allocations."""
+        goal = self.get_goal(goal_id)
+        return compute_drift(goal.policy, request.current_allocations)

--- a/agents/src/application/services/policy_service.py
+++ b/agents/src/application/services/policy_service.py
@@ -239,17 +239,28 @@ class PolicyService:
         self._lock_path = (
             path.parent / "goals.lock" if path else LOCK_FILE
         )
+        self._cached_data: GoalsFile | None = None
+        self._cached_mtime: float = 0.0
 
     def _flock(self) -> _FileLockContext:
         return _FileLockContext(self._lock_path)
 
     def _load_unlocked(self) -> GoalsFile:
-        """Load goals without acquiring lock (caller must hold lock)."""
+        """Load goals without acquiring lock (caller must hold lock).
+
+        Uses mtime-based caching to avoid redundant disk reads.
+        """
         if not self._path.exists():
             return GoalsFile()
         try:
+            mtime = self._path.stat().st_mtime
+            if self._cached_data is not None and mtime == self._cached_mtime:
+                return self._cached_data
             raw = json.loads(self._path.read_text(encoding="utf-8"))
-            return GoalsFile.model_validate(raw)
+            data = GoalsFile.model_validate(raw)
+            self._cached_data = data
+            self._cached_mtime = mtime
+            return data
         except (json.JSONDecodeError, ValidationError, OSError) as exc:
             logger.error("Corrupt goals file %s: %s", self._path, exc)
             raise GoalsCorruptError(str(exc)) from exc
@@ -289,6 +300,12 @@ class PolicyService:
         finally:
             if dir_fd is not None:
                 os.close(dir_fd)
+        # Update mtime cache after successful write
+        self._cached_data = data
+        try:
+            self._cached_mtime = self._path.stat().st_mtime
+        except OSError:
+            self._cached_mtime = 0.0
 
     # -- public API --------------------------------------------------------
 
@@ -380,7 +397,7 @@ class PolicyService:
         return updated
 
     def delete_goal(self, goal_id: str) -> bool:
-        """Delete a goal. Returns True if it existed."""
+        """Delete a goal. Raises GoalNotFoundError if missing."""
         with self._flock():
             data = self._load_unlocked()
             if goal_id not in data.goals:

--- a/agents/src/application/services/policy_service.py
+++ b/agents/src/application/services/policy_service.py
@@ -384,8 +384,8 @@ class PolicyService:
             updates["updated_at"] = datetime.now(UTC)
 
             updated = goal.model_copy(update=updates)
-            # Re-validate goal-type invariants on the updated goal
-            Goal.model_validate(updated.model_dump())
+            # Re-validate all Goal invariants (including field validators)
+            updated = Goal.model_validate(updated.model_dump())
             data.goals[goal_id] = updated
             self._write_atomic(data)
         return updated

--- a/agents/src/application/services/policy_service.py
+++ b/agents/src/application/services/policy_service.py
@@ -243,7 +243,7 @@ class PolicyService:
             path.parent / "goals.lock" if path else LOCK_FILE
         )
         self._cached_data: GoalsFile | None = None
-        self._cached_mtime: float = 0.0
+        self._cached_mtime_ns: int = 0
 
     def _flock(self) -> _FileLockContext:
         return _FileLockContext(self._lock_path)
@@ -256,13 +256,13 @@ class PolicyService:
         if not self._path.exists():
             return GoalsFile()
         try:
-            mtime = self._path.stat().st_mtime
-            if self._cached_data is not None and mtime == self._cached_mtime:
+            mtime_ns = self._path.stat().st_mtime_ns
+            if self._cached_data is not None and mtime_ns == self._cached_mtime_ns:
                 return self._cached_data
             raw = json.loads(self._path.read_text(encoding="utf-8"))
             data = GoalsFile.model_validate(raw)
             self._cached_data = data
-            self._cached_mtime = mtime
+            self._cached_mtime_ns = mtime_ns
             return data
         except (json.JSONDecodeError, ValidationError, OSError) as exc:
             logger.error("Corrupt goals file %s: %s", self._path, exc)
@@ -305,9 +305,9 @@ class PolicyService:
         # Update mtime cache after successful write
         self._cached_data = data
         try:
-            self._cached_mtime = self._path.stat().st_mtime
+            self._cached_mtime_ns = self._path.stat().st_mtime_ns
         except OSError:
-            self._cached_mtime = 0.0
+            self._cached_mtime_ns = 0
 
     # -- public API --------------------------------------------------------
 
@@ -375,20 +375,12 @@ class PolicyService:
                 raise GoalNotFoundError(f"Goal '{goal_id}' not found")
 
             updates: dict[str, object] = {}
-            if request.name is not None:
-                updates["name"] = request.name
-            if request.policy is not None:
-                updates["policy"] = request.policy
-            if request.horizon_years is not None:
-                updates["horizon_years"] = request.horizon_years
-            if request.target_amount is not None:
-                updates["target_amount"] = request.target_amount
-            if request.withdrawal_rate is not None:
-                updates["withdrawal_rate"] = request.withdrawal_rate
-            if request.inflation_assumption is not None:
-                updates["inflation_assumption"] = request.inflation_assumption
-            if request.notes is not None:
-                updates["notes"] = request.notes
+            for field in (
+                "name", "policy", "horizon_years", "target_amount",
+                "withdrawal_rate", "inflation_assumption", "notes",
+            ):
+                if field in request.model_fields_set:
+                    updates[field] = getattr(request, field)
             updates["updated_at"] = datetime.now(UTC)
 
             updated = goal.model_copy(update=updates)

--- a/agents/src/application/services/policy_service.py
+++ b/agents/src/application/services/policy_service.py
@@ -70,8 +70,11 @@ class _FileLockContext:
         self._fd = os.open(str(self._lock_path), os.O_CREAT | os.O_RDWR)
         try:
             fcntl.flock(self._fd, fcntl.LOCK_EX)
-        except Exception:
-            os.close(self._fd)
+        except BaseException:
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
             self._fd = None
             raise
         return self
@@ -274,11 +277,10 @@ class PolicyService:
         )
         tmp_path = Path(tmp_name)
         try:
-            try:
-                os.write(fd_num, content)
-                os.fsync(fd_num)
-            finally:
-                os.close(fd_num)
+            with os.fdopen(fd_num, "wb") as tmp_file:
+                tmp_file.write(content)
+                tmp_file.flush()
+                os.fsync(tmp_file.fileno())
             os.chmod(str(tmp_path), 0o600)
             tmp_path.replace(self._path)
         except Exception:

--- a/agents/src/application/services/policy_service.py
+++ b/agents/src/application/services/policy_service.py
@@ -283,7 +283,7 @@ class PolicyService:
                 os.fsync(tmp_file.fileno())
             os.chmod(str(tmp_path), 0o600)
             tmp_path.replace(self._path)
-        except Exception:
+        except BaseException:
             try:
                 tmp_path.unlink(missing_ok=True)
             except OSError as cleanup_exc:

--- a/agents/src/application/services/policy_service.py
+++ b/agents/src/application/services/policy_service.py
@@ -212,7 +212,7 @@ def compute_drift(
         target = policy.allocations[ac].target_weight
         current = current_allocations.get(ac, Decimal("0"))
         drift = current - target
-        band = policy.rebalancing_bands.get(ac)
+        band = (policy.rebalancing_bands or {}).get(ac)
         breaches = abs(drift) > band.threshold if band else False
         drifts.append(DriftResult(
             asset_class=ac,
@@ -258,7 +258,7 @@ class PolicyService:
         try:
             mtime_ns = self._path.stat().st_mtime_ns
             if self._cached_data is not None and mtime_ns == self._cached_mtime_ns:
-                return self._cached_data
+                return self._cached_data.model_copy(deep=True)
             raw = json.loads(self._path.read_text(encoding="utf-8"))
             data = GoalsFile.model_validate(raw)
             self._cached_data = data

--- a/agents/tests/test_policy_service.py
+++ b/agents/tests/test_policy_service.py
@@ -207,15 +207,47 @@ class TestInvestmentPolicy:
             )
 
     def test_infeasible_min_unreachable_with_valid_targets(self) -> None:
-        # Note: sum(min) > 1 is impossible when each min <= target
-        # and targets sum to 1.  The validator is defense-in-depth.
-        # We verify the guard exists by testing directly with raw data.
-        pass
+        # sum(min) > 1 is impossible with valid AllocationTargets where
+        # min<=target and targets sum to 1. Use model_construct on both
+        # AllocationTarget and InvestmentPolicy, then call the validator.
+        alloc = {
+            ac: AllocationTarget.model_construct(
+                target_weight=_D("1") / 9,
+                min_weight=_D("0.12"),  # 9*0.12=1.08 > 1
+                max_weight=_D("0.30"),
+            )
+            for ac in AssetClass
+        }
+        policy = InvestmentPolicy.model_construct(
+            allocations=alloc,
+            rebalancing_bands={},
+            benchmark_blend=[],
+            risk_budget=None,
+            liquidity_floor=_D("0"),
+        )
+        with pytest.raises(ValueError, match="infeasible"):
+            policy._policy_invariants()
 
     def test_infeasible_max_unreachable_with_valid_targets(self) -> None:
-        # Similarly, sum(max) < 1 is impossible when each target <= max
-        # and targets sum to 1.
-        pass
+        # sum(max) < 1 is impossible with valid AllocationTargets where
+        # target<=max and targets sum to 1. Bypass via model_construct.
+        alloc = {
+            ac: AllocationTarget.model_construct(
+                target_weight=_D("1") / 9,
+                min_weight=_D("0"),
+                max_weight=_D("0.10"),  # 9*0.10=0.90 < 1
+            )
+            for ac in AssetClass
+        }
+        policy = InvestmentPolicy.model_construct(
+            allocations=alloc,
+            rebalancing_bands={},
+            benchmark_blend=[],
+            risk_budget=None,
+            liquidity_floor=_D("0"),
+        )
+        with pytest.raises(ValueError, match="infeasible"):
+            policy._policy_invariants()
 
     def test_cash_below_liquidity_floor_rejected(self) -> None:
         alloc = _full_allocations({
@@ -255,6 +287,12 @@ class TestInvestmentPolicy:
             ],
         )
         assert len(p.benchmark_blend) == 2
+
+    def test_default_rebalancing_bands_populated(self) -> None:
+        p = _valid_policy()
+        assert len(p.rebalancing_bands) == 9
+        for ac in AssetClass:
+            assert ac in p.rebalancing_bands
 
 
 # ---------------------------------------------------------------------------
@@ -418,6 +456,18 @@ class TestDriftComputation:
         current[AssetClass.US_TREASURIES] -= _D("0.03")
         report = compute_drift(policy, current)
         assert report.total_drift >= _D("0.06")
+
+    def test_drift_request_negative_weight_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"\[0, 1\]"):
+            DriftRequest(
+                current_allocations={AssetClass.US_EQUITY: _D("-0.10")},
+            )
+
+    def test_drift_request_weight_above_one_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"\[0, 1\]"):
+            DriftRequest(
+                current_allocations={AssetClass.US_EQUITY: _D("1.50")},
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/agents/tests/test_policy_service.py
+++ b/agents/tests/test_policy_service.py
@@ -175,6 +175,10 @@ class TestBenchmarkComponent:
         with pytest.raises(ValueError, match="non-negative"):
             BenchmarkComponent(ticker="SPY", weight=_D("-0.01"))
 
+    def test_blank_ticker_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            BenchmarkComponent(ticker="   ", weight=_D("0.50"))
+
 
 # ---------------------------------------------------------------------------
 # InvestmentPolicy validation
@@ -568,6 +572,18 @@ class TestPolicyService:
             UpdateGoalRequest(target_amount=None),
         )
         assert cleared.target_amount is None
+
+    def test_update_normalizes_name(self, tmp_path: Path) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        goal = svc.create_from_template(GoalType.WEALTH_BUILDING)
+        updated = svc.update_goal(
+            goal.id,
+            UpdateGoalRequest(name="  Padded Name  "),
+        )
+        assert updated.name == "Padded Name"
+        # Verify persisted
+        reloaded = svc.get_goal(goal.id)
+        assert reloaded.name == "Padded Name"
 
     def test_create_request_retirement_requires_withdrawal(self) -> None:
         with pytest.raises(ValueError, match="withdrawal_rate"):

--- a/agents/tests/test_policy_service.py
+++ b/agents/tests/test_policy_service.py
@@ -533,12 +533,38 @@ class TestPolicyService:
         )
         assert updated.name == "Updated Name"
         assert updated.horizon_years == 25
-        assert updated.updated_at > goal.created_at
+        assert updated.updated_at >= goal.created_at
 
     def test_update_nonexistent_raises(self, tmp_path: Path) -> None:
         svc = PolicyService(path=tmp_path / "goals.json")
         with pytest.raises(GoalNotFoundError):
             svc.update_goal("nope", UpdateGoalRequest(name="x"))
+
+    def test_update_clear_optional_to_none(self, tmp_path: Path) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        goal = svc.create_from_template(GoalType.RETIREMENT)
+        assert goal.target_amount is None
+        # Set a target amount
+        updated = svc.update_goal(
+            goal.id,
+            UpdateGoalRequest(target_amount=_D("2000000")),
+        )
+        assert updated.target_amount == _D("2000000")
+        # Clear it back to None via explicit set
+        cleared = svc.update_goal(
+            goal.id,
+            UpdateGoalRequest(target_amount=None),
+        )
+        assert cleared.target_amount is None
+
+    def test_create_request_retirement_requires_withdrawal(self) -> None:
+        with pytest.raises(ValueError, match="withdrawal_rate"):
+            CreateGoalRequest(
+                name="Bad",
+                goal_type=GoalType.RETIREMENT,
+                policy=_valid_policy(),
+                horizon_years=30,
+            )
 
     def test_delete_goal(self, tmp_path: Path) -> None:
         svc = PolicyService(path=tmp_path / "goals.json")

--- a/agents/tests/test_policy_service.py
+++ b/agents/tests/test_policy_service.py
@@ -294,6 +294,16 @@ class TestInvestmentPolicy:
         for ac in AssetClass:
             assert ac in p.rebalancing_bands
 
+    def test_partial_rebalancing_bands_filled(self) -> None:
+        custom = RebalancingBand(threshold=_D("0.10"))
+        p = _valid_policy(
+            rebalancing_bands={AssetClass.US_EQUITY: custom},
+        )
+        assert len(p.rebalancing_bands) == 9
+        assert p.rebalancing_bands[AssetClass.US_EQUITY].threshold == _D("0.10")
+        # Other classes get the default threshold
+        assert p.rebalancing_bands[AssetClass.TIPS].threshold == _D("0.05")
+
 
 # ---------------------------------------------------------------------------
 # Goal validation
@@ -455,7 +465,7 @@ class TestDriftComputation:
         current[AssetClass.US_EQUITY] += _D("0.03")
         current[AssetClass.US_TREASURIES] -= _D("0.03")
         report = compute_drift(policy, current)
-        assert report.total_drift >= _D("0.06")
+        assert report.total_drift == _D("0.06")
 
     def test_drift_request_negative_weight_rejected(self) -> None:
         with pytest.raises(ValueError, match=r"\[0, 1\]"):

--- a/agents/tests/test_policy_service.py
+++ b/agents/tests/test_policy_service.py
@@ -430,6 +430,46 @@ class TestCreateGoalRequest:
         )
         assert req.name == "Growth"
 
+    def test_negative_target_amount_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            CreateGoalRequest(
+                name="Test",
+                goal_type=GoalType.WEALTH_BUILDING,
+                policy=_valid_policy(),
+                horizon_years=20,
+                target_amount=_D("-100"),
+            )
+
+    def test_negative_inflation_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            CreateGoalRequest(
+                name="Test",
+                goal_type=GoalType.WEALTH_BUILDING,
+                policy=_valid_policy(),
+                horizon_years=20,
+                inflation_assumption=_D("-0.01"),
+            )
+
+    def test_zero_withdrawal_rate_rejected_for_retirement(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            CreateGoalRequest(
+                name="Retire",
+                goal_type=GoalType.RETIREMENT,
+                policy=_valid_policy(),
+                horizon_years=30,
+                withdrawal_rate=_D("0"),
+            )
+
+    def test_negative_withdrawal_rate_rejected_for_retirement(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            CreateGoalRequest(
+                name="Retire",
+                goal_type=GoalType.RETIREMENT,
+                policy=_valid_policy(),
+                horizon_years=30,
+                withdrawal_rate=_D("-0.01"),
+            )
+
 
 # ---------------------------------------------------------------------------
 # UpdateGoalRequest validation

--- a/agents/tests/test_policy_service.py
+++ b/agents/tests/test_policy_service.py
@@ -315,6 +315,18 @@ class TestGoal:
         g = _valid_goal()
         assert g.goal_type == GoalType.WEALTH_BUILDING
 
+    def test_blank_name_rejected(self) -> None:
+        with pytest.raises(ValueError, match="blank"):
+            _valid_goal(name="   ")
+
+    def test_empty_name_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            _valid_goal(name="")
+
+    def test_name_stripped(self) -> None:
+        g = _valid_goal(name="  My Goal  ")
+        assert g.name == "My Goal"
+
     def test_retirement_requires_withdrawal_rate(self) -> None:
         with pytest.raises(ValueError, match="withdrawal_rate"):
             _valid_goal(goal_type=GoalType.RETIREMENT)

--- a/agents/tests/test_policy_service.py
+++ b/agents/tests/test_policy_service.py
@@ -1,0 +1,543 @@
+"""Tests for policy allocation and goals."""
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from src.application.contracts.household import AssetClass
+from src.application.contracts.policy import (
+    AllocationTarget,
+    BenchmarkComponent,
+    CreateGoalRequest,
+    DriftRequest,
+    Goal,
+    GoalType,
+    InvestmentPolicy,
+    RebalancingBand,
+    UpdateGoalRequest,
+)
+from src.application.services.policy_service import (
+    GoalNotFoundError,
+    GoalsCorruptError,
+    PolicyService,
+    compute_drift,
+    create_retirement_goal,
+    create_wealth_building_goal,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_D = Decimal
+
+
+def _zero_alloc(
+    target: Decimal = _D("0"),
+    mn: Decimal = _D("0"),
+    mx: Decimal = _D("0.10"),
+) -> AllocationTarget:
+    return AllocationTarget(target_weight=target, min_weight=mn, max_weight=mx)
+
+
+def _full_allocations(
+    overrides: dict[AssetClass, tuple[Decimal, Decimal, Decimal]] | None = None,
+) -> dict[AssetClass, AllocationTarget]:
+    """Build a valid full allocation dict with optional overrides."""
+    default_min = _D("0")
+    default_max = _D("0.30")
+    result: dict[AssetClass, AllocationTarget] = {}
+    classes = list(AssetClass)
+
+    # Apply overrides first
+    for ac in classes:
+        if overrides and ac in overrides:
+            t, mn, mx = overrides[ac]
+            result[ac] = AllocationTarget(
+                target_weight=t, min_weight=mn, max_weight=mx,
+            )
+
+    # Remaining classes get equal share of what's left
+    override_total = sum(
+        a.target_weight for a in result.values()
+    )
+    remaining = [ac for ac in classes if ac not in result]
+    if remaining:
+        each = (_D("1") - override_total) / len(remaining)
+        for ac in remaining:
+            result[ac] = AllocationTarget(
+                target_weight=each,
+                min_weight=default_min,
+                max_weight=default_max,
+            )
+    return result
+
+
+def _valid_policy(**kwargs: object) -> InvestmentPolicy:
+    defaults: dict[str, object] = {
+        "allocations": _full_allocations(),
+        "liquidity_floor": _D("0"),
+    }
+    defaults.update(kwargs)
+    return InvestmentPolicy(**defaults)  # type: ignore[arg-type]
+
+
+def _valid_goal(**kwargs: object) -> Goal:
+    defaults: dict[str, object] = {
+        "name": "Test Goal",
+        "goal_type": GoalType.WEALTH_BUILDING,
+        "policy": _valid_policy(),
+        "horizon_years": 20,
+    }
+    defaults.update(kwargs)
+    return Goal(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# AllocationTarget validation
+# ---------------------------------------------------------------------------
+
+
+class TestAllocationTarget:
+    def test_valid(self) -> None:
+        at = AllocationTarget(
+            target_weight=_D("0.30"),
+            min_weight=_D("0.20"),
+            max_weight=_D("0.40"),
+        )
+        assert at.target_weight == _D("0.30")
+
+    def test_min_greater_than_target_rejected(self) -> None:
+        with pytest.raises(ValueError, match="min"):
+            AllocationTarget(
+                target_weight=_D("0.10"),
+                min_weight=_D("0.20"),
+                max_weight=_D("0.30"),
+            )
+
+    def test_target_greater_than_max_rejected(self) -> None:
+        with pytest.raises(ValueError, match="max"):
+            AllocationTarget(
+                target_weight=_D("0.40"),
+                min_weight=_D("0.10"),
+                max_weight=_D("0.30"),
+            )
+
+    def test_negative_min_rejected(self) -> None:
+        with pytest.raises(ValueError, match="min"):
+            AllocationTarget(
+                target_weight=_D("0.10"),
+                min_weight=_D("-0.01"),
+                max_weight=_D("0.20"),
+            )
+
+    def test_max_above_one_rejected(self) -> None:
+        with pytest.raises(ValueError, match="max"):
+            AllocationTarget(
+                target_weight=_D("0.10"),
+                min_weight=_D("0"),
+                max_weight=_D("1.01"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# RebalancingBand validation
+# ---------------------------------------------------------------------------
+
+
+class TestRebalancingBand:
+    def test_valid(self) -> None:
+        b = RebalancingBand(threshold=_D("0.03"))
+        assert b.threshold == _D("0.03")
+
+    def test_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            RebalancingBand(threshold=_D("0"))
+
+    def test_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            RebalancingBand(threshold=_D("-0.01"))
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkComponent validation
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkComponent:
+    def test_ticker_uppercased(self) -> None:
+        c = BenchmarkComponent(ticker="spy", weight=_D("0.60"))
+        assert c.ticker == "SPY"
+
+    def test_negative_weight_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            BenchmarkComponent(ticker="SPY", weight=_D("-0.01"))
+
+
+# ---------------------------------------------------------------------------
+# InvestmentPolicy validation
+# ---------------------------------------------------------------------------
+
+
+class TestInvestmentPolicy:
+    def test_valid_policy(self) -> None:
+        p = _valid_policy()
+        assert len(p.allocations) == 9
+
+    def test_missing_asset_class_rejected(self) -> None:
+        alloc = _full_allocations()
+        del alloc[AssetClass.TIPS]
+        with pytest.raises(ValueError, match="Missing allocations"):
+            InvestmentPolicy(
+                allocations=alloc, liquidity_floor=_D("0"),
+            )
+
+    def test_weights_not_summing_to_one_rejected(self) -> None:
+        alloc = _full_allocations()
+        alloc[AssetClass.US_EQUITY] = AllocationTarget(
+            target_weight=_D("0.50"),
+            min_weight=_D("0"),
+            max_weight=_D("0.60"),
+        )
+        with pytest.raises(ValueError, match="sum to 1.0"):
+            InvestmentPolicy(
+                allocations=alloc, liquidity_floor=_D("0"),
+            )
+
+    def test_infeasible_min_unreachable_with_valid_targets(self) -> None:
+        # Note: sum(min) > 1 is impossible when each min <= target
+        # and targets sum to 1.  The validator is defense-in-depth.
+        # We verify the guard exists by testing directly with raw data.
+        pass
+
+    def test_infeasible_max_unreachable_with_valid_targets(self) -> None:
+        # Similarly, sum(max) < 1 is impossible when each target <= max
+        # and targets sum to 1.
+        pass
+
+    def test_cash_below_liquidity_floor_rejected(self) -> None:
+        alloc = _full_allocations({
+            AssetClass.CASH_MONEY_MARKET: (
+                _D("0.12"), _D("0.02"), _D("0.20"),
+            ),
+        })
+        with pytest.raises(ValueError, match="liquidity_floor"):
+            InvestmentPolicy(
+                allocations=alloc,
+                liquidity_floor=_D("0.05"),
+            )
+
+    def test_benchmark_weights_not_summing_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Benchmark weights"):
+            _valid_policy(
+                benchmark_blend=[
+                    BenchmarkComponent(ticker="SPY", weight=_D("0.50")),
+                    BenchmarkComponent(ticker="AGG", weight=_D("0.30")),
+                ],
+            )
+
+    def test_benchmark_duplicate_tickers_rejected(self) -> None:
+        with pytest.raises(ValueError, match="duplicate"):
+            _valid_policy(
+                benchmark_blend=[
+                    BenchmarkComponent(ticker="SPY", weight=_D("0.50")),
+                    BenchmarkComponent(ticker="SPY", weight=_D("0.50")),
+                ],
+            )
+
+    def test_valid_benchmark(self) -> None:
+        p = _valid_policy(
+            benchmark_blend=[
+                BenchmarkComponent(ticker="SPY", weight=_D("0.60")),
+                BenchmarkComponent(ticker="AGG", weight=_D("0.40")),
+            ],
+        )
+        assert len(p.benchmark_blend) == 2
+
+
+# ---------------------------------------------------------------------------
+# Goal validation
+# ---------------------------------------------------------------------------
+
+
+class TestGoal:
+    def test_valid_wealth_building(self) -> None:
+        g = _valid_goal()
+        assert g.goal_type == GoalType.WEALTH_BUILDING
+
+    def test_retirement_requires_withdrawal_rate(self) -> None:
+        with pytest.raises(ValueError, match="withdrawal_rate"):
+            _valid_goal(goal_type=GoalType.RETIREMENT)
+
+    def test_retirement_with_withdrawal_rate(self) -> None:
+        g = _valid_goal(
+            goal_type=GoalType.RETIREMENT,
+            withdrawal_rate=_D("0.04"),
+        )
+        assert g.withdrawal_rate == _D("0.04")
+
+    def test_wealth_building_rejects_withdrawal_rate(self) -> None:
+        with pytest.raises(ValueError, match="should not have"):
+            _valid_goal(withdrawal_rate=_D("0.04"))
+
+    def test_zero_horizon_rejected(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            _valid_goal(horizon_years=0)
+
+    def test_negative_target_amount_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            _valid_goal(target_amount=_D("-1000"))
+
+    def test_negative_inflation_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            _valid_goal(inflation_assumption=_D("-0.01"))
+
+    def test_id_auto_generated(self) -> None:
+        g1 = _valid_goal()
+        g2 = _valid_goal()
+        assert g1.id != g2.id
+        assert len(g1.id) == 12
+
+
+# ---------------------------------------------------------------------------
+# Canned goal factories
+# ---------------------------------------------------------------------------
+
+
+class TestCannedGoals:
+    def test_retirement_goal(self) -> None:
+        g = create_retirement_goal()
+        assert g.goal_type == GoalType.RETIREMENT
+        assert g.withdrawal_rate == _D("0.035")
+        assert g.horizon_years == 30
+        total = sum(
+            a.target_weight for a in g.policy.allocations.values()
+        )
+        assert abs(total - 1) < _D("0.001")
+
+    def test_wealth_building_goal(self) -> None:
+        g = create_wealth_building_goal()
+        assert g.goal_type == GoalType.WEALTH_BUILDING
+        assert g.withdrawal_rate is None
+        assert g.horizon_years == 20
+        total = sum(
+            a.target_weight for a in g.policy.allocations.values()
+        )
+        assert abs(total - 1) < _D("0.001")
+
+    def test_retirement_benchmark_sums_to_one(self) -> None:
+        g = create_retirement_goal()
+        bw = sum(c.weight for c in g.policy.benchmark_blend)
+        assert abs(bw - 1) < _D("0.001")
+
+    def test_wealth_building_benchmark_sums_to_one(self) -> None:
+        g = create_wealth_building_goal()
+        bw = sum(c.weight for c in g.policy.benchmark_blend)
+        assert abs(bw - 1) < _D("0.001")
+
+    def test_retirement_custom_name(self) -> None:
+        g = create_retirement_goal(name="My Retirement")
+        assert g.name == "My Retirement"
+
+
+# ---------------------------------------------------------------------------
+# Drift computation
+# ---------------------------------------------------------------------------
+
+
+class TestDriftComputation:
+    def test_no_drift_when_on_target(self) -> None:
+        policy = _valid_policy(
+            rebalancing_bands={ac: RebalancingBand() for ac in AssetClass},
+        )
+        current = {
+            ac: policy.allocations[ac].target_weight
+            for ac in AssetClass
+        }
+        report = compute_drift(policy, current)
+        assert not report.any_breach
+        assert report.total_drift == _D("0")
+        for d in report.drifts:
+            assert d.drift == _D("0")
+
+    def test_overweight_detected(self) -> None:
+        policy = _valid_policy(
+            rebalancing_bands={ac: RebalancingBand() for ac in AssetClass},
+        )
+        current = {
+            ac: policy.allocations[ac].target_weight
+            for ac in AssetClass
+        }
+        # Overweight US_EQUITY by 10pp
+        current[AssetClass.US_EQUITY] += _D("0.10")
+        current[AssetClass.CASH_MONEY_MARKET] -= _D("0.10")
+        report = compute_drift(policy, current)
+        eq_drift = next(
+            d for d in report.drifts
+            if d.asset_class == AssetClass.US_EQUITY
+        )
+        assert eq_drift.drift == _D("0.10")
+        assert eq_drift.breaches_band is True
+        assert report.any_breach is True
+
+    def test_small_drift_no_breach(self) -> None:
+        policy = _valid_policy(
+            rebalancing_bands={ac: RebalancingBand() for ac in AssetClass},
+        )
+        current = {
+            ac: policy.allocations[ac].target_weight
+            for ac in AssetClass
+        }
+        # Small drift: 2pp (below default 5pp threshold)
+        current[AssetClass.US_EQUITY] += _D("0.02")
+        current[AssetClass.CASH_MONEY_MARKET] -= _D("0.02")
+        report = compute_drift(policy, current)
+        assert not report.any_breach
+
+    def test_missing_class_treated_as_zero(self) -> None:
+        policy = _valid_policy(
+            rebalancing_bands={ac: RebalancingBand() for ac in AssetClass},
+        )
+        # Only provide US_EQUITY
+        report = compute_drift(
+            policy, {AssetClass.US_EQUITY: _D("1.0")},
+        )
+        assert report.any_breach  # Everything else drifted
+
+    def test_total_drift_sum_of_absolutes(self) -> None:
+        policy = _valid_policy(
+            rebalancing_bands={ac: RebalancingBand() for ac in AssetClass},
+        )
+        current = {
+            ac: policy.allocations[ac].target_weight
+            for ac in AssetClass
+        }
+        current[AssetClass.US_EQUITY] += _D("0.03")
+        current[AssetClass.US_TREASURIES] -= _D("0.03")
+        report = compute_drift(policy, current)
+        assert report.total_drift >= _D("0.06")
+
+
+# ---------------------------------------------------------------------------
+# PolicyService persistence
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyService:
+    def test_list_goals_empty(self, tmp_path: Path) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        assert svc.list_goals() == []
+
+    def test_create_and_get(self, tmp_path: Path) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        req = CreateGoalRequest(
+            name="Test",
+            goal_type=GoalType.WEALTH_BUILDING,
+            policy=_valid_policy(),
+            horizon_years=20,
+        )
+        goal = svc.create_goal(req)
+        assert goal.name == "Test"
+        retrieved = svc.get_goal(goal.id)
+        assert retrieved.id == goal.id
+
+    def test_create_from_template_retirement(
+        self, tmp_path: Path,
+    ) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        goal = svc.create_from_template(GoalType.RETIREMENT)
+        assert goal.goal_type == GoalType.RETIREMENT
+        assert goal.withdrawal_rate is not None
+        assert svc.get_goal(goal.id).id == goal.id
+
+    def test_create_from_template_wealth(self, tmp_path: Path) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        goal = svc.create_from_template(GoalType.WEALTH_BUILDING)
+        assert goal.goal_type == GoalType.WEALTH_BUILDING
+
+    def test_create_from_template_custom_rejected(
+        self, tmp_path: Path,
+    ) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        with pytest.raises(ValueError, match="No template"):
+            svc.create_from_template(GoalType.CUSTOM)
+
+    def test_update_goal(self, tmp_path: Path) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        goal = svc.create_from_template(GoalType.WEALTH_BUILDING)
+        updated = svc.update_goal(
+            goal.id,
+            UpdateGoalRequest(name="Updated Name", horizon_years=25),
+        )
+        assert updated.name == "Updated Name"
+        assert updated.horizon_years == 25
+        assert updated.updated_at > goal.created_at
+
+    def test_update_nonexistent_raises(self, tmp_path: Path) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        with pytest.raises(GoalNotFoundError):
+            svc.update_goal("nope", UpdateGoalRequest(name="x"))
+
+    def test_delete_goal(self, tmp_path: Path) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        goal = svc.create_from_template(GoalType.RETIREMENT)
+        assert svc.delete_goal(goal.id) is True
+        with pytest.raises(GoalNotFoundError):
+            svc.get_goal(goal.id)
+
+    def test_delete_nonexistent_raises(self, tmp_path: Path) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        with pytest.raises(GoalNotFoundError):
+            svc.delete_goal("nope")
+
+    def test_persistence_roundtrip(self, tmp_path: Path) -> None:
+        path = tmp_path / "goals.json"
+        svc = PolicyService(path=path)
+        svc.create_from_template(GoalType.RETIREMENT)
+        svc.create_from_template(GoalType.WEALTH_BUILDING)
+
+        # Reload from disk
+        svc2 = PolicyService(path=path)
+        goals = svc2.list_goals()
+        assert len(goals) == 2
+
+    def test_corrupt_file_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "goals.json"
+        path.write_text("not json!", encoding="utf-8")
+        svc = PolicyService(path=path)
+        with pytest.raises(GoalsCorruptError):
+            svc.load()
+
+    def test_file_permissions(self, tmp_path: Path) -> None:
+        path = tmp_path / "goals.json"
+        svc = PolicyService(path=path)
+        svc.create_from_template(GoalType.RETIREMENT)
+        mode = path.stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_compute_drift_via_service(self, tmp_path: Path) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        goal = svc.create_from_template(GoalType.RETIREMENT)
+        current = {
+            ac: goal.policy.allocations[ac].target_weight
+            for ac in AssetClass
+        }
+        req = DriftRequest(current_allocations=current)
+        report = svc.compute_drift(goal.id, req)
+        assert not report.any_breach
+
+    def test_list_goals_sorted_by_name(self, tmp_path: Path) -> None:
+        svc = PolicyService(path=tmp_path / "goals.json")
+        svc.create_from_template(GoalType.WEALTH_BUILDING)
+        svc.create_from_template(GoalType.RETIREMENT)
+        goals = svc.list_goals()
+        assert goals[0].name < goals[1].name
+
+    def test_schema_version_preserved(self, tmp_path: Path) -> None:
+        path = tmp_path / "goals.json"
+        svc = PolicyService(path=path)
+        svc.create_from_template(GoalType.RETIREMENT)
+        raw = json.loads(path.read_text())
+        assert raw["schema_version"] == 1

--- a/agents/tests/test_policy_service.py
+++ b/agents/tests/test_policy_service.py
@@ -407,6 +407,72 @@ class TestCannedGoals:
 
 
 # ---------------------------------------------------------------------------
+# CreateGoalRequest validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateGoalRequest:
+    def test_whitespace_name_rejected(self) -> None:
+        with pytest.raises(ValueError, match="blank"):
+            CreateGoalRequest(
+                name="   ",
+                goal_type=GoalType.WEALTH_BUILDING,
+                policy=_valid_policy(),
+                horizon_years=20,
+            )
+
+    def test_name_stripped(self) -> None:
+        req = CreateGoalRequest(
+            name="  Growth  ",
+            goal_type=GoalType.WEALTH_BUILDING,
+            policy=_valid_policy(),
+            horizon_years=20,
+        )
+        assert req.name == "Growth"
+
+
+# ---------------------------------------------------------------------------
+# UpdateGoalRequest validation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateGoalRequest:
+    def test_blank_name_rejected(self) -> None:
+        with pytest.raises(ValueError, match="blank"):
+            UpdateGoalRequest(name="   ")
+
+    def test_name_stripped(self) -> None:
+        req = UpdateGoalRequest(name="  Edited  ")
+        assert req.name == "Edited"
+
+    def test_none_name_allowed(self) -> None:
+        req = UpdateGoalRequest(name=None)
+        assert req.name is None
+
+    def test_negative_horizon_rejected(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            UpdateGoalRequest(horizon_years=0)
+
+    def test_negative_target_amount_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            UpdateGoalRequest(target_amount=_D("-1"))
+
+    def test_negative_inflation_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            UpdateGoalRequest(inflation_assumption=_D("-0.01"))
+
+    def test_valid_partial_update(self) -> None:
+        req = UpdateGoalRequest(
+            horizon_years=25,
+            target_amount=_D("1000000"),
+            inflation_assumption=_D("0.03"),
+        )
+        assert req.horizon_years == 25
+        assert req.target_amount == _D("1000000")
+        assert req.inflation_assumption == _D("0.03")
+
+
+# ---------------------------------------------------------------------------
 # Drift computation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements the Policy Allocation & Goals service (Phase 1C of the macro ETF pivot).

### What's included

**Contracts** (`agents/src/application/contracts/policy.py`):
- `AllocationTarget`: target/min/max weights with ordering validation
- `RebalancingBand`: absolute threshold (portfolio-weight points)
- `BenchmarkComponent`: ticker + weight for synthetic benchmark blends
- `InvestmentPolicy`: full allocation across 9 asset classes with feasibility checks
- `Goal` / `GoalType`: investment goals with type-specific invariants
- `DriftResult` / `DriftReport`: per-class drift and band breach detection
- Request/response models for API integration

**Service** (`agents/src/application/services/policy_service.py`):
- `PolicyService`: CRUD for goals with fcntl.flock cross-process locking
- Atomic writes (mkstemp + fsync + replace, 0o600 permissions)
- Canned goal factories: retirement (conservative 40/40/10/10) and wealth building (growth 65/20/10/5)
- `compute_drift()`: pure math drift computation with band breach detection
- Mtime-based in-memory cache for reads

**Tests** (`agents/tests/test_policy_service.py`):
- 52 tests covering contracts, validation, persistence, drift, canned goals, error handling

### Design decisions
- Embeds policy in Goal (simpler than separate reusable policies)
- Absolute rebalancing bands (threshold in portfolio-weight points, not relative %)
- All 9 asset classes required in every policy
- Cash min_weight >= liquidity_floor enforced
- Retirement requires withdrawal_rate; non-retirement rejects it
- Follows HouseholdService patterns (fcntl.flock, atomic writes)

Closes #104